### PR TITLE
feat: packagekit error handling

### DIFF
--- a/lib/src/deb/deb_model.dart
+++ b/lib/src/deb/deb_model.dart
@@ -49,6 +49,8 @@ class DebModel extends ChangeNotifier {
   PackageKitPackageInfo? packageInfo;
   bool get isInstalled => packageInfo!.info == PackageKitInfo.installed;
 
+  Stream<PackageKitServiceError> get errorStream => packageKit.errorStream;
+
   Future<void> init() async {
     _state = await AsyncValue.guard(() async {
       await packageKit.activateService();

--- a/lib/src/packagekit/logger.dart
+++ b/lib/src/packagekit/logger.dart
@@ -1,0 +1,3 @@
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+final log = Logger('packagekit');

--- a/lib/src/packagekit/packagekit_service.dart
+++ b/lib/src/packagekit/packagekit_service.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
+import 'logger.dart';
+
 typedef PackageKitPackageInfo = PackageKitPackageEvent;
 
 class PackageKitService {
@@ -52,7 +54,8 @@ class PackageKitService {
       await _client.connect();
       _isAvailable = true;
     } on DBusServiceUnknownException catch (_) {
-      // Service isn't available
+      log.info(
+          'Could not connect to PackageKit - marking service as unavailable');
     }
   }
 
@@ -74,6 +77,9 @@ class PackageKitService {
       if (event is PackageKitFinishedEvent || event is PackageKitDestroyEvent) {
         _transactions.remove(id);
         subscription.cancel();
+      } else if (event is PackageKitErrorCodeEvent) {
+        log.error(
+            'Received PackageKitErrorCodeEvent (${event.code}): ${event.details}');
       }
     });
     await action?.call(transaction);

--- a/test/deb_model_test.dart
+++ b/test/deb_model_test.dart
@@ -83,5 +83,33 @@ void main() {
     ).called(1);
   });
 
+  test('error stream', () async {
+    final packageKit = createMockPackageKitService(
+      packageInfo: packageInfo,
+      errorStream: Stream.value(
+        const PackageKitServiceError(
+          code: PackageKitError.noNetwork,
+          details: 'error details',
+        ),
+      ),
+    );
+    final appstream = createMockAppstreamService(component: component);
+    final model = DebModel(
+      appstream: appstream,
+      packageKit: packageKit,
+      id: 'testdeb',
+    );
+
+    model.errorStream.listen(
+      expectAsync1<void, PackageKitServiceError>(
+        (e) {
+          expect(e.code, equals(PackageKitError.noNetwork));
+          expect(e.details, equals('error details'));
+        },
+      ),
+    );
+    await model.init();
+  });
+
   // TODO: test `activeTransactionId` and `cancel()`
 }

--- a/test/deb_page_test.dart
+++ b/test/deb_page_test.dart
@@ -1,0 +1,72 @@
+import 'package:app_center/appstream.dart';
+import 'package:app_center/src/deb/deb_model.dart';
+import 'package:app_center/src/deb/deb_page.dart';
+import 'package:app_center/src/packagekit/packagekit_service.dart';
+import 'package:appstream/appstream.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:packagekit/packagekit.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
+
+import 'test_utils.dart';
+
+const packageInfo = PackageKitPackageInfo(
+  info: PackageKitInfo.available,
+  packageId: PackageKitPackageId(name: 'testdeb', version: '1.0'),
+  summary: 'summary',
+);
+
+const component = AppstreamComponent(
+  id: 'testdeb',
+  type: AppstreamComponentType.desktopApplication,
+  package: 'testdeb-package',
+  name: {'C': 'Test Deb Package'},
+  summary: {'C': 'Appstream summary'},
+  description: {'C': 'description'},
+  developerName: {'C': 'developer name'},
+);
+
+void main() {
+  testWidgets('metadata', (tester) async {
+    final debModel = createMockDebModel(
+      id: 'testdeb',
+      component: component,
+      packageInfo: packageInfo,
+    );
+
+    await tester.pumpApp((_) => ProviderScope(
+          overrides: [debModelProvider.overrideWith((_, __) => debModel)],
+          child: const DebPage(id: 'testdeb'),
+        ));
+    await tester.pump();
+
+    expect(find.text(component.getLocalizedName()), findsOneWidget);
+    expect(find.html(component.getLocalizedDescription()), findsOneWidget);
+    expect(find.text(component.getLocalizedDeveloperName()), findsOneWidget);
+    expect(find.text(packageInfo.packageId.version), findsOneWidget);
+  });
+
+  testWidgets('error dialog', (tester) async {
+    final debModel = createMockDebModel(
+      id: 'testdeb',
+      component: component,
+      packageInfo: packageInfo,
+      errorStream: Stream.value(
+        const PackageKitServiceError(
+          code: PackageKitError.internalError,
+          details: 'internal error',
+        ),
+      ),
+    );
+
+    await tester.pumpApp((_) => ProviderScope(
+          overrides: [debModelProvider.overrideWith((_, __) => debModel)],
+          child: const DebPage(id: 'testdeb'),
+        ));
+    await tester.pump();
+
+    expect(find.text('internal error'), findsOneWidget);
+    expect(find.text('PackageKit error: ${PackageKitError.internalError}'),
+        findsOneWidget);
+  });
+}

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -5,6 +5,7 @@ import 'package:app_center/l10n.dart';
 import 'package:app_center/packagekit.dart';
 import 'package:app_center/ratings.dart';
 import 'package:app_center/snapd.dart';
+import 'package:app_center/src/deb/deb_model.dart';
 import 'package:app_center/src/manage/manage_model.dart';
 import 'package:appstream/appstream.dart';
 import 'package:collection/collection.dart';
