### PR TITLE
fix(updates_model): handle error on refresh

### DIFF
--- a/lib/src/snapd/updates_model.dart
+++ b/lib/src/snapd/updates_model.dart
@@ -40,8 +40,12 @@ class UpdatesModel extends ChangeNotifier {
     _state = const AsyncValue.loading();
     notifyListeners();
     _state = await AsyncValue.guard(() async {
-      _refreshableSnaps = await snapd.find(filter: SnapFindFilter.refresh);
-      notifyListeners();
+      try {
+        _refreshableSnaps = await snapd.find(filter: SnapFindFilter.refresh);
+        notifyListeners();
+      } on SnapdException catch (e) {
+        _handleError(e);
+      }
     });
   }
 


### PR DESCRIPTION
Turns out the `refresh()` method wasn't handling snapd errors.
There will be an error dialog instead of an empty button now, in case snapd can't get the list of pending updates.

Fix #1429