### PR TITLE
feat: add appstream results to autocompletion

### DIFF
--- a/lib/appstream.dart
+++ b/lib/appstream.dart
@@ -1,2 +1,3 @@
+export 'src/appstream/appstream_search.dart';
 export 'src/appstream/appstream_service.dart';
 export 'src/appstream/appstream_utils.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github/github.dart';
 import 'package:gtk/gtk.dart';
 import 'package:snapcraft_launcher/snapcraft_launcher.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'appstream.dart';
 import 'l10n.dart';
 import 'snapd.dart';
 import 'store.dart';
@@ -24,7 +28,15 @@ Future<void> main(List<String> args) async {
   registerService(() => GitHub());
   registerService(() => GtkApplicationNotifier(args));
 
+  final appstream = AppstreamService();
+  // Explicitly ignore the future to continue while appstream is reading the
+  // metadata from the disk.
+  unawaited(appstream.init());
+  registerServiceInstance(appstream);
+
   await initDefaultLocale();
+
+  Logger.setup();
 
   runApp(const ProviderScope(child: StoreApp()));
 }

--- a/lib/snapd.dart
+++ b/lib/snapd.dart
@@ -2,6 +2,7 @@ export 'src/snapd/snap_category_enum.dart';
 export 'src/snapd/snap_l10n.dart';
 export 'src/snapd/snap_launcher.dart';
 export 'src/snapd/snap_model.dart';
+export 'src/snapd/snap_search.dart';
 export 'src/snapd/snap_sort.dart';
 export 'src/snapd/snapd_service.dart';
 export 'src/snapd/snapx.dart';

--- a/lib/src/appstream/appstream_search.dart
+++ b/lib/src/appstream/appstream_search.dart
@@ -1,0 +1,18 @@
+import 'package:appstream/appstream.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+import '/appstream.dart';
+
+final appstreamSearchProvider =
+    StreamProvider.family<List<AppstreamComponent>, String>(
+        (ref, query) async* {
+  final appstream = getService<AppstreamService>();
+  if (!appstream.initialized) {
+    // Return empty results in order to not slow down the autocompletion, in case
+    // the appstream service is still populating the cache.
+    yield [];
+    await appstream.init();
+  }
+  yield await appstream.search(query);
+});

