### PR TITLE
feat: snapd error handling

### DIFF
--- a/lib/snapd.dart
+++ b/lib/snapd.dart
@@ -7,4 +7,4 @@ export 'src/snapd/snap_search.dart';
 export 'src/snapd/snap_sort.dart';
 export 'src/snapd/snapd_service.dart';
 export 'src/snapd/snapx.dart';
-export 'src/snapd/updates_model.dart' hide log;
+export 'src/snapd/updates_model.dart';

--- a/lib/snapd.dart
+++ b/lib/snapd.dart
@@ -7,4 +7,4 @@ export 'src/snapd/snap_search.dart';
 export 'src/snapd/snap_sort.dart';
 export 'src/snapd/snapd_service.dart';
 export 'src/snapd/snapx.dart';
-export 'src/snapd/updates_model.dart';
+export 'src/snapd/updates_model.dart' hide log;

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -46,7 +46,7 @@ class _ManagePageState extends ConsumerState<ManagePage> {
 
   Future<void> showError(SnapdException e) => showErrorDialog(
         context: context,
-        title: e.kind ?? '',
+        title: e.kind ?? 'Unknown Snapd Exception',
         message: e.message,
       );
 

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:snapd/snapd.dart';
@@ -13,7 +15,7 @@ import '/widgets.dart';
 import 'local_snap_providers.dart';
 import 'manage_model.dart';
 
-class ManagePage extends ConsumerWidget {
+class ManagePage extends ConsumerStatefulWidget {
   const ManagePage({super.key});
 
   static IconData icon(bool selected) => YaruIcons.app_grid;
@@ -21,7 +23,35 @@ class ManagePage extends ConsumerWidget {
       AppLocalizations.of(context).managePageLabel;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ManagePage> createState() => _ManagePageState();
+}
+
+class _ManagePageState extends ConsumerState<ManagePage> {
+  StreamSubscription? _errorSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _errorSubscription =
+        ref.read(updatesModelProvider).errorStream.listen(showError);
+  }
+
+  @override
+  void dispose() {
+    _errorSubscription?.cancel();
+    _errorSubscription = null;
+    super.dispose();
+  }
+
+  Future<void> showError(SnapdException e) => showErrorDialog(
+        context: context,
+        title: e.kind ?? '',
+        message: e.message,
+      );
+
+  @override
+  Widget build(BuildContext context) {
     final manageModel = ref.watch(manageModelProvider);
     return manageModel.state.when(
       data: (_) => _ManageView(manageModel: manageModel),

--- a/lib/src/snapd/logger.dart
+++ b/lib/src/snapd/logger.dart
@@ -1,0 +1,3 @@
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+final log = Logger('snapd');

--- a/lib/src/snapd/snap_model.dart
+++ b/lib/src/snapd/snap_model.dart
@@ -3,15 +3,11 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:meta/meta.dart';
 import 'package:snapd/snapd.dart';
-import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 import '/snapd.dart';
-
-@internal
-final log = Logger('snap');
+import 'logger.dart';
 
 final snapModelProvider =
     ChangeNotifierProvider.family.autoDispose<SnapModel, String>(

--- a/lib/src/snapd/snap_page.dart
+++ b/lib/src/snapd/snap_page.dart
@@ -55,7 +55,7 @@ class _SnapPageState extends ConsumerState<SnapPage> {
 
   Future<void> showError(SnapdException e) => showErrorDialog(
         context: context,
-        title: e.kind ?? '',
+        title: e.kind ?? 'Unknown Snapd Exception',
         message: e.message,
       );
 

--- a/lib/src/snapd/updates_model.dart
+++ b/lib/src/snapd/updates_model.dart
@@ -2,15 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:meta/meta.dart';
 import 'package:snapd/snapd.dart';
-import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 import '/snapd.dart';
-
-@internal
-final log = Logger('snap');
+import 'logger.dart';
 
 final updatesModelProvider = ChangeNotifierProvider(
   (ref) => UpdatesModel(getService<SnapdService>())..refresh(),

--- a/lib/src/snapd/updates_model.dart
+++ b/lib/src/snapd/updates_model.dart
@@ -1,9 +1,16 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meta/meta.dart';
 import 'package:snapd/snapd.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 import '/snapd.dart';
+
+@internal
+final log = Logger('snap');
 
 final updatesModelProvider = ChangeNotifierProvider(
   (ref) => UpdatesModel(getService<SnapdService>())..refresh(),
@@ -23,6 +30,16 @@ class UpdatesModel extends ChangeNotifier {
   AsyncValue<void> get state => _state;
   AsyncValue<void> _state;
 
+  Stream<SnapdException> get errorStream => _errorStreamController.stream;
+  final StreamController<SnapdException> _errorStreamController =
+      StreamController.broadcast();
+
+  void _handleError(SnapdException e) {
+    _errorStreamController.add(e);
+    log.error(
+        'Caught exception when handling updates for $refreshableSnapNames', e);
+  }
+
   Future<void> refresh() async {
     _state = const AsyncValue.loading();
     notifyListeners();
@@ -36,10 +53,14 @@ class UpdatesModel extends ChangeNotifier {
 
   Future<void> updateAll() async {
     if (_refreshableSnaps == null) return;
-    final changeId = await snapd.refreshMany(refreshableSnapNames.toList());
-    _activeChangeId = changeId;
-    notifyListeners();
-    await snapd.waitChange(changeId);
+    try {
+      final changeId = await snapd.refreshMany(refreshableSnapNames.toList());
+      _activeChangeId = changeId;
+      notifyListeners();
+      await snapd.waitChange(changeId);
+    } on SnapdException catch (e) {
+      _handleError(e);
+    }
     _activeChangeId = null;
     await refresh();
   }

--- a/lib/src/store/store_app.dart
+++ b/lib/src/store/store_app.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart' hide AboutDialog, showAboutDialog;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:meta/meta.dart';
-import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -15,9 +13,6 @@ import 'store_observer.dart';
 import 'store_pages.dart';
 import 'store_providers.dart';
 import 'store_routes.dart';
-
-@internal
-final log = Logger('store_app');
 
 class StoreApp extends ConsumerStatefulWidget {
   const StoreApp({super.key});

--- a/lib/src/widgets/dialogs.dart
+++ b/lib/src/widgets/dialogs.dart
@@ -78,3 +78,5 @@ class ErrorDialog extends StatelessWidget {
     );
   }
 }
+
+// TODO: add confirmation dialogs (issue #1398)

--- a/lib/src/widgets/dialogs.dart
+++ b/lib/src/widgets/dialogs.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+
+import '/l10n.dart';
+
+const kMaxWidth = 500.0;
+
+Future<void> showErrorDialog({
+  required BuildContext context,
+  required String title,
+  required String message,
+  IconData? icon,
+}) {
+  return showDialog(
+    context: context,
+    builder: (context) => ErrorDialog(
+      title: title,
+      message: message,
+      icon: icon,
+    ),
+  );
+}
+
+class ErrorDialog extends StatelessWidget {
+  const ErrorDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    this.icon,
+  });
+
+  final String title;
+  final String message;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = UbuntuLocalizations.of(context);
+    return AlertDialog(
+      actions: [
+        PushButton.filled(
+          onPressed: Navigator.of(context).pop,
+          child: Text(l10n.closeLabel),
+        )
+      ],
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: kMaxWidth),
+        child: Row(
+          children: [
+            Icon(
+              icon ?? YaruIcons.error,
+              color: Theme.of(context).colorScheme.error,
+              size: 64.0,
+            ),
+            const SizedBox(width: 16),
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    height: Theme.of(context).textTheme.titleMedium!.fontSize! *
+                        1.5,
+                    child: Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(message),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -3,5 +3,6 @@ export 'src/widgets/app_icon.dart';
 export 'src/widgets/app_info_bar.dart';
 export 'src/widgets/app_title.dart';
 export 'src/widgets/clickable.dart';
+export 'src/widgets/dialogs.dart';
 export 'src/widgets/screenshot_gallery.dart';
 export 'src/widgets/snap_grid.dart';

--- a/test/snap_model_test.dart
+++ b/test/snap_model_test.dart
@@ -207,4 +207,29 @@ void main() {
     verify(service.abortChange('changeId')).called(1);
     expect(model.activeChangeId, isNull);
   });
+
+  test('error stream', () async {
+    final service = createMockSnapdService(
+      localSnap: localSnap,
+      storeSnap: storeSnap,
+    );
+    when(service.install(
+      any,
+      channel: anyNamed('channel'),
+      classic: anyNamed('classic'),
+    )).thenThrow(SnapdException(message: 'error message', kind: 'error kind'));
+
+    final model = SnapModel(snapd: service, snapName: 'testsnap');
+    await model.init();
+
+    model.errorStream.listen(
+      expectAsync1<void, SnapdException>(
+        (e) {
+          expect(e.kind, equals('error kind'));
+          expect(e.message, equals('error message'));
+        },
+      ),
+    );
+    await model.install();
+  });
 }

--- a/test/snap_page_test.dart
+++ b/test/snap_page_test.dart
@@ -300,5 +300,33 @@ void main() {
     expect(find.text(snapRating.ratingsBand.localize(l10n)), findsNothing);
   });
 
+  testWidgets('error dialog', (tester) async {
+    final snapModel = createMockSnapModel(
+      state: const AsyncValue.loading(),
+      storeSnap: storeSnap,
+      errorStream: Stream.value(
+        SnapdException(
+          message: 'error message',
+          kind: 'error kind',
+        ),
+      ),
+    );
+    final snapLauncher = createMockSnapLauncher(isLaunchable: true);
+    final updatesModel = createMockUpdatesModel();
+
+    await tester.pumpApp((_) => ProviderScope(
+          overrides: [
+            snapModelProvider.overrideWith((ref, arg) => snapModel),
+            launchProvider.overrideWith((ref, arg) => snapLauncher),
+            updatesModelProvider.overrideWith((ref) => updatesModel)
+          ],
+          child: SnapPage(snapName: storeSnap.name),
+        ));
+    await tester.pump();
+
+    expect(find.text('error message'), findsOneWidget);
+    expect(find.text('error kind'), findsOneWidget);
+  });
+
   // TODO: test loading states with snap change in progress
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -155,6 +155,7 @@ MockSnapdService createMockSnapdService({
     channel: anyNamed('channel'),
     classic: anyNamed('classic'),
   )).thenAnswer((_) async => 'id');
+  when(service.refreshMany(any)).thenAnswer((_) async => 'id');
   when(service.remove(any)).thenAnswer((_) async => 'id');
   when(service.find(filter: SnapFindFilter.refresh))
       .thenAnswer((_) async => refreshableSnaps ?? []);

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -164,8 +164,10 @@ MockSnapdService createMockSnapdService({
 }
 
 @GenerateMocks([UpdatesModel])
-MockUpdatesModel createMockUpdatesModel(
-    {Iterable<String>? refreshableSnapNames}) {
+MockUpdatesModel createMockUpdatesModel({
+  Iterable<String>? refreshableSnapNames,
+  Stream<SnapdException>? errorStream,
+}) {
   final model = MockUpdatesModel();
   when(model.refreshableSnapNames)
       .thenReturn(refreshableSnapNames ?? const Iterable.empty());
@@ -173,6 +175,8 @@ MockUpdatesModel createMockUpdatesModel(
       refreshableSnapNames?.contains(i.positionalArguments.single) ?? false);
   when(model.state).thenReturn(AsyncValue.data(() {}()));
   when(model.activeChangeId).thenReturn(null);
+  when(model.errorStream)
+      .thenAnswer((_) => errorStream ?? const Stream.empty());
   return model;
 }
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -89,6 +89,7 @@ SnapModel createMockSnapModel({
   String? selectedChannel,
   String? snapName,
   AsyncValue<void>? state,
+  Stream<SnapdException>? errorStream,
 }) {
   final model = MockSnapModel();
   when(model.localSnap).thenReturn(localSnap);
@@ -107,6 +108,8 @@ SnapModel createMockSnapModel({
       model.storeSnap != null && model.storeSnap!.screenshotUrls.isNotEmpty);
   when(model.snapName)
       .thenReturn(snapName ?? localSnap?.name ?? storeSnap?.name ?? '');
+  when(model.errorStream)
+      .thenAnswer((_) => errorStream ?? const Stream.empty());
   return model;
 }
 

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -371,6 +371,11 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
         returnValueForMissingStub: null,
       );
   @override
+  _i11.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
+        Invocation.getter(#errorStream),
+        returnValue: _i11.Stream<_i2.SnapdException>.empty(),
+      ) as _i11.Stream<_i2.SnapdException>);
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -1046,6 +1046,11 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
         ),
       ) as _i5.AsyncValue<void>);
   @override
+  _i11.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
+        Invocation.getter(#errorStream),
+        returnValue: _i11.Stream<_i2.SnapdException>.empty(),
+      ) as _i11.Stream<_i2.SnapdException>);
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,


### PR DESCRIPTION
UDENG-1363
UDENG-1422
Close #1366
Ref #1394 

![image](https://github.com/ubuntu/app-center/assets/113362648/f648f6f1-74a2-480c-87f2-c11cdaf1fee7)
(This state isn't reachable in practice, since we don't show the update button unless there is an update available)

* Adds a rudimentary error dialog widget
* Adds error streams to `SnapModel` and `UpdateModel`
* Logs snapd exceptions caught in the `SnapdModel` and `UpdateModel`
* Shows an error dialog on the `SnapPage` and `ManagePage` when errors are caught in the underlying models