### PR TITLE
feat(appstream): keep original search tokens

### DIFF
--- a/lib/src/appstream/appstream_service.dart
+++ b/lib/src/appstream/appstream_service.dart
@@ -226,7 +226,13 @@ class AppstreamService {
         stemmersMap[PlatformDispatcher.instance.locale.languageCode];
     if (algorithm != null) {
       final stemmer = SnowballStemmer(algorithm);
-      return words.map((element) => stemmer.stem(element)).toSet().toList();
+      return words
+          .map((element) => stemmer.stem(element))
+          // Keep original tokens as well, since the stemming algorithm might
+          // have unintended effects. See #1305.
+          .followedBy(words)
+          .toSet()
+          .toList();
     } else {
       return words;
     }


### PR DESCRIPTION
UDENG-1440
Fix #1305

The stemming algorithm used in the appstream search function tends to turn 'y' into 'i' at the end of the word for some English words (can be tested [here](https://snowballstem.org/demo.html)).
I'm not sure what the best solution is, but simply keeping the original search tokens along with the ones generated by the stemmer seems to work well.
I couldn't reproduce the issue with `appstreamcli` so I had a brief look at appstream's implementation of the search logic, but didn't spot any obvious differences.