### PR TITLE
fix(appstream): add fallback locale

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,15 @@ import 'store.dart';
 Future<void> main(List<String> args) async {
   await YaruWindowTitleBar.ensureInitialized();
 
+  final binaryName = p.basename(Platform.resolvedExecutable);
+  Logger.setup(
+    path: p.join(
+      xdg.dataHome.path,
+      binaryName,
+      '$binaryName.log',
+    ),
+  );
+
   final snapd = SnapdService();
   await snapd.loadAuthorization();
   registerServiceInstance(snapd);
@@ -54,15 +63,6 @@ Future<void> main(List<String> args) async {
       dispose: (service) => service.dispose());
 
   await initDefaultLocale();
-
-  final binaryName = p.basename(Platform.resolvedExecutable);
-  Logger.setup(
-    path: p.join(
-      xdg.dataHome.path,
-      binaryName,
-      '$binaryName.log',
-    ),
-  );
 
   runApp(const ProviderScope(child: StoreApp()));
 }

--- a/lib/src/appstream/logger.dart
+++ b/lib/src/appstream/logger.dart
@@ -1,0 +1,3 @@
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+final log = Logger('appstream');


### PR DESCRIPTION
UDENG-1439
Fix #1397

* Loads l10n strings when instantiating the `AppstreamService`
* Defaults to "en" if the user's locale isn't supported