### PR TITLE
refactor: rename and move SnapIcon and DetailPage

### DIFF
--- a/lib/detail.dart
+++ b/lib/detail.dart
@@ -1,1 +1,0 @@
-export 'src/detail/detail_page.dart';

--- a/lib/snapd.dart
+++ b/lib/snapd.dart
@@ -2,6 +2,7 @@ export 'src/snapd/snap_category_enum.dart';
 export 'src/snapd/snap_l10n.dart';
 export 'src/snapd/snap_launcher.dart';
 export 'src/snapd/snap_model.dart';
+export 'src/snapd/snap_page.dart';
 export 'src/snapd/snap_search.dart';
 export 'src/snapd/snap_sort.dart';
 export 'src/snapd/snapd_service.dart';

--- a/lib/src/about/about_page.dart
+++ b/lib/src/about/about_page.dart
@@ -155,7 +155,7 @@ class _ContributorWrap extends StatelessWidget {
                   : null,
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(16),
-                child: SnapIcon(
+                child: AppIcon(
                   iconUrl: contributor?.avatarUrl,
                   size: 32,
                 ),

--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -410,7 +410,7 @@ class _Header extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SnapIcon(iconUrl: snap.iconUrl, size: 96),
+            AppIcon(iconUrl: snap.iconUrl, size: 96),
             const SizedBox(width: 16),
             Expanded(child: SnapTitle.large(snap: snap)),
           ],

--- a/lib/src/explore/explore_page.dart
+++ b/lib/src/explore/explore_page.dart
@@ -131,13 +131,11 @@ class _CategorySnapList extends ConsumerWidget {
     return showScreenshots
         ? SnapImageCardGrid(
             snaps: snaps,
-            onTap: (snap) =>
-                StoreNavigator.pushDetail(context, name: snap.name),
+            onTap: (snap) => StoreNavigator.pushSnap(context, name: snap.name),
           )
         : SnapCardGrid(
             snaps: snaps,
-            onTap: (snap) =>
-                StoreNavigator.pushDetail(context, name: snap.name),
+            onTap: (snap) => StoreNavigator.pushSnap(context, name: snap.name),
           );
   }
 }
@@ -269,7 +267,7 @@ class _BannerIconState extends State<_BannerIcon> {
       verticalOffset: _kMaxSize / 2,
       message: widget.snap.titleOrName,
       child: InkWell(
-        onTap: () => StoreNavigator.pushDetail(context, name: widget.snap.name),
+        onTap: () => StoreNavigator.pushSnap(context, name: widget.snap.name),
         onHover: (hover) {
           setState(() => scale = hover ? _kScaleLarge : 1.0);
         },

--- a/lib/src/explore/explore_page.dart
+++ b/lib/src/explore/explore_page.dart
@@ -293,7 +293,7 @@ class _BannerIconState extends State<_BannerIcon> {
                     )
                   ],
                 ),