--- a/lib/src/appstream/appstream_service.dart
+++ b/lib/src/appstream/appstream_service.dart
@@ -124,7 +124,13 @@ class _ScoredComponent {
 
 class AppstreamService {
   final AppstreamPool _pool;
-  late final Future<void> _loader = _pool.load().then((_) => _populateCache());
+  late final Future<void> _loader = _pool.load().then((_) {
+    _populateCache();
+    _initialized = true;
+  });
+
+  bool get initialized => _initialized;
+  bool _initialized = false;
 
   // TODO: cache AppstreamPool
   AppstreamService({@visibleForTesting AppstreamPool? pool})

--- a/lib/src/explore/explore_page.dart
+++ b/lib/src/explore/explore_page.dart
@@ -6,7 +6,6 @@ import 'package:yaru_icons/yaru_icons.dart';
 
 import '/l10n.dart';
 import '/layout.dart';
-import '/search.dart';
 import '/snapd.dart';
 import '/store.dart';
 import '/widgets.dart';
@@ -109,7 +108,7 @@ class _CategorySnapList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final categorySnaps = ref
         // get snaps from `category`
-        .watch(searchProvider(SnapSearchParameters(category: category)))
+        .watch(snapSearchProvider(SnapSearchParameters(category: category)))
         .whenOrNull(data: (data) => data)
         // .. without the banner snaps, if we don't want them
         ?.where(
@@ -150,7 +149,7 @@ class _CategoryBanner extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final snaps = ref
-        .watch(searchProvider(SnapSearchParameters(category: category)))
+        .watch(snapSearchProvider(SnapSearchParameters(category: category)))
         .whenOrNull(data: (data) => data);
     final featuredSnaps = category.featuredSnapNames != null
         ? category.featuredSnapNames!

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -52,8 +52,9 @@
     "developmentPageLabel": "Development",
     "gamesPageLabel": "Games",
     "unknownPublisher": "Unknown Publisher",
+    "searchFieldDebSection": "Debian packages",
     "searchFieldSearchHint": "Search for apps",
-    "searchFieldSearchForLabel": "Search for \"{query}\"",
+    "searchFieldSearchForLabel": "See all results for \"{query}\"",
     "@searchFieldSearchForLabel": {
         "placeholders": {
             "query": {
@@ -61,6 +62,7 @@
             }
         }
     },
+    "searchFieldSnapSection": "Snap packages",
     "searchPageFilterByLabel": "Filter by",
     "searchPageNoResults": "No results found for \"{query}\"",
     "@searchPageNoResults": {

--- a/lib/src/search/search_page.dart
+++ b/lib/src/search/search_page.dart
@@ -9,7 +9,6 @@ import '/layout.dart';
 import '/snapd.dart';
 import '/store.dart';
 import '/widgets.dart';
-import 'search_provider.dart';
 
 // TODO: break down into smaller widgets
 class SearchPage extends StatelessWidget {
@@ -50,7 +49,7 @@ class SearchPage extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Consumer(builder: (context, ref, child) {
-                      final sortOrder = ref.watch(sortOrderProvider);
+                      final sortOrder = ref.watch(snapSortOrderProvider);
                       return MenuButtonBuilder<SnapSortOrder?>(
                         values: const [
                           null,
@@ -63,8 +62,9 @@ class SearchPage extends StatelessWidget {
                           sortOrder?.localize(l10n) ??
                               l10n.snapSortOrderRelevance,
                         ),
-                        onSelected: (value) =>
-                            ref.read(sortOrderProvider.notifier).state = value,
+                        onSelected: (value) => ref
+                            .read(snapSortOrderProvider.notifier)
+                            .state = value,
                         child: Text(
                           sortOrder?.localize(l10n) ??
                               l10n.snapSortOrderRelevance,
@@ -88,11 +88,12 @@ class SearchPage extends StatelessWidget {
                                 category?.localize(l10n) ??
                                     l10n.snapCategoryAll),
                             onSelected: (value) => ref
-                                .read(
-                                    categoryProvider(initialCategory).notifier)
+                                .read(snapCategoryProvider(initialCategory)
+                                    .notifier)
                                 .state = value,
                             child: Text(ref
-                                    .watch(categoryProvider(initialCategory))
+                                    .watch(
+                                        snapCategoryProvider(initialCategory))
                                     ?.localize(l10n) ??
                                 l10n.snapCategoryAll),
                           );
@@ -106,10 +107,10 @@ class SearchPage extends StatelessWidget {
           ),
           Expanded(
             child: Consumer(builder: (context, ref, child) {
-              final category = ref.watch(
-                  categoryProvider(initialCategoryName?.toSnapCategoryEnum()));
+              final category = ref.watch(snapCategoryProvider(
+                  initialCategoryName?.toSnapCategoryEnum()));
               final results = ref.watch(
-                sortedSearchProvider(
+                sortedSnapSearchProvider(
                   SnapSearchParameters(
                     query: query,
                     category: category,

--- a/lib/src/search/search_provider.dart
+++ b/lib/src/search/search_provider.dart
@@ -1,66 +1,40 @@
 import 'dart:async';
 
+import 'package:appstream/appstream.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:snapd/snapd.dart';
 
+import '/appstream.dart';
 import '/snapd.dart';
-
-class SnapSearchParameters {
-  const SnapSearchParameters({this.query, this.category});
-  final String? query;
-  final SnapCategoryEnum? category;
-
-  @override
-  bool operator ==(Object other) =>
-      other is SnapSearchParameters &&
-      other.query == query &&
-      other.category == category;
-
-  @override
-  int get hashCode => Object.hash(query, category);
-}
-
-final searchProvider =
-    StreamProvider.family((ref, SnapSearchParameters searchParameters) async* {
-  final snapd = getService<SnapdService>();
-  if (searchParameters.category == SnapCategoryEnum.ubuntuDesktop) {
-    yield* snapd.getStoreSnaps(searchParameters.category!.featuredSnapNames
-            ?.where((name) => name.contains(searchParameters.query ?? ''))
-            .toList() ??
-        []);
-  } else if (searchParameters.query == null &&
-      searchParameters.category != null) {
-    yield* snapd.getCategory(searchParameters.category!.categoryName);
-  } else {
-    yield await snapd.find(
-      query: searchParameters.query,
-      category: searchParameters.category?.categoryName,
-    );
-  }
-});
 
 final queryProvider = StateProvider<String?>((_) => null);
 
-final categoryProvider = StateProvider.family
-    .autoDispose<SnapCategoryEnum?, SnapCategoryEnum?>(
-        (ref, initialValue) => initialValue);
-
-final autoCompleteProvider = FutureProvider((ref) async {
-  final query = ref.watch(queryProvider);
-  final completer = Completer();
-  ref.onDispose(completer.complete);
-  await Future.delayed(const Duration(milliseconds: 100));
-  if ((query?.isNotEmpty ?? true) && !completer.isCompleted) {
-    return ref.watch(searchProvider(SnapSearchParameters(query: query)).future);
-  }
-  return [];
+typedef AutoCompleteOptions = ({
+  Iterable<Snap> snaps,
+  Iterable<AppstreamComponent> debs,
 });
 
-final sortOrderProvider =
-    StateProvider.autoDispose<SnapSortOrder?>((_) => null);
+final autoCompleteProvider = FutureProvider<AutoCompleteOptions>((ref) async {
+  final query = ref.watch(queryProvider);
 
-final sortedSearchProvider = FutureProvider.family
-    .autoDispose((ref, SnapSearchParameters searchParameters) {
-  return ref.watch(searchProvider(searchParameters).future).then(
-      (snaps) => snaps.sortedSnaps(ref.watch(sortOrderProvider)).toList());
+  // The completer is used to make sure no queries are sent if the provider is
+  // already disposed.
+  final completer = Completer();
+  ref.onDispose(completer.complete);
+
+  // Wait for a short duration before sending off the query (i.e. wait until
+  // the user stops typing). This also helps to ensure the results arrive in
+  // the correct order.
+  await Future.delayed(const Duration(milliseconds: 100));
+
+  if ((query?.isNotEmpty ?? true) && !completer.isCompleted) {
+    final results = await Future.wait([
+      ref.watch(snapSearchProvider(SnapSearchParameters(query: query)).future),
+      ref.watch(appstreamSearchProvider(query ?? '').future)
+    ]);
+    final snaps = results[0] as List<Snap>;
+    final debs = results[1] as List<AppstreamComponent>;
+    return (snaps: snaps, debs: debs);
+  }
+  return (snaps: <Snap>[], debs: <AppstreamComponent>[]);
 });

--- a/lib/src/snapd/snap_search.dart
+++ b/lib/src/snapd/snap_search.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+import '/snapd.dart';
+
+class SnapSearchParameters {
+  const SnapSearchParameters({this.query, this.category});
+  final String? query;
+  final SnapCategoryEnum? category;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapSearchParameters &&
+      other.query == query &&
+      other.category == category;
+
+  @override
+  int get hashCode => Object.hash(query, category);
+}
+
+final snapCategoryProvider = StateProvider.family
+    .autoDispose<SnapCategoryEnum?, SnapCategoryEnum?>(
+        (ref, initialValue) => initialValue);
+
+final snapSearchProvider =
+    StreamProvider.family((ref, SnapSearchParameters searchParameters) async* {
+  final snapd = getService<SnapdService>();
+  if (searchParameters.category == SnapCategoryEnum.ubuntuDesktop) {
+    yield* snapd.getStoreSnaps(searchParameters.category!.featuredSnapNames
+            ?.where((name) => name.contains(searchParameters.query ?? ''))
+            .toList() ??
+        []);
+  } else if (searchParameters.query == null &&
+      searchParameters.category != null) {
+    yield* snapd.getCategory(searchParameters.category!.categoryName);
+  } else {
+    yield await snapd.find(
+      query: searchParameters.query,
+      category: searchParameters.category?.categoryName,
+    );
+  }
+});
+
+final snapSortOrderProvider =
+    StateProvider.autoDispose<SnapSortOrder?>((_) => null);
+
+final sortedSnapSearchProvider = FutureProvider.family
+    .autoDispose((ref, SnapSearchParameters searchParameters) {
+  return ref.watch(snapSearchProvider(searchParameters).future).then(
+      (snaps) => snaps.sortedSnaps(ref.watch(snapSortOrderProvider)).toList());
+});

--- a/lib/src/store/store_app.dart
+++ b/lib/src/store/store_app.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart' hide AboutDialog, showAboutDialog;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meta/meta.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -12,6 +14,9 @@ import 'store_observer.dart';
 import 'store_pages.dart';
 import 'store_providers.dart';
 import 'store_routes.dart';
+
+@internal
+final log = Logger('store_app');
 
 class StoreApp extends ConsumerStatefulWidget {
   const StoreApp({super.key});
@@ -45,7 +50,10 @@ class _StoreAppState extends ConsumerState<StoreApp> {
               child: SearchField(
                 onSearch: (query) =>
                     _navigator.pushAndRemoveSearch(query: query),
-                onSelected: (name) => _navigator.pushDetail(name: name),
+                onSnapSelected: (name) => _navigator.pushDetail(name: name),
+                onDebSelected: (_) {
+                  log.debug('Detail page for debs not implemented yet!');
+                }, // TODO: push detail page
               ),
             ),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   snapd: ^0.4.11
   snowball_stemmer: ^0.1.0
   ubuntu_localizations: ^0.3.3
+  ubuntu_logger: ^0.1.0
   ubuntu_service: ^0.2.2
   ubuntu_test: ^0.1.0-0
   ubuntu_widgets: ^0.2.0

--- a/test/appstream_service_test.dart
+++ b/test/appstream_service_test.dart
@@ -64,9 +64,11 @@ void main() {
 
   test('initialize service', () async {
     verifyNever(pool.load());
+    expect(service.initialized, isFalse);
     await service.init();
     verify(pool.load()).called(1);
     expect(service.cacheSize, 0);
+    expect(service.initialized, isTrue);
   });
 
   test('load and cache components', () async {

--- a/test/search_page_test.dart
+++ b/test/search_page_test.dart
@@ -9,7 +9,7 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'test_utils.dart';
 
 void main() {
-  final mockSearchProvider = createMockSearchProvider({
+  final mockSearchProvider = createMockSnapSearchProvider({
     const SnapSearchParameters(query: 'testsn'): const [
       Snap(name: 'testsnap', title: 'Test Snap', downloadSize: 3),
       Snap(name: 'testsnap2', title: 'Another Test Snap', downloadSize: 1),
@@ -29,7 +29,8 @@ void main() {
     await tester.pumpApp(
       (_) => ProviderScope(
         overrides: [
-          searchProvider.overrideWith((ref, query) => mockSearchProvider(query))
+          snapSearchProvider
+              .overrideWith((ref, query) => mockSearchProvider(query))
         ],
         child: const SearchPage(query: 'testsn'),
       ),
@@ -52,7 +53,8 @@ void main() {
     await tester.pumpApp(
       (_) => ProviderScope(
         overrides: [
-          searchProvider.overrideWith((ref, query) => mockSearchProvider(query))
+          snapSearchProvider
+              .overrideWith((ref, query) => mockSearchProvider(query))
         ],
         child: const SearchPage(
           query: 'testsn',
@@ -78,7 +80,8 @@ void main() {
     await tester.pumpApp(
       (_) => ProviderScope(
         overrides: [
-          searchProvider.overrideWith((ref, query) => mockSearchProvider(query))
+          snapSearchProvider
+              .overrideWith((ref, query) => mockSearchProvider(query))
         ],
         child: const SearchPage(
           category: 'education',
@@ -101,7 +104,7 @@ void main() {
       await tester.pumpApp(
         (_) => ProviderScope(
           overrides: [
-            searchProvider
+            snapSearchProvider
                 .overrideWith((ref, query) => mockSearchProvider(query))
           ],
           child: const SearchPage(query: 'testsn'),
@@ -126,7 +129,7 @@ void main() {
       await tester.pumpApp(
         (_) => ProviderScope(
           overrides: [
-            searchProvider
+            snapSearchProvider
                 .overrideWith((ref, query) => mockSearchProvider(query))
           ],
           child: const SearchPage(query: 'testsn'),
@@ -154,7 +157,7 @@ void main() {
       await tester.pumpApp(
         (_) => ProviderScope(
           overrides: [
-            searchProvider
+            snapSearchProvider
                 .overrideWith((ref, query) => mockSearchProvider(query))
           ],
           child: const SearchPage(query: 'testsn'),
@@ -185,7 +188,7 @@ void main() {
       await tester.pumpApp(
         (_) => ProviderScope(
           overrides: [
-            searchProvider
+            snapSearchProvider
                 .overrideWith((ref, query) => mockSearchProvider(query))
           ],
           child: const SearchPage(query: 'foo'),
@@ -202,7 +205,7 @@ void main() {
       await tester.pumpApp(
         (_) => ProviderScope(
           overrides: [
-            searchProvider
+            snapSearchProvider
                 .overrideWith((ref, query) => mockSearchProvider(query))
           ],
           child: const SearchPage(query: 'foo', category: 'social'),

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:app_center/l10n.dart';
-import 'package:app_center/search.dart';
 import 'package:app_center/snapd.dart';
 import 'package:app_center/src/manage/manage_model.dart';
+import 'package:appstream/appstream.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -27,12 +27,20 @@ extension WidgetTesterX on WidgetTester {
   }
 }
 
-Stream<List<Snap>> Function(SnapSearchParameters) createMockSearchProvider(
+Stream<List<Snap>> Function(SnapSearchParameters) createMockSnapSearchProvider(
     Map<SnapSearchParameters, List<Snap>> searchResults) {
   return (SnapSearchParameters searchParameters) => Stream.value(
         searchResults.entries
                 .firstWhereOrNull((e) => e.key == searchParameters)
                 ?.value ??
+            [],
+      );
+}
+
+Stream<List<AppstreamComponent>> Function(String) createMockDebSearchProvider(
+    Map<String, List<AppstreamComponent>> searchResults) {
+  return (String query) => Stream.value(
+        searchResults.entries.firstWhereOrNull((e) => e.key == query)?.value ??
             [],
       );
 }


### PR DESCRIPTION
UDENG-1364
Ref #1367

![Screenshot from 2023-09-13 15-06-44](https://github.com/ubuntu/app-center/assets/113362648/4bcfcd2d-4bb4-4b6e-a3bc-87f330e573d5)

@tim-hm when running this in debug mode loading the appstream metadata slows down the app drastically to the point where the UI becomes unresponsive for a short time. This should be hardly noticeable in release mode, though. However, there's some delay before the appstream autocompletion results become available - we should cache the metadata pool in a format that can be loaded more quickly later on.

I had to refactor the search providers a bit:
* src/search now only contains the common search logic (i.e. the search query and the autocompletion provider
* src/appstream and src/snapd now have their own separate search providers - there's no common filtering and sorting logic yet.