@@ -108,6 +109,36 @@ SnapModel createMockSnapModel({
       model.storeSnap != null && model.storeSnap!.screenshotUrls.isNotEmpty);
   when(model.snapName)
       .thenReturn(snapName ?? localSnap?.name ?? storeSnap?.name ?? '');
+  when(model.errorStream)
+      .thenAnswer((_) => errorStream ?? const Stream.empty());
+  return model;
+}
+
+@GenerateMocks([DebModel])
+DebModel createMockDebModel({
+  String? id,
+  AppstreamComponent? component,
+  PackageKitPackageInfo? packageInfo,
+  AsyncValue<void>? state,
+  Stream<PackageKitServiceError>? errorStream,
+}) {
+  final model = MockDebModel();
+  when(model.id).thenReturn(id ?? '');
+  when(model.state).thenReturn(state ?? AsyncValue.data(() {}()));
+  when(model.component).thenReturn(
+    component ??
+        const AppstreamComponent(
+          id: '',
+          type: AppstreamComponentType.desktopApplication,
+          package: '',
+          name: {'C': ''},
+          summary: {'C': ''},
+        ),
+  );
+  when(model.packageInfo).thenReturn(packageInfo);
+  when(model.isInstalled)
+      .thenReturn(packageInfo?.info == PackageKitInfo.installed);
+  when(model.activeTransactionId).thenReturn(null);
   when(model.errorStream)
       .thenAnswer((_) => errorStream ?? const Stream.empty());
   return model;

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -275,10 +275,12 @@ MockAppstreamService createMockAppstreamService({
 MockPackageKitService createMockPackageKitService({
   PackageKitPackageInfo? packageInfo,
   int transactionId = 0,
+  Stream<PackageKitServiceError> errorStream = const Stream.empty(),
 }) {
   final packageKit = MockPackageKitService();
   when(packageKit.resolve(any)).thenAnswer((_) async => packageInfo);
   when(packageKit.install(any)).thenAnswer((_) async => transactionId);
   when(packageKit.remove(any)).thenAnswer((_) async => transactionId);
+  when(packageKit.errorStream).thenAnswer((_) => errorStream);
   return packageKit;
 }

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -3,23 +3,24 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:ui' as _i12;
+import 'dart:async' as _i13;
+import 'dart:ui' as _i14;
 
+import 'package:app_center/appstream.dart' as _i7;
+import 'package:app_center/packagekit.dart' as _i8;
 import 'package:app_center/snapd.dart' as _i6;
-import 'package:app_center/src/appstream/appstream_service.dart' as _i17;
-import 'package:app_center/src/manage/manage_model.dart' as _i13;
-import 'package:app_center/src/packagekit/packagekit_service.dart' as _i18;
-import 'package:app_center/src/ratings/exports.dart' as _i10;
-import 'package:app_center/src/ratings/ratings_model.dart' as _i9;
+import 'package:app_center/src/deb/deb_model.dart' as _i15;
+import 'package:app_center/src/manage/manage_model.dart' as _i16;
+import 'package:app_center/src/ratings/exports.dart' as _i12;
+import 'package:app_center/src/ratings/ratings_model.dart' as _i11;
 import 'package:app_center/src/ratings/ratings_service.dart' as _i4;
-import 'package:appstream/appstream.dart' as _i8;
-import 'package:dbus/dbus.dart' as _i16;
-import 'package:file/file.dart' as _i14;
+import 'package:appstream/appstream.dart' as _i9;
+import 'package:dbus/dbus.dart' as _i19;
+import 'package:file/file.dart' as _i17;
 import 'package:flutter_riverpod/flutter_riverpod.dart' as _i5;
-import 'package:gtk/src/gtk_application_notifier.dart' as _i15;
+import 'package:gtk/src/gtk_application_notifier.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:packagekit/packagekit.dart' as _i7;
+import 'package:packagekit/packagekit.dart' as _i10;
 import 'package:snapcraft_launcher/snapcraft_launcher.dart' as _i3;
 import 'package:snapd/snapd.dart' as _i2;
 
@@ -86,8 +87,9 @@ class _FakeSnapdService_4 extends _i1.SmartFake implements _i6.SnapdService {
         );
 }
 
-class _FakeUpdatesModel_5 extends _i1.SmartFake implements _i6.UpdatesModel {
-  _FakeUpdatesModel_5(
+class _FakeAppstreamService_5 extends _i1.SmartFake
+    implements _i7.AppstreamService {
+  _FakeAppstreamService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -96,9 +98,41 @@ class _FakeUpdatesModel_5 extends _i1.SmartFake implements _i6.UpdatesModel {
         );
 }
 
-class _FakeSnapdSystemInfoResponse_6 extends _i1.SmartFake
+class _FakePackageKitService_6 extends _i1.SmartFake
+    implements _i8.PackageKitService {
+  _FakePackageKitService_6(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAppstreamComponent_7 extends _i1.SmartFake
+    implements _i9.AppstreamComponent {
+  _FakeAppstreamComponent_7(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeUpdatesModel_8 extends _i1.SmartFake implements _i6.UpdatesModel {
+  _FakeUpdatesModel_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSnapdSystemInfoResponse_9 extends _i1.SmartFake
     implements _i2.SnapdSystemInfoResponse {
-  _FakeSnapdSystemInfoResponse_6(
+  _FakeSnapdSystemInfoResponse_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,9 +141,9 @@ class _FakeSnapdSystemInfoResponse_6 extends _i1.SmartFake
         );
 }
 
-class _FakeSnapdConnectionsResponse_7 extends _i1.SmartFake
+class _FakeSnapdConnectionsResponse_10 extends _i1.SmartFake
     implements _i2.SnapdConnectionsResponse {
-  _FakeSnapdConnectionsResponse_7(
+  _FakeSnapdConnectionsResponse_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -118,9 +152,9 @@ class _FakeSnapdConnectionsResponse_7 extends _i1.SmartFake
         );
 }
 
-class _FakeSnapdLoginResponse_8 extends _i1.SmartFake
+class _FakeSnapdLoginResponse_11 extends _i1.SmartFake
     implements _i2.SnapdLoginResponse {
-  _FakeSnapdLoginResponse_8(
+  _FakeSnapdLoginResponse_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -129,8 +163,8 @@ class _FakeSnapdLoginResponse_8 extends _i1.SmartFake
         );
 }
 
-class _FakeSnapdChange_9 extends _i1.SmartFake implements _i2.SnapdChange {
-  _FakeSnapdChange_9(
+class _FakeSnapdChange_12 extends _i1.SmartFake implements _i2.SnapdChange {
+  _FakeSnapdChange_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -139,20 +173,9 @@ class _FakeSnapdChange_9 extends _i1.SmartFake implements _i2.SnapdChange {
         );
 }
 
-class _FakePackageKitTransaction_10 extends _i1.SmartFake
-    implements _i7.PackageKitTransaction {
-  _FakePackageKitTransaction_10(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeAppstreamComponent_11 extends _i1.SmartFake
-    implements _i8.AppstreamComponent {
-  _FakeAppstreamComponent_11(
+class _FakePackageKitTransaction_13 extends _i1.SmartFake
+    implements _i10.PackageKitTransaction {
+  _FakePackageKitTransaction_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,7 +229,7 @@ class MockSnapLauncher extends _i1.Mock implements _i6.SnapLauncher {
 /// A class which mocks [RatingsModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRatingsModel extends _i1.Mock implements _i9.RatingsModel {
+class MockRatingsModel extends _i1.Mock implements _i11.RatingsModel {
   MockRatingsModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -233,7 +256,7 @@ class MockRatingsModel extends _i1.Mock implements _i9.RatingsModel {
       ) as String);
 
   @override
-  set snapRating(_i10.Rating? _snapRating) => super.noSuchMethod(
+  set snapRating(_i12.Rating? _snapRating) => super.noSuchMethod(
         Invocation.setter(
           #snapRating,
           _snapRating,
@@ -257,27 +280,27 @@ class MockRatingsModel extends _i1.Mock implements _i9.RatingsModel {
       ) as bool);
 
   @override
-  _i11.Future<void> init() => (super.noSuchMethod(
+  _i13.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> castVote(_i9.VoteStatus? castVote) => (super.noSuchMethod(
+  _i13.Future<void> castVote(_i11.VoteStatus? castVote) => (super.noSuchMethod(
         Invocation.method(
           #castVote,
           [castVote],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -286,7 +309,7 @@ class MockRatingsModel extends _i1.Mock implements _i9.RatingsModel {
       );
 
   @override
-  void removeListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -394,10 +417,10 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       );
 
   @override
-  _i11.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
+  _i13.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i11.Stream<_i2.SnapdException>.empty(),
-      ) as _i11.Stream<_i2.SnapdException>);
+        returnValue: _i13.Stream<_i2.SnapdException>.empty(),
+      ) as _i13.Stream<_i2.SnapdException>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -406,67 +429,67 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       ) as bool);
 
   @override
-  _i11.Future<void> init() => (super.noSuchMethod(
+  _i13.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> dispose() => (super.noSuchMethod(
+  _i13.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> cancel() => (super.noSuchMethod(
+  _i13.Future<void> cancel() => (super.noSuchMethod(
         Invocation.method(
           #cancel,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> install() => (super.noSuchMethod(
+  _i13.Future<void> install() => (super.noSuchMethod(
         Invocation.method(
           #install,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> refresh() => (super.noSuchMethod(
+  _i13.Future<void> refresh() => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> remove() => (super.noSuchMethod(
+  _i13.Future<void> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -475,7 +498,7 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       );
 
   @override
-  void removeListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -493,10 +516,166 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       );
 }
 
+/// A class which mocks [DebModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockDebModel extends _i1.Mock implements _i15.DebModel {
+  MockDebModel() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i7.AppstreamService get appstream => (super.noSuchMethod(
+        Invocation.getter(#appstream),
+        returnValue: _FakeAppstreamService_5(
+          this,
+          Invocation.getter(#appstream),
+        ),
+      ) as _i7.AppstreamService);
+
+  @override
+  _i8.PackageKitService get packageKit => (super.noSuchMethod(
+        Invocation.getter(#packageKit),
+        returnValue: _FakePackageKitService_6(
+          this,
+          Invocation.getter(#packageKit),
+        ),
+      ) as _i8.PackageKitService);
+
+  @override
+  String get id => (super.noSuchMethod(
+        Invocation.getter(#id),
+        returnValue: '',
+      ) as String);
+
+  @override
+  _i9.AppstreamComponent get component => (super.noSuchMethod(
+        Invocation.getter(#component),
+        returnValue: _FakeAppstreamComponent_7(
+          this,
+          Invocation.getter(#component),
+        ),
+      ) as _i9.AppstreamComponent);
+
+  @override
+  set packageInfo(_i10.PackageKitPackageEvent? _packageInfo) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #packageInfo,
+          _packageInfo,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.AsyncValue<void> get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _FakeAsyncValue_3<void>(
+          this,
+          Invocation.getter(#state),
+        ),
+      ) as _i5.AsyncValue<void>);
+
+  @override
+  bool get isInstalled => (super.noSuchMethod(
+        Invocation.getter(#isInstalled),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i13.Stream<_i10.PackageKitErrorCodeEvent> get errorStream =>
+      (super.noSuchMethod(
+        Invocation.getter(#errorStream),
+        returnValue: _i13.Stream<_i10.PackageKitErrorCodeEvent>.empty(),
+      ) as _i13.Stream<_i10.PackageKitErrorCodeEvent>);
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i13.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> install() => (super.noSuchMethod(
+        Invocation.method(
+          #install,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> remove() => (super.noSuchMethod(
+        Invocation.method(
+          #remove,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  _i13.Future<void> cancel() => (super.noSuchMethod(
+        Invocation.method(
+          #cancel,
+          [],
+        ),
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
+
+  @override
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
 /// A class which mocks [ManageModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockManageModel extends _i1.Mock implements _i13.ManageModel {
+class MockManageModel extends _i1.Mock implements _i16.ManageModel {
   MockManageModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -513,7 +692,7 @@ class MockManageModel extends _i1.Mock implements _i13.ManageModel {
   @override
   _i6.UpdatesModel get updatesModel => (super.noSuchMethod(
         Invocation.getter(#updatesModel),
-        returnValue: _FakeUpdatesModel_5(
+        returnValue: _FakeUpdatesModel_8(
           this,
           Invocation.getter(#updatesModel),
         ),
@@ -547,14 +726,14 @@ class MockManageModel extends _i1.Mock implements _i13.ManageModel {
       ) as bool);
 
   @override
-  _i11.Future<void> init() => (super.noSuchMethod(
+  _i13.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -566,7 +745,7 @@ class MockManageModel extends _i1.Mock implements _i13.ManageModel {
       );
 
   @override
-  void addListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -575,7 +754,7 @@ class MockManageModel extends _i1.Mock implements _i13.ManageModel {
       );
 
   @override
-  void removeListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -626,25 +805,25 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
       );
 
   @override
-  _i11.Future<void> waitChange(String? changeId) => (super.noSuchMethod(
+  _i13.Future<void> waitChange(String? changeId) => (super.noSuchMethod(
         Invocation.method(
           #waitChange,
           [changeId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> loadAuthorization({String? path}) => (super.noSuchMethod(
+  _i13.Future<void> loadAuthorization({String? path}) => (super.noSuchMethod(
         Invocation.method(
           #loadAuthorization,
           [],
           {#path: path},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setAuthorization(
@@ -663,47 +842,47 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
       );
 
   @override
-  _i11.Future<_i2.SnapdSystemInfoResponse> systemInfo() => (super.noSuchMethod(
+  _i13.Future<_i2.SnapdSystemInfoResponse> systemInfo() => (super.noSuchMethod(
         Invocation.method(
           #systemInfo,
           [],
         ),
-        returnValue: _i11.Future<_i2.SnapdSystemInfoResponse>.value(
-            _FakeSnapdSystemInfoResponse_6(
+        returnValue: _i13.Future<_i2.SnapdSystemInfoResponse>.value(
+            _FakeSnapdSystemInfoResponse_9(
           this,
           Invocation.method(
             #systemInfo,
             [],
           ),
         )),
-      ) as _i11.Future<_i2.SnapdSystemInfoResponse>);
+      ) as _i13.Future<_i2.SnapdSystemInfoResponse>);
 
   @override
-  _i11.Future<List<_i2.Snap>> getSnaps() => (super.noSuchMethod(
+  _i13.Future<List<_i2.Snap>> getSnaps() => (super.noSuchMethod(
         Invocation.method(
           #getSnaps,
           [],
         ),
-        returnValue: _i11.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
-      ) as _i11.Future<List<_i2.Snap>>);
+        returnValue: _i13.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
+      ) as _i13.Future<List<_i2.Snap>>);
 
   @override
-  _i11.Future<_i2.Snap> getSnap(String? name) => (super.noSuchMethod(
+  _i13.Future<_i2.Snap> getSnap(String? name) => (super.noSuchMethod(
         Invocation.method(
           #getSnap,
           [name],
         ),
-        returnValue: _i11.Future<_i2.Snap>.value(_FakeSnap_0(
+        returnValue: _i13.Future<_i2.Snap>.value(_FakeSnap_0(
           this,
           Invocation.method(
             #getSnap,
             [name],
           ),
         )),
-      ) as _i11.Future<_i2.Snap>);
+      ) as _i13.Future<_i2.Snap>);
 
   @override
-  _i11.Future<List<_i2.SnapApp>> getApps({
+  _i13.Future<List<_i2.SnapApp>> getApps({
     List<String>? names,
     _i2.SnapdAppFilter? filter,
   }) =>
@@ -716,22 +895,22 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<List<_i2.SnapApp>>.value(<_i2.SnapApp>[]),
-      ) as _i11.Future<List<_i2.SnapApp>>);
+        returnValue: _i13.Future<List<_i2.SnapApp>>.value(<_i2.SnapApp>[]),
+      ) as _i13.Future<List<_i2.SnapApp>>);
 
   @override
-  _i11.Future<List<_i2.SnapdCategoryDetails>> getCategories() =>
+  _i13.Future<List<_i2.SnapdCategoryDetails>> getCategories() =>
       (super.noSuchMethod(
         Invocation.method(
           #getCategories,
           [],
         ),
-        returnValue: _i11.Future<List<_i2.SnapdCategoryDetails>>.value(
+        returnValue: _i13.Future<List<_i2.SnapdCategoryDetails>>.value(
             <_i2.SnapdCategoryDetails>[]),
-      ) as _i11.Future<List<_i2.SnapdCategoryDetails>>);
+      ) as _i13.Future<List<_i2.SnapdCategoryDetails>>);
 
   @override
-  _i11.Future<_i2.SnapdConnectionsResponse> getConnections({
+  _i13.Future<_i2.SnapdConnectionsResponse> getConnections({
     String? snap,
     String? interface,
     _i2.SnapdConnectionFilter? filter,
@@ -746,8 +925,8 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i2.SnapdConnectionsResponse>.value(
-            _FakeSnapdConnectionsResponse_7(
+        returnValue: _i13.Future<_i2.SnapdConnectionsResponse>.value(
+            _FakeSnapdConnectionsResponse_10(
           this,
           Invocation.method(
             #getConnections,
@@ -759,19 +938,19 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             },
           ),
         )),
-      ) as _i11.Future<_i2.SnapdConnectionsResponse>);
+      ) as _i13.Future<_i2.SnapdConnectionsResponse>);
 
   @override
-  _i11.Future<String> refreshMany(List<String>? names) => (super.noSuchMethod(
+  _i13.Future<String> refreshMany(List<String>? names) => (super.noSuchMethod(
         Invocation.method(
           #refreshMany,
           [names],
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<String> connect(
+  _i13.Future<String> connect(
     String? snap,
     String? plug,
     String? slotSnap,
@@ -787,11 +966,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             slot,
           ],
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<String> disconnect(
+  _i13.Future<String> disconnect(
     String? plugSnap,
     String? plug,
     String? slotSnap,
@@ -807,11 +986,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             slot,
           ],
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<List<_i2.Snap>> find({
+  _i13.Future<List<_i2.Snap>> find({
     String? query,
     String? name,
     String? category,
@@ -830,11 +1009,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
-      ) as _i11.Future<List<_i2.Snap>>);
+        returnValue: _i13.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
+      ) as _i13.Future<List<_i2.Snap>>);
 
   @override
-  _i11.Future<_i2.SnapdLoginResponse> login(
+  _i13.Future<_i2.SnapdLoginResponse> login(
     String? email,
     String? password, {
     String? otp,
@@ -848,8 +1027,8 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           ],
           {#otp: otp},
         ),
-        returnValue:
-            _i11.Future<_i2.SnapdLoginResponse>.value(_FakeSnapdLoginResponse_8(
+        returnValue: _i13.Future<_i2.SnapdLoginResponse>.value(
+            _FakeSnapdLoginResponse_11(
           this,
           Invocation.method(
             #login,
@@ -860,19 +1039,19 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             {#otp: otp},
           ),
         )),
-      ) as _i11.Future<_i2.SnapdLoginResponse>);
+      ) as _i13.Future<_i2.SnapdLoginResponse>);
 
   @override
-  _i11.Future<dynamic> logout(int? id) => (super.noSuchMethod(
+  _i13.Future<dynamic> logout(int? id) => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [id],
         ),
-        returnValue: _i11.Future<dynamic>.value(),
-      ) as _i11.Future<dynamic>);
+        returnValue: _i13.Future<dynamic>.value(),
+      ) as _i13.Future<dynamic>);
 
   @override
-  _i11.Future<String> install(
+  _i13.Future<String> install(
     String? name, {
     String? channel,
     String? revision,
@@ -894,11 +1073,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #jailmode: jailmode,
           },
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<String> refresh(
+  _i13.Future<String> refresh(
     String? name, {
     String? channel,
     bool? classic = false,
@@ -912,11 +1091,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #classic: classic,
           },
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<String> remove(
+  _i13.Future<String> remove(
     String? name, {
     bool? purge = false,
   }) =>
@@ -926,44 +1105,44 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           [name],
           {#purge: purge},
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<String> enable(String? name) => (super.noSuchMethod(
+  _i13.Future<String> enable(String? name) => (super.noSuchMethod(
         Invocation.method(
           #enable,
           [name],
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<String> disable(String? name) => (super.noSuchMethod(
+  _i13.Future<String> disable(String? name) => (super.noSuchMethod(
         Invocation.method(
           #disable,
           [name],
         ),
-        returnValue: _i11.Future<String>.value(''),
-      ) as _i11.Future<String>);
+        returnValue: _i13.Future<String>.value(''),
+      ) as _i13.Future<String>);
 
   @override
-  _i11.Future<_i2.SnapdChange> getChange(String? id) => (super.noSuchMethod(
+  _i13.Future<_i2.SnapdChange> getChange(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getChange,
           [id],
         ),
-        returnValue: _i11.Future<_i2.SnapdChange>.value(_FakeSnapdChange_9(
+        returnValue: _i13.Future<_i2.SnapdChange>.value(_FakeSnapdChange_12(
           this,
           Invocation.method(
             #getChange,
             [id],
           ),
         )),
-      ) as _i11.Future<_i2.SnapdChange>);
+      ) as _i13.Future<_i2.SnapdChange>);
 
   @override
-  _i11.Future<List<_i2.SnapdChange>> getChanges({
+  _i13.Future<List<_i2.SnapdChange>> getChanges({
     _i2.SnapdChangeFilter? filter,
     String? name,
   }) =>
@@ -977,23 +1156,23 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           },
         ),
         returnValue:
-            _i11.Future<List<_i2.SnapdChange>>.value(<_i2.SnapdChange>[]),
-      ) as _i11.Future<List<_i2.SnapdChange>>);
+            _i13.Future<List<_i2.SnapdChange>>.value(<_i2.SnapdChange>[]),
+      ) as _i13.Future<List<_i2.SnapdChange>>);
 
   @override
-  _i11.Future<_i2.SnapdChange> abortChange(String? id) => (super.noSuchMethod(
+  _i13.Future<_i2.SnapdChange> abortChange(String? id) => (super.noSuchMethod(
         Invocation.method(
           #abortChange,
           [id],
         ),
-        returnValue: _i11.Future<_i2.SnapdChange>.value(_FakeSnapdChange_9(
+        returnValue: _i13.Future<_i2.SnapdChange>.value(_FakeSnapdChange_12(
           this,
           Invocation.method(
             #abortChange,
             [id],
           ),
         )),
-      ) as _i11.Future<_i2.SnapdChange>);
+      ) as _i13.Future<_i2.SnapdChange>);
 
   @override
   void close() => super.noSuchMethod(
@@ -1005,10 +1184,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
       );
 
   @override
-  _i11.Stream<List<_i2.Snap>> getCategory(
+  _i13.Stream<List<_i2.Snap>> getCategory(
     String? name, {
     Duration? expiry = const Duration(days: 1),
-    _i14.FileSystem? fs,
+    _i17.FileSystem? fs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1019,14 +1198,14 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #fs: fs,
           },
         ),
-        returnValue: _i11.Stream<List<_i2.Snap>>.empty(),
-      ) as _i11.Stream<List<_i2.Snap>>);
+        returnValue: _i13.Stream<List<_i2.Snap>>.empty(),
+      ) as _i13.Stream<List<_i2.Snap>>);
 
   @override
-  _i11.Stream<_i2.Snap?> getStoreSnap(
+  _i13.Stream<_i2.Snap?> getStoreSnap(
     String? name, {
     Duration? expiry = const Duration(minutes: 1),
-    _i14.FileSystem? fs,
+    _i17.FileSystem? fs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1037,14 +1216,14 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #fs: fs,
           },
         ),
-        returnValue: _i11.Stream<_i2.Snap?>.empty(),
-      ) as _i11.Stream<_i2.Snap?>);
+        returnValue: _i13.Stream<_i2.Snap?>.empty(),
+      ) as _i13.Stream<_i2.Snap?>);
 
   @override
-  _i11.Stream<List<_i2.Snap>> getStoreSnaps(
+  _i13.Stream<List<_i2.Snap>> getStoreSnaps(
     List<String>? names, {
     Duration? expiry = const Duration(minutes: 1),
-    _i14.FileSystem? fs,
+    _i17.FileSystem? fs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1055,11 +1234,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #fs: fs,
           },
         ),
-        returnValue: _i11.Stream<List<_i2.Snap>>.empty(),
-      ) as _i11.Stream<List<_i2.Snap>>);
+        returnValue: _i13.Stream<List<_i2.Snap>>.empty(),
+      ) as _i13.Stream<List<_i2.Snap>>);
 
   @override
-  _i11.Stream<_i2.SnapdChange> watchChange(
+  _i13.Stream<_i2.SnapdChange> watchChange(
     String? id, {
     Duration? interval = const Duration(milliseconds: 100),
   }) =>
@@ -1069,11 +1248,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           [id],
           {#interval: interval},
         ),
-        returnValue: _i11.Stream<_i2.SnapdChange>.empty(),
-      ) as _i11.Stream<_i2.SnapdChange>);
+        returnValue: _i13.Stream<_i2.SnapdChange>.empty(),
+      ) as _i13.Stream<_i2.SnapdChange>);
 
   @override
-  _i11.Stream<List<String>> watchChanges({
+  _i13.Stream<List<String>> watchChanges({
     String? name,
     Duration? interval = const Duration(milliseconds: 100),
   }) =>
@@ -1086,8 +1265,8 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #interval: interval,
           },
         ),
-        returnValue: _i11.Stream<List<String>>.empty(),
-      ) as _i11.Stream<List<String>>);
+        returnValue: _i13.Stream<List<String>>.empty(),
+      ) as _i13.Stream<List<String>>);
 }
 
 /// A class which mocks [UpdatesModel].
@@ -1123,10 +1302,10 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       ) as _i5.AsyncValue<void>);
 
   @override
-  _i11.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
+  _i13.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i11.Stream<_i2.SnapdException>.empty(),
-      ) as _i11.Stream<_i2.SnapdException>);
+        returnValue: _i13.Stream<_i2.SnapdException>.empty(),
+      ) as _i13.Stream<_i2.SnapdException>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -1135,14 +1314,14 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       ) as bool);
 
   @override
-  _i11.Future<void> refresh() => (super.noSuchMethod(
+  _i13.Future<void> refresh() => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool hasUpdate(String? snapName) => (super.noSuchMethod(
@@ -1154,17 +1333,17 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       ) as bool);
 
   @override
-  _i11.Future<void> updateAll() => (super.noSuchMethod(
+  _i13.Future<void> updateAll() => (super.noSuchMethod(
         Invocation.method(
           #updateAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1173,7 +1352,7 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       );
 
   @override
-  void removeListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1204,13 +1383,13 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGtkApplicationNotifier extends _i1.Mock
-    implements _i15.GtkApplicationNotifier {
+    implements _i18.GtkApplicationNotifier {
   MockGtkApplicationNotifier() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void addCommandLineListener(_i15.GtkCommandLineListener? listener) =>
+  void addCommandLineListener(_i18.GtkCommandLineListener? listener) =>
       super.noSuchMethod(
         Invocation.method(
           #addCommandLineListener,
@@ -1220,7 +1399,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
       );
 
   @override
-  void removeCommandLineListener(_i15.GtkCommandLineListener? listener) =>
+  void removeCommandLineListener(_i18.GtkCommandLineListener? listener) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCommandLineListener,
@@ -1230,7 +1409,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
       );
 
   @override
-  void addOpenListener(_i15.GtkOpenListener? listener) => super.noSuchMethod(
+  void addOpenListener(_i18.GtkOpenListener? listener) => super.noSuchMethod(
         Invocation.method(
           #addOpenListener,
           [listener],
@@ -1239,7 +1418,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
       );
 
   @override
-  void removeOpenListener(_i15.GtkOpenListener? listener) => super.noSuchMethod(
+  void removeOpenListener(_i18.GtkOpenListener? listener) => super.noSuchMethod(
         Invocation.method(
           #removeOpenListener,
           [listener],
@@ -1286,7 +1465,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
 /// A class which mocks [PackageKitClient].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPackageKitClient extends _i1.Mock implements _i7.PackageKitClient {
+class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
   MockPackageKitClient() {
     _i1.throwOnMissingStub(this);
   }
@@ -1385,16 +1564,16 @@ class MockPackageKitClient extends _i1.Mock implements _i7.PackageKitClient {
       ) as String);
 
   @override
-  Set<_i7.PackageKitFilter> get filters => (super.noSuchMethod(
+  Set<_i10.PackageKitFilter> get filters => (super.noSuchMethod(
         Invocation.getter(#filters),
-        returnValue: <_i7.PackageKitFilter>{},
-      ) as Set<_i7.PackageKitFilter>);
+        returnValue: <_i10.PackageKitFilter>{},
+      ) as Set<_i10.PackageKitFilter>);
 
   @override
-  Set<_i7.PackageKitGroup> get groups => (super.noSuchMethod(
+  Set<_i10.PackageKitGroup> get groups => (super.noSuchMethod(
         Invocation.getter(#groups),
-        returnValue: <_i7.PackageKitGroup>{},
-      ) as Set<_i7.PackageKitGroup>);
+        returnValue: <_i10.PackageKitGroup>{},
+      ) as Set<_i10.PackageKitGroup>);
 
   @override
   bool get locked => (super.noSuchMethod(
@@ -1409,16 +1588,16 @@ class MockPackageKitClient extends _i1.Mock implements _i7.PackageKitClient {
       ) as List<String>);
 
   @override
-  Set<_i7.PackageKitRole> get roles => (super.noSuchMethod(
+  Set<_i10.PackageKitRole> get roles => (super.noSuchMethod(
         Invocation.getter(#roles),
-        returnValue: <_i7.PackageKitRole>{},
-      ) as Set<_i7.PackageKitRole>);
+        returnValue: <_i10.PackageKitRole>{},
+      ) as Set<_i10.PackageKitRole>);
 
   @override
-  _i7.PackageKitNetworkState get networkState => (super.noSuchMethod(
+  _i10.PackageKitNetworkState get networkState => (super.noSuchMethod(
         Invocation.getter(#networkState),
-        returnValue: _i7.PackageKitNetworkState.unknown,
-      ) as _i7.PackageKitNetworkState);
+        returnValue: _i10.PackageKitNetworkState.unknown,
+      ) as _i10.PackageKitNetworkState);
 
   @override
   int get versionMajor => (super.noSuchMethod(
@@ -1439,84 +1618,84 @@ class MockPackageKitClient extends _i1.Mock implements _i7.PackageKitClient {
       ) as int);
 
   @override
-  _i11.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+  _i13.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
         Invocation.getter(#propertiesChanged),
-        returnValue: _i11.Stream<List<String>>.empty(),
-      ) as _i11.Stream<List<String>>);
+        returnValue: _i13.Stream<List<String>>.empty(),
+      ) as _i13.Stream<List<String>>);
 
   @override
-  _i11.Future<void> connect() => (super.noSuchMethod(
+  _i13.Future<void> connect() => (super.noSuchMethod(
         Invocation.method(
           #connect,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<_i7.PackageKitTransaction> getTransaction(
-          _i16.DBusObjectPath? path) =>
+  _i13.Future<_i10.PackageKitTransaction> getTransaction(
+          _i19.DBusObjectPath? path) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTransaction,
           [path],
         ),
-        returnValue: _i11.Future<_i7.PackageKitTransaction>.value(
-            _FakePackageKitTransaction_10(
+        returnValue: _i13.Future<_i10.PackageKitTransaction>.value(
+            _FakePackageKitTransaction_13(
           this,
           Invocation.method(
             #getTransaction,
             [path],
           ),
         )),
-      ) as _i11.Future<_i7.PackageKitTransaction>);
+      ) as _i13.Future<_i10.PackageKitTransaction>);
 
   @override
-  _i11.Future<_i7.PackageKitTransaction> createTransaction() =>
+  _i13.Future<_i10.PackageKitTransaction> createTransaction() =>
       (super.noSuchMethod(
         Invocation.method(
           #createTransaction,
           [],
         ),
-        returnValue: _i11.Future<_i7.PackageKitTransaction>.value(
-            _FakePackageKitTransaction_10(
+        returnValue: _i13.Future<_i10.PackageKitTransaction>.value(
+            _FakePackageKitTransaction_13(
           this,
           Invocation.method(
             #createTransaction,
             [],
           ),
         )),
-      ) as _i11.Future<_i7.PackageKitTransaction>);
+      ) as _i13.Future<_i10.PackageKitTransaction>);
 
   @override
-  _i11.Future<void> close() => (super.noSuchMethod(
+  _i13.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }
 
 /// A class which mocks [PackageKitTransaction].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPackageKitTransaction extends _i1.Mock
-    implements _i7.PackageKitTransaction {
+    implements _i10.PackageKitTransaction {
   MockPackageKitTransaction() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i11.Stream<_i7.PackageKitEvent> get events => (super.noSuchMethod(
+  _i13.Stream<_i10.PackageKitEvent> get events => (super.noSuchMethod(
         Invocation.getter(#events),
-        returnValue: _i11.Stream<_i7.PackageKitEvent>.empty(),
-      ) as _i11.Stream<_i7.PackageKitEvent>);
+        returnValue: _i13.Stream<_i10.PackageKitEvent>.empty(),
+      ) as _i13.Stream<_i10.PackageKitEvent>);
 
   @override
-  set events(_i11.Stream<_i7.PackageKitEvent>? _events) => super.noSuchMethod(
+  set events(_i13.Stream<_i10.PackageKitEvent>? _events) => super.noSuchMethod(
         Invocation.setter(
           #events,
           _events,
@@ -1525,16 +1704,16 @@ class MockPackageKitTransaction extends _i1.Mock
       );
 
   @override
-  _i7.PackageKitRole get role => (super.noSuchMethod(
+  _i10.PackageKitRole get role => (super.noSuchMethod(
         Invocation.getter(#role),
-        returnValue: _i7.PackageKitRole.unknown,
-      ) as _i7.PackageKitRole);
+        returnValue: _i10.PackageKitRole.unknown,
+      ) as _i10.PackageKitRole);
 
   @override
-  _i7.PackageKitStatus get status => (super.noSuchMethod(
+  _i10.PackageKitStatus get status => (super.noSuchMethod(
         Invocation.getter(#status),
-        returnValue: _i7.PackageKitStatus.unknown,
-      ) as _i7.PackageKitStatus);
+        returnValue: _i10.PackageKitStatus.unknown,
+      ) as _i10.PackageKitStatus);
 
   @override
   String get lastPackage => (super.noSuchMethod(
@@ -1591,32 +1770,32 @@ class MockPackageKitTransaction extends _i1.Mock
       ) as int);
 
   @override
-  Set<_i7.PackageKitTransactionFlag> get transactionFlags =>
+  Set<_i10.PackageKitTransactionFlag> get transactionFlags =>
       (super.noSuchMethod(
         Invocation.getter(#transactionFlags),
-        returnValue: <_i7.PackageKitTransactionFlag>{},
-      ) as Set<_i7.PackageKitTransactionFlag>);
+        returnValue: <_i10.PackageKitTransactionFlag>{},
+      ) as Set<_i10.PackageKitTransactionFlag>);
 
   @override
-  _i11.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+  _i13.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
         Invocation.getter(#propertiesChanged),
-        returnValue: _i11.Stream<List<String>>.empty(),
-      ) as _i11.Stream<List<String>>);
+        returnValue: _i13.Stream<List<String>>.empty(),
+      ) as _i13.Stream<List<String>>);
 
   @override
-  _i11.Future<void> cancel() => (super.noSuchMethod(
+  _i13.Future<void> cancel() => (super.noSuchMethod(
         Invocation.method(
           #cancel,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> dependsOn(
-    Iterable<_i7.PackageKitPackageId>? packageIds, {
-    Set<_i7.PackageKitFilter>? filter = const {},
+  _i13.Future<void> dependsOn(
+    Iterable<_i10.PackageKitPackageId>? packageIds, {
+    Set<_i10.PackageKitFilter>? filter = const {},
     bool? recursive = false,
   }) =>
       (super.noSuchMethod(
@@ -1628,35 +1807,36 @@ class MockPackageKitTransaction extends _i1.Mock
             #recursive: recursive,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getDetails(Iterable<_i7.PackageKitPackageId>? packageIds) =>
+  _i13.Future<void> getDetails(
+          Iterable<_i10.PackageKitPackageId>? packageIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDetails,
           [packageIds],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getDetailsLocal(Iterable<String>? paths) =>
+  _i13.Future<void> getDetailsLocal(Iterable<String>? paths) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDetailsLocal,
           [paths],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> downloadPackages(
-    Iterable<_i7.PackageKitPackageId>? packageIds, {
+  _i13.Future<void> downloadPackages(
+    Iterable<_i10.PackageKitPackageId>? packageIds, {
     bool? storeInCache = false,
   }) =>
       (super.noSuchMethod(
@@ -1665,60 +1845,60 @@ class MockPackageKitTransaction extends _i1.Mock
           [packageIds],
           {#storeInCache: storeInCache},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getFiles(Iterable<_i7.PackageKitPackageId>? packageIds) =>
+  _i13.Future<void> getFiles(Iterable<_i10.PackageKitPackageId>? packageIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #getFiles,
           [packageIds],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getFilesLocal(Iterable<String>? paths) =>
+  _i13.Future<void> getFilesLocal(Iterable<String>? paths) =>
       (super.noSuchMethod(
         Invocation.method(
           #getFilesLocal,
           [paths],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getPackages(
-          {Set<_i7.PackageKitFilter>? filter = const {}}) =>
+  _i13.Future<void> getPackages(
+          {Set<_i10.PackageKitFilter>? filter = const {}}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPackages,
           [],
           {#filter: filter},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getRepositoryList(
-          {Set<_i7.PackageKitFilter>? filter = const {}}) =>
+  _i13.Future<void> getRepositoryList(
+          {Set<_i10.PackageKitFilter>? filter = const {}}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRepositoryList,
           [],
           {#filter: filter},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> setRepositoryEnabled(
+  _i13.Future<void> setRepositoryEnabled(
     String? id,
     bool? enabled,
   ) =>
@@ -1730,12 +1910,12 @@ class MockPackageKitTransaction extends _i1.Mock
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> setRepositoryData(
+  _i13.Future<void> setRepositoryData(
     String? id,
     String? parameter,
     String? value,
@@ -1749,12 +1929,12 @@ class MockPackageKitTransaction extends _i1.Mock
             value,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> removeRepository(
+  _i13.Future<void> removeRepository(
     String? id, {
     bool? autoremovePackages = false,
   }) =>
@@ -1764,39 +1944,39 @@ class MockPackageKitTransaction extends _i1.Mock
           [id],
           {#autoremovePackages: autoremovePackages},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getUpdateDetail(
-          Iterable<_i7.PackageKitPackageId>? packageIds) =>
+  _i13.Future<void> getUpdateDetail(
+          Iterable<_i10.PackageKitPackageId>? packageIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUpdateDetail,
           [packageIds],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> getUpdates(
-          {Set<_i7.PackageKitFilter>? filter = const {}}) =>
+  _i13.Future<void> getUpdates(
+          {Set<_i10.PackageKitFilter>? filter = const {}}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUpdates,
           [],
           {#filter: filter},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> installFiles(
+  _i13.Future<void> installFiles(
     Iterable<String>? paths, {
-    Set<_i7.PackageKitTransactionFlag>? transactionFlags = const {},
+    Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1804,14 +1984,14 @@ class MockPackageKitTransaction extends _i1.Mock
           [paths],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> installPackages(
-    Iterable<_i7.PackageKitPackageId>? packageIds, {
-    Set<_i7.PackageKitTransactionFlag>? transactionFlags = const {},
+  _i13.Future<void> installPackages(
+    Iterable<_i10.PackageKitPackageId>? packageIds, {
+    Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1819,25 +1999,25 @@ class MockPackageKitTransaction extends _i1.Mock
           [packageIds],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> refreshCache({bool? force = false}) => (super.noSuchMethod(
+  _i13.Future<void> refreshCache({bool? force = false}) => (super.noSuchMethod(
         Invocation.method(
           #refreshCache,
           [],
           {#force: force},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> removePackages(
-    Iterable<_i7.PackageKitPackageId>? packageIds, {
-    Set<_i7.PackageKitTransactionFlag>? transactionFlags = const {},
+  _i13.Future<void> removePackages(
+    Iterable<_i10.PackageKitPackageId>? packageIds, {
+    Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
     bool? allowDeps = false,
     bool? autoremove = false,
   }) =>
@@ -1851,14 +2031,14 @@ class MockPackageKitTransaction extends _i1.Mock
             #autoremove: autoremove,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> resolve(
+  _i13.Future<void> resolve(
     Iterable<String>? packages, {
-    Set<_i7.PackageKitTransactionFlag>? transactionFlags = const {},
+    Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1866,14 +2046,14 @@ class MockPackageKitTransaction extends _i1.Mock
           [packages],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> searchFiles(
+  _i13.Future<void> searchFiles(
     Iterable<String>? values, {
-    Set<_i7.PackageKitFilter>? filter = const {},
+    Set<_i10.PackageKitFilter>? filter = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1881,14 +2061,14 @@ class MockPackageKitTransaction extends _i1.Mock
           [values],
           {#filter: filter},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> searchNames(
+  _i13.Future<void> searchNames(
     Iterable<String>? values, {
-    Set<_i7.PackageKitFilter>? filter = const {},
+    Set<_i10.PackageKitFilter>? filter = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1896,14 +2076,14 @@ class MockPackageKitTransaction extends _i1.Mock
           [values],
           {#filter: filter},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> updatePackages(
-    Iterable<_i7.PackageKitPackageId>? packageIds, {
-    Set<_i7.PackageKitTransactionFlag>? transactionFlags = const {},
+  _i13.Future<void> updatePackages(
+    Iterable<_i10.PackageKitPackageId>? packageIds, {
+    Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1911,15 +2091,15 @@ class MockPackageKitTransaction extends _i1.Mock
           [packageIds],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> upgradeSystem(
+  _i13.Future<void> upgradeSystem(
     String? distroId,
-    _i7.PackageKitDistroUpgrade? upgradeKind, {
-    Set<_i7.PackageKitTransactionFlag>? transactionFlags = const {},
+    _i10.PackageKitDistroUpgrade? upgradeKind, {
+    Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1930,9 +2110,9 @@ class MockPackageKitTransaction extends _i1.Mock
           ],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }
 
 /// A class which mocks [RatingsService].
@@ -1944,59 +2124,59 @@ class MockRatingsService extends _i1.Mock implements _i4.RatingsService {
   }
 
   @override
-  _i11.Future<_i10.Rating?> getRating(String? snapId) => (super.noSuchMethod(
+  _i13.Future<_i12.Rating?> getRating(String? snapId) => (super.noSuchMethod(
         Invocation.method(
           #getRating,
           [snapId],
         ),
-        returnValue: _i11.Future<_i10.Rating?>.value(),
-      ) as _i11.Future<_i10.Rating?>);
+        returnValue: _i13.Future<_i12.Rating?>.value(),
+      ) as _i13.Future<_i12.Rating?>);
 
   @override
-  _i11.Future<void> vote(_i10.Vote? vote) => (super.noSuchMethod(
+  _i13.Future<void> vote(_i12.Vote? vote) => (super.noSuchMethod(
         Invocation.method(
           #vote,
           [vote],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> delete() => (super.noSuchMethod(
+  _i13.Future<void> delete() => (super.noSuchMethod(
         Invocation.method(
           #delete,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<List<_i10.Vote>> listMyVotes(String? snapFilter) =>
+  _i13.Future<List<_i12.Vote>> listMyVotes(String? snapFilter) =>
       (super.noSuchMethod(
         Invocation.method(
           #listMyVotes,
           [snapFilter],
         ),
-        returnValue: _i11.Future<List<_i10.Vote>>.value(<_i10.Vote>[]),
-      ) as _i11.Future<List<_i10.Vote>>);
+        returnValue: _i13.Future<List<_i12.Vote>>.value(<_i12.Vote>[]),
+      ) as _i13.Future<List<_i12.Vote>>);
 
   @override
-  _i11.Future<List<_i10.Vote>> getSnapVotes(String? snapId) =>
+  _i13.Future<List<_i12.Vote>> getSnapVotes(String? snapId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getSnapVotes,
           [snapId],
         ),
-        returnValue: _i11.Future<List<_i10.Vote>>.value(<_i10.Vote>[]),
-      ) as _i11.Future<List<_i10.Vote>>);
+        returnValue: _i13.Future<List<_i12.Vote>>.value(<_i12.Vote>[]),
+      ) as _i13.Future<List<_i12.Vote>>);
 }
 
 /// A class which mocks [AppstreamService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppstreamService extends _i1.Mock implements _i17.AppstreamService {
+class MockAppstreamService extends _i1.Mock implements _i7.AppstreamService {
   MockAppstreamService() {
     _i1.throwOnMissingStub(this);
   }
@@ -2014,46 +2194,46 @@ class MockAppstreamService extends _i1.Mock implements _i17.AppstreamService {
       ) as int);
 
   @override
-  _i11.Future<void> init() => (super.noSuchMethod(
+  _i13.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<List<_i8.AppstreamComponent>> search(String? search) =>
+  _i13.Future<List<_i9.AppstreamComponent>> search(String? search) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [search],
         ),
-        returnValue: _i11.Future<List<_i8.AppstreamComponent>>.value(
-            <_i8.AppstreamComponent>[]),
-      ) as _i11.Future<List<_i8.AppstreamComponent>>);
+        returnValue: _i13.Future<List<_i9.AppstreamComponent>>.value(
+            <_i9.AppstreamComponent>[]),
+      ) as _i13.Future<List<_i9.AppstreamComponent>>);
 
   @override
-  _i8.AppstreamComponent getFromId(String? id) => (super.noSuchMethod(
+  _i9.AppstreamComponent getFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getFromId,
           [id],
         ),
-        returnValue: _FakeAppstreamComponent_11(
+        returnValue: _FakeAppstreamComponent_7(
           this,
           Invocation.method(
             #getFromId,
             [id],
           ),
         ),
-      ) as _i8.AppstreamComponent);
+      ) as _i9.AppstreamComponent);
 }
 
 /// A class which mocks [PackageKitService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPackageKitService extends _i1.Mock implements _i18.PackageKitService {
+class MockPackageKitService extends _i1.Mock implements _i8.PackageKitService {
   MockPackageKitService() {
     _i1.throwOnMissingStub(this);
   }
@@ -2065,86 +2245,86 @@ class MockPackageKitService extends _i1.Mock implements _i18.PackageKitService {
       ) as bool);
 
   @override
-  _i11.Stream<_i7.PackageKitErrorCodeEvent> get errorStream =>
+  _i13.Stream<_i10.PackageKitErrorCodeEvent> get errorStream =>
       (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i11.Stream<_i7.PackageKitErrorCodeEvent>.empty(),
-      ) as _i11.Stream<_i7.PackageKitErrorCodeEvent>);
+        returnValue: _i13.Stream<_i10.PackageKitErrorCodeEvent>.empty(),
+      ) as _i13.Stream<_i10.PackageKitErrorCodeEvent>);
 
   @override
-  _i7.PackageKitTransaction? getTransaction(int? id) =>
+  _i10.PackageKitTransaction? getTransaction(int? id) =>
       (super.noSuchMethod(Invocation.method(
         #getTransaction,
         [id],
-      )) as _i7.PackageKitTransaction?);
+      )) as _i10.PackageKitTransaction?);
 
   @override
-  _i11.Future<void> activateService() => (super.noSuchMethod(
+  _i13.Future<void> activateService() => (super.noSuchMethod(
         Invocation.method(
           #activateService,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> waitTransaction(int? id) => (super.noSuchMethod(
+  _i13.Future<void> waitTransaction(int? id) => (super.noSuchMethod(
         Invocation.method(
           #waitTransaction,
           [id],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<void> cancelTransaction(int? id) => (super.noSuchMethod(
+  _i13.Future<void> cancelTransaction(int? id) => (super.noSuchMethod(
         Invocation.method(
           #cancelTransaction,
           [id],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i11.Future<int> install(_i7.PackageKitPackageId? packageId) =>
+  _i13.Future<int> install(_i10.PackageKitPackageId? packageId) =>
       (super.noSuchMethod(
         Invocation.method(
           #install,
           [packageId],
         ),
-        returnValue: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i11.Future<int> remove(_i7.PackageKitPackageId? packageId) =>
+  _i13.Future<int> remove(_i10.PackageKitPackageId? packageId) =>
       (super.noSuchMethod(
         Invocation.method(
           #remove,
           [packageId],
         ),
-        returnValue: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i11.Future<_i7.PackageKitPackageEvent?> resolve(String? name) =>
+  _i13.Future<_i10.PackageKitPackageEvent?> resolve(String? name) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolve,
           [name],
         ),
-        returnValue: _i11.Future<_i7.PackageKitPackageEvent?>.value(),
-      ) as _i11.Future<_i7.PackageKitPackageEvent?>);
+        returnValue: _i13.Future<_i10.PackageKitPackageEvent?>.value(),
+      ) as _i13.Future<_i10.PackageKitPackageEvent?>);
 
   @override
-  _i11.Future<void> dispose() => (super.noSuchMethod(
+  _i13.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -2065,6 +2065,13 @@ class MockPackageKitService extends _i1.Mock implements _i18.PackageKitService {
       ) as bool);
 
   @override
+  _i11.Stream<_i7.PackageKitErrorCodeEvent> get errorStream =>
+      (super.noSuchMethod(
+        Invocation.getter(#errorStream),
+        returnValue: _i11.Stream<_i7.PackageKitErrorCodeEvent>.empty(),
+      ) as _i11.Stream<_i7.PackageKitErrorCodeEvent>);
+
+  @override
   _i7.PackageKitTransaction? getTransaction(int? id) =>
       (super.noSuchMethod(Invocation.method(
         #getTransaction,


### PR DESCRIPTION
UDENG-1365
Fixes #1368

![Screenshot from 2023-09-27 15-30-44](https://github.com/ubuntu/app-center/assets/113362648/4157781e-eb64-49aa-ab25-a45cdd36bd73)

To keep things simple, I implemented the `errorStream` already in the service layer instead of throwing custom exceptions from there.