-                child: SnapIcon(
+                child: AppIcon(
                   iconUrl: widget.snap.iconUrl,
                   size: _kIconSize * scale,
                 ),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1,25 +1,25 @@
 {
     "appstreamSearchGreylist": "app;application;package;program;programme;suite;tool",
-    "detailPageChannelLabel": "Channel",
-    "detailPageConfinementLabel": "Confinement",
-    "detailPageContactPublisherLabel": "Contact {publisher}",
-    "@detailPageContactPublisherLabel": {
+    "snapPageChannelLabel": "Channel",
+    "snapPageConfinementLabel": "Confinement",
+    "snapPageContactPublisherLabel": "Contact {publisher}",
+    "@snapPageContactPublisherLabel": {
         "placeholders": {
             "publisher": {
                 "type": "String"
             }
         }
     },
-    "detailPageDescriptionLabel": "Description",
-    "detailPageDeveloperWebsiteLabel": "Developer Website",
-    "detailPageDownloadSizeLabel": "Download Size",
-    "detailPageGalleryLabel": "Gallery",
-    "detailPageLicenseLabel": "License",
-    "detailPageLinksLabel": "Links",
-    "detailPagePublisherLabel": "Publisher",
-    "detailPagePublishedLabel": "Published",
-    "detailPageSummaryLabel": "Summary",
-    "detailPageVersionLabel": "Version",
+    "snapPageDescriptionLabel": "Description",
+    "snapPageDeveloperWebsiteLabel": "Developer Website",
+    "snapPageDownloadSizeLabel": "Download Size",
+    "snapPageGalleryLabel": "Gallery",
+    "snapPageLicenseLabel": "License",
+    "snapPageLinksLabel": "Links",
+    "snapPagePublisherLabel": "Publisher",
+    "snapPagePublishedLabel": "Published",
+    "snapPageSummaryLabel": "Summary",
+    "snapPageVersionLabel": "Version",
     "explorePageLabel": "Explore",
     "explorePageCategoriesLabel": "Categories",
     "managePageCheckForUpdates": "Check for updates",

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -328,7 +328,7 @@ class _ManageSnapTile extends ConsumerWidget {
           ),
       },
       leading: Clickable(
-        onTap: () => StoreNavigator.pushDetail(context, name: snap.name),
+        onTap: () => StoreNavigator.pushSnap(context, name: snap.name),
         child: AppIcon(iconUrl: snap.iconUrl, size: 40),
       ),
       title: Row(
@@ -338,8 +338,7 @@ class _ManageSnapTile extends ConsumerWidget {
             child: Align(
               alignment: Alignment.centerLeft,
               child: Clickable(
-                onTap: () =>
-                    StoreNavigator.pushDetail(context, name: snap.name),
+                onTap: () => StoreNavigator.pushSnap(context, name: snap.name),
                 child: Text(
                   snap.titleOrName,
                   maxLines: 1,
@@ -429,7 +428,7 @@ class _ManageSnapTile extends ConsumerWidget {
             menuChildren: [
               MenuItemButton(
                 onPressed: () =>
-                    StoreNavigator.pushDetail(context, name: snap.name),
+                    StoreNavigator.pushSnap(context, name: snap.name),
                 child: Text(
                   l10n.managePageShowDetailsLabel,
                   style: Theme.of(context).textTheme.bodyMedium,

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -329,7 +329,7 @@ class _ManageSnapTile extends ConsumerWidget {
       },
       leading: Clickable(
         onTap: () => StoreNavigator.pushDetail(context, name: snap.name),
-        child: SnapIcon(iconUrl: snap.iconUrl, size: 40),
+        child: AppIcon(iconUrl: snap.iconUrl, size: 40),
       ),
       title: Row(
         children: [

--- a/lib/src/search/search_field.dart
+++ b/lib/src/search/search_field.dart
@@ -209,7 +209,7 @@ class _AutoCompleteTile extends StatelessWidget {
       AutoCompleteSnapOption(snap: final snap) => ListTile(
           selected: selected,
           title: Text(snap.titleOrName),
-          leading: SnapIcon(
+          leading: AppIcon(
             size: _iconSize,
             iconUrl: snap.iconUrl,
           ),
@@ -217,7 +217,7 @@ class _AutoCompleteTile extends StatelessWidget {
       AutoCompleteDebOption(deb: final deb) => ListTile(
           selected: selected,
           title: Text(deb.getLocalizedName()),
-          leading: SnapIcon(
+          leading: AppIcon(
             size: _iconSize,
             iconUrl:
                 deb.icons.whereType<AppstreamRemoteIcon>().firstOrNull?.url,

--- a/lib/src/search/search_page.dart
+++ b/lib/src/search/search_page.dart
@@ -123,7 +123,7 @@ class SearchPage extends StatelessWidget {
                         slivers: [
                           SnapCardGrid(
                             snaps: data,
-                            onTap: (snap) => StoreNavigator.pushSearchDetail(
+                            onTap: (snap) => StoreNavigator.pushSearchSnap(
                               context,
                               name: snap.name,
                               query: query,

--- a/lib/src/snapd/snap_page.dart
+++ b/lib/src/snapd/snap_page.dart
@@ -22,8 +22,8 @@ const _kChannelDropdownWidth = 220.0;
 
 typedef SnapInfo = ({String label, Widget value});
 
-class DetailPage extends ConsumerWidget {
-  const DetailPage({super.key, required this.snapName});
+class SnapPage extends ConsumerWidget {
+  const SnapPage({super.key, required this.snapName});
 
   final String snapName;
 
@@ -56,7 +56,7 @@ class _SnapView extends ConsumerWidget {
 
     final snapInfos = <SnapInfo>[
       (
-        label: l10n.detailPageConfinementLabel,
+        label: l10n.snapPageConfinementLabel,
         value: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -74,7 +74,7 @@ class _SnapView extends ConsumerWidget {
         ),
       ),
       (
-        label: l10n.detailPageDownloadSizeLabel,
+        label: l10n.snapPageDownloadSizeLabel,
         value: Text(
           snapModel.channelInfo != null
               ? context.formatByteSize(snapModel.channelInfo!.size)
@@ -82,7 +82,7 @@ class _SnapView extends ConsumerWidget {
         ),
       ),
       (
-        label: l10n.detailPagePublishedLabel,
+        label: l10n.snapPagePublishedLabel,
         value: Text(
           snapModel.channelInfo != null
               ? DateFormat.yMMMd().format(snapModel.channelInfo!.releasedAt)
@@ -90,18 +90,18 @@ class _SnapView extends ConsumerWidget {
         ),
       ),
       (
-        label: l10n.detailPageLicenseLabel,
+        label: l10n.snapPageLicenseLabel,
         value: Text(snapModel.snap.license ?? ''),
       ),
       (
-        label: l10n.detailPageLinksLabel,
+        label: l10n.snapPageLinksLabel,
         value: Column(
           children: [
             if (snapModel.snap.website != null)
-              '<a href="${snapModel.snap.website}">${l10n.detailPageDeveloperWebsiteLabel}</a>',
+              '<a href="${snapModel.snap.website}">${l10n.snapPageDeveloperWebsiteLabel}</a>',
             if (snapModel.snap.contact != null &&
                 snapModel.snap.publisher != null)
-              '<a href="${snapModel.snap.contact}">${l10n.detailPageContactPublisherLabel(snapModel.snap.publisher!.displayName)}</a>'
+              '<a href="${snapModel.snap.contact}">${l10n.snapPageContactPublisherLabel(snapModel.snap.publisher!.displayName)}</a>'
           ]
               .map((link) => Html(
                     data: link,
@@ -140,14 +140,14 @@ class _SnapView extends ConsumerWidget {
                       const Divider(),
                       if (snapModel.hasGallery)
                         _Section(
-                          header: Text(l10n.detailPageGalleryLabel),
+                          header: Text(l10n.snapPageGalleryLabel),
                           child: SnapScreenshotGallery(
                             snap: snapModel.storeSnap!,
                             height: layout.totalWidth / 2,
                           ),
                         ),
                       _Section(
-                        header: Text(l10n.detailPageDescriptionLabel),
+                        header: Text(l10n.snapPageDescriptionLabel),
                         child: SizedBox(
                           width: double.infinity,
                           child: MarkdownBody(
@@ -445,7 +445,7 @@ class _ChannelDropdown extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          l10n.detailPageChannelLabel,
+          l10n.snapPageChannelLabel,
           style: Theme.of(context).textTheme.labelLarge,
         ),
         const SizedBox(width: 16),
@@ -510,9 +510,9 @@ class _ChannelDropdownEntry extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(l10n.detailPageChannelLabel),
-                  Text(l10n.detailPageVersionLabel),
-                  Text(l10n.detailPagePublishedLabel),
+                  Text(l10n.snapPageChannelLabel),
+                  Text(l10n.snapPageVersionLabel),
+                  Text(l10n.snapPagePublishedLabel),
                 ],
               ),
             ),

--- a/lib/src/store/store_app.dart
+++ b/lib/src/store/store_app.dart
@@ -5,10 +5,10 @@ import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '/detail.dart';
 import '/l10n.dart';
 import '/layout.dart';
 import '/search.dart';
+import '/snapd.dart';
 import 'store_navigator.dart';
 import 'store_observer.dart';
 import 'store_pages.dart';
@@ -50,7 +50,7 @@ class _StoreAppState extends ConsumerState<StoreApp> {
               child: SearchField(
                 onSearch: (query) =>
                     _navigator.pushAndRemoveSearch(query: query),
-                onSnapSelected: (name) => _navigator.pushDetail(name: name),
+                onSnapSelected: (name) => _navigator.pushSnap(name: name),
                 onDebSelected: (_) {
                   log.debug('Detail page for debs not implemented yet!');
                 }, // TODO: push detail page
@@ -71,10 +71,10 @@ class _StoreAppState extends ConsumerState<StoreApp> {
             breakpoint: 0, // always landscape
             onGenerateRoute: (settings) =>
                 switch (StoreRoutes.routeOf(settings)) {
-              StoreRoutes.detail => MaterialPageRoute(
+              StoreRoutes.snap => MaterialPageRoute(
                   settings: settings,
-                  builder: (_) => DetailPage(
-                    snapName: StoreRoutes.detailOf(settings)!,
+                  builder: (_) => SnapPage(
+                    snapName: StoreRoutes.snapOf(settings)!,
                   ),
                 ),
               StoreRoutes.search => MaterialPageRoute(

--- a/lib/src/store/store_navigator.dart
+++ b/lib/src/store/store_navigator.dart
@@ -3,11 +3,11 @@ import 'package:flutter/widgets.dart';
 import 'store_routes.dart';
 
 class StoreNavigator {
-  static Future<void> pushDetail(
+  static Future<void> pushSnap(
     BuildContext context, {
     required String name,
   }) {
-    return Navigator.of(context).pushDetail(name: name);
+    return Navigator.of(context).pushSnap(name: name);
   }
 
   static Future<void> pushSearch(
@@ -18,13 +18,13 @@ class StoreNavigator {
     return Navigator.of(context).pushSearch(query: query, category: category);
   }
 
-  static Future<void> pushSearchDetail(
+  static Future<void> pushSearchSnap(
     BuildContext context, {
     required String name,
     String? query,
     String? category,
   }) {
-    return Navigator.of(context).pushSearchDetail(
+    return Navigator.of(context).pushSearchSnap(
       name: name,
       query: query,
       category: category,
@@ -33,8 +33,8 @@ class StoreNavigator {
 }
 
 extension StoreNavigatorState on NavigatorState {
-  Future<void> pushDetail({required String name}) {
-    return pushNamed(StoreRoutes.namedDetail(name: name));
+  Future<void> pushSnap({required String name}) {
+    return pushNamed(StoreRoutes.namedSnap(name: name));
   }
 
   Future<void> pushSearch({String? query, String? category}) {
@@ -48,12 +48,12 @@ extension StoreNavigatorState on NavigatorState {
     );
   }
 
-  Future<void> pushSearchDetail({
+  Future<void> pushSearchSnap({
     required String name,
     String? query,
     String? category,
   }) {
-    return pushNamed(StoreRoutes.namedSearchDetail(
+    return pushNamed(StoreRoutes.namedSearchSnap(
       name: name,
       query: query,
       category: category,

--- a/lib/src/store/store_providers.dart
+++ b/lib/src/store/store_providers.dart
@@ -33,7 +33,7 @@ String? _parseRoute(List<String>? args) {
     if (args?.firstOrNull?.startsWith(_kUrlPrefix) ?? false) {
       final snap = args!.first.split(_kUrlPrefix)[1];
       if (snap.isNotEmpty) {
-        return StoreRoutes.namedDetail(name: snap);
+        return StoreRoutes.namedSnap(name: snap);
       }
     }
     final result = parser.parse(args ?? []);
@@ -45,7 +45,7 @@ String? _parseRoute(List<String>? args) {
 
     final snap = result['snap'] as String? ?? result.rest.singleOrNull;
     if (snap != null) {
-      return StoreRoutes.namedDetail(name: snap);
+      return StoreRoutes.namedSnap(name: snap);
     }
   } on FormatException {
     // TODO: print usage

--- a/lib/src/store/store_routes.dart
+++ b/lib/src/store/store_routes.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/widgets.dart';
 
-// TODO: sort out "snap" vs. "detail"
 abstract class StoreRoutes {
   static const explore = '/explore';
-  static const detail = '/detail';
+  static const snap = '/snap';
   static const manage = '/manage';
   static const search = '/search';
 
-  static bool isDetail(RouteSettings route) => routeOf(route) == detail;
+  static bool isSnap(RouteSettings route) => routeOf(route) == snap;
   static bool isSearch(RouteSettings route) => routeOf(route) == search;
 
   static String routeOf(RouteSettings route) =>
@@ -16,7 +15,7 @@ abstract class StoreRoutes {
   static String? categoryOf(RouteSettings route) =>
       Uri.parse(route.name ?? '').queryParameters['category'];
 
-  static String? detailOf(RouteSettings route) =>
+  static String? snapOf(RouteSettings route) =>
       Uri.parse(route.name ?? '').queryParameters['snap'];
 
   static String? queryOf(RouteSettings route) =>
@@ -26,8 +25,8 @@ abstract class StoreRoutes {
     return Uri(path: path, queryParameters: params).toString();
   }
 
-  static String namedDetail({required String name}) {
-    return namedRoute(StoreRoutes.detail, {'snap': name});
+  static String namedSnap({required String name}) {
+    return namedRoute(StoreRoutes.snap, {'snap': name});
   }
 
   static String namedSearch({String? query, String? category}) {
@@ -37,12 +36,12 @@ abstract class StoreRoutes {
     });
   }
 
-  static String namedSearchDetail({
+  static String namedSearchSnap({
     required String name,
     String? query,
     String? category,
   }) {
-    return namedRoute(StoreRoutes.detail, {
+    return namedRoute(StoreRoutes.snap, {
       'snap': name,
       if (query != null) 'query': query,
       if (category != null) 'category': category,

--- a/lib/src/widgets/app_icon.dart
+++ b/lib/src/widgets/app_icon.dart
@@ -7,8 +7,8 @@ import '/constants.dart';
 import '/layout.dart';
 import '/xdg_cache_manager.dart';
 
-class SnapIcon extends StatelessWidget {
-  const SnapIcon({
+class AppIcon extends StatelessWidget {
+  const AppIcon({
     super.key,
     required this.iconUrl,
     this.size = kIconSize,

--- a/lib/src/widgets/snap_card.dart
+++ b/lib/src/widgets/snap_card.dart
@@ -30,7 +30,7 @@ class SnapCard extends StatelessWidget {
         direction: compact ? Axis.vertical : Axis.horizontal,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SnapIcon(iconUrl: snap.iconUrl),
+          AppIcon(iconUrl: snap.iconUrl),
           const SizedBox(width: 16, height: 16),
           Expanded(child: _SnapCardBody(snap: snap)),
         ],

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,6 +1,6 @@
+export 'src/widgets/app_icon.dart';
 export 'src/widgets/clickable.dart';
 export 'src/widgets/snap_card.dart';
 export 'src/widgets/snap_grid.dart';
-export 'src/widgets/snap_icon.dart';
 export 'src/widgets/snap_screenshot_gallery.dart';
 export 'src/widgets/snap_title.dart';

--- a/test/initial_route_test.dart
+++ b/test/initial_route_test.dart
@@ -38,7 +38,7 @@ void main() {
       fireImmediately: true,
     );
 
-    verify(listener(null, StoreRoutes.namedDetail(name: 'bar'))).called(1);
+    verify(listener(null, StoreRoutes.namedSnap(name: 'bar'))).called(1);
   });
 
   test('snap url', () {
@@ -54,7 +54,7 @@ void main() {
       fireImmediately: true,
     );
 
-    verify(listener(null, StoreRoutes.namedDetail(name: 'bar'))).called(1);
+    verify(listener(null, StoreRoutes.namedSnap(name: 'bar'))).called(1);
   });
 
   test('no arguments', () {

--- a/test/snap_page_test.dart
+++ b/test/snap_page_test.dart
@@ -1,7 +1,6 @@
 import 'package:app_center/l10n.dart';
 import 'package:app_center/ratings.dart';
 import 'package:app_center/snapd.dart';
-import 'package:app_center/src/detail/detail_page.dart';
 import 'package:app_center/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -75,16 +74,16 @@ void expectSnapInfos(
   expect(find.markdownBody(snap.description), findsOneWidget);
   expect(find.text(snap.license!), findsOneWidget);
 
-  expect(find.text(tester.l10n.detailPageConfinementLabel), findsOneWidget);
-  expect(find.text(tester.l10n.detailPageDescriptionLabel), findsOneWidget);
-  expect(find.text(tester.l10n.detailPageLicenseLabel), findsOneWidget);
-  expect(find.text(tester.l10n.detailPagePublishedLabel), findsOneWidget);
+  expect(find.text(tester.l10n.snapPageConfinementLabel), findsOneWidget);
+  expect(find.text(tester.l10n.snapPageDescriptionLabel), findsOneWidget);
+  expect(find.text(tester.l10n.snapPageLicenseLabel), findsOneWidget);
+  expect(find.text(tester.l10n.snapPagePublishedLabel), findsOneWidget);
 
   final snapChannel = snap.channels[channel];
   if (snapChannel != null) {
     expect(find.text(snapChannel.confinement.localize(tester.l10n)),
         findsOneWidget);
-    expect(find.text(tester.l10n.detailPageDownloadSizeLabel), findsOneWidget);
+    expect(find.text(tester.l10n.snapPageDownloadSizeLabel), findsOneWidget);
     expect(find.text(tester.context.formatByteSize(snapChannel.size)),
         findsOneWidget);
     expect(find.text(DateFormat.yMMMd().format(snapChannel.releasedAt)),
@@ -115,7 +114,7 @@ void main() {
             updatesModelProvider.overrideWith((ref) => updatesModel),
             ratingsModelProvider.overrideWith((ref, arg) => ratingsModel),
           ],
-          child: const DetailPage(snapName: 'testsnap'),
+          child: const SnapPage(snapName: 'testsnap'),
         ));
     await tester.pump();
     expectSnapInfos(tester, storeSnap, 'latest/edge');
@@ -159,7 +158,7 @@ void main() {
             updatesModelProvider.overrideWith((ref) => updatesModel),
             ratingsModelProvider.overrideWith((ref, arg) => ratingsModel),
           ],
-          child: DetailPage(snapName: storeSnap.name),
+          child: SnapPage(snapName: storeSnap.name),
         ));
     await tester.pump();
     expectSnapInfos(tester, storeSnap, 'latest/edge');
@@ -196,7 +195,7 @@ void main() {
             updatesModelProvider.overrideWith((ref) => updatesModel),
             ratingsModelProvider.overrideWith((ref, arg) => ratingsModel),
           ],
-          child: DetailPage(snapName: storeSnap.name),
+          child: SnapPage(snapName: storeSnap.name),
         ));
     await tester.pump();
     expectSnapInfos(tester, storeSnap);
@@ -229,7 +228,7 @@ void main() {
             updatesModelProvider.overrideWith((ref) => updatesModel),
             ratingsModelProvider.overrideWith((ref, arg) => ratingsModel),
           ],
-          child: DetailPage(snapName: localSnap.name),
+          child: SnapPage(snapName: localSnap.name),
         ));
     await tester.pump();
     expectSnapInfos(tester, localSnap);
@@ -266,7 +265,7 @@ void main() {
             launchProvider.overrideWith((ref, arg) => snapLauncher),
             updatesModelProvider.overrideWith((ref) => updatesModel)
           ],
-          child: DetailPage(snapName: storeSnap.name),
+          child: SnapPage(snapName: storeSnap.name),
         ));
     await tester.pump();
     expect(find.text(tester.l10n.snapActionRemoveLabel), findsNothing);

--- a/test/store_navigator_test.dart
+++ b/test/store_navigator_test.dart
@@ -22,11 +22,11 @@ void main() {
     ));
 
     final context = tester.element(find.byType(Scaffold));
-    unawaited(StoreNavigator.pushDetail(context, name: 'foo'));
+    unawaited(StoreNavigator.pushSnap(context, name: 'foo'));
     await tester.pump();
     expect(
       generatedRoutes,
-      expectedRoutes..add(StoreRoutes.namedDetail(name: 'foo')),
+      expectedRoutes..add(StoreRoutes.namedSnap(name: 'foo')),
     );
 
     unawaited(
@@ -50,7 +50,7 @@ void main() {
     );
 
     unawaited(
-      StoreNavigator.pushSearchDetail(
+      StoreNavigator.pushSearchSnap(
         context,
         name: 'foo',
         query: 'bar',
@@ -61,7 +61,7 @@ void main() {
     expect(
       generatedRoutes,
       expectedRoutes
-        ..add(StoreRoutes.namedSearchDetail(
+        ..add(StoreRoutes.namedSearchSnap(
             name: 'foo', query: 'bar', category: 'baz')),
     );
   });

--- a/test/store_routes_test.dart
+++ b/test/store_routes_test.dart
@@ -6,31 +6,31 @@ void main() {
   test('route of', () {
     const root = RouteSettings(name: '/');
     expect(StoreRoutes.routeOf(root), equals('/'));
-    expect(StoreRoutes.isDetail(root), isFalse);
-    expect(StoreRoutes.detailOf(root), isNull);
+    expect(StoreRoutes.isSnap(root), isFalse);
+    expect(StoreRoutes.snapOf(root), isNull);
     expect(StoreRoutes.isSearch(root), isFalse);
     expect(StoreRoutes.queryOf(root), isNull);
 
-    const detail = RouteSettings(name: '/detail?snap=foo');
-    expect(StoreRoutes.routeOf(detail), equals('/detail'));
-    expect(StoreRoutes.isDetail(detail), isTrue);
-    expect(StoreRoutes.detailOf(detail), equals('foo'));
-    expect(StoreRoutes.isSearch(detail), isFalse);
-    expect(StoreRoutes.queryOf(detail), isNull);
+    const snap = RouteSettings(name: '/snap?snap=foo');
+    expect(StoreRoutes.routeOf(snap), equals('/snap'));
+    expect(StoreRoutes.isSnap(snap), isTrue);
+    expect(StoreRoutes.snapOf(snap), equals('foo'));
+    expect(StoreRoutes.isSearch(snap), isFalse);
+    expect(StoreRoutes.queryOf(snap), isNull);
 
     const search = RouteSettings(name: '/search?query=bar');
     expect(StoreRoutes.routeOf(search), equals('/search'));
-    expect(StoreRoutes.isDetail(search), isFalse);
-    expect(StoreRoutes.detailOf(search), isNull);
+    expect(StoreRoutes.isSnap(search), isFalse);
+    expect(StoreRoutes.snapOf(search), isNull);
     expect(StoreRoutes.isSearch(search), isTrue);
     expect(StoreRoutes.queryOf(search), equals('bar'));
 
-    const searchDetail = RouteSettings(name: '/detail?query=bar&snap=foo');
-    expect(StoreRoutes.routeOf(searchDetail), equals('/detail'));
-    expect(StoreRoutes.isDetail(searchDetail), isTrue);
-    expect(StoreRoutes.detailOf(searchDetail), equals('foo'));
-    expect(StoreRoutes.isSearch(searchDetail), isFalse);
-    expect(StoreRoutes.queryOf(searchDetail), equals('bar'));
+    const searchSnap = RouteSettings(name: '/snap?query=bar&snap=foo');
+    expect(StoreRoutes.routeOf(searchSnap), equals('/snap'));
+    expect(StoreRoutes.isSnap(searchSnap), isTrue);
+    expect(StoreRoutes.snapOf(searchSnap), equals('foo'));
+    expect(StoreRoutes.isSearch(searchSnap), isFalse);
+    expect(StoreRoutes.queryOf(searchSnap), equals('bar'));
   });
 
   test('named route', () {
@@ -39,9 +39,9 @@ void main() {
     expect(
         StoreRoutes.namedRoute('/foo', {'bar': 'baz'}), equals('/foo?bar=baz'));
 
-    expect(StoreRoutes.namedDetail(name: 'foo'), equals('/detail?snap=foo'));
+    expect(StoreRoutes.namedSnap(name: 'foo'), equals('/snap?snap=foo'));
     expect(StoreRoutes.namedSearch(query: 'bar'), equals('/search?query=bar'));
-    expect(StoreRoutes.namedSearchDetail(query: 'bar', name: 'foo'),
-        equals('/detail?snap=foo&query=bar'));
+    expect(StoreRoutes.namedSearchSnap(query: 'bar', name: 'foo'),
+        equals('/snap?snap=foo&query=bar'));
   });
 }


### PR DESCRIPTION
`SnapIcon` is already general enough that it can simply be renamed to `AppIcon` and later reused for debs.

Rather than trying to generalize the existing `DetailPage` with the current time constraints, I'd prefer moving and renaming it to `SnapPage` and add a separate `DebPage` later.