### PR TITLE
fix(packagekit): check arch compatibility in resolve

### DIFF
--- a/test/packagekit_service_test.dart
+++ b/test/packagekit_service_test.dart
@@ -108,7 +108,11 @@ void main() {
     test('unique package', () async {
       const mockInfo = PackageKitPackageEvent(
         info: PackageKitInfo.available,
-        packageId: PackageKitPackageId(name: 'foo', version: '1.0'),
+        packageId: PackageKitPackageId(
+          name: 'foo',
+          version: '1.0',
+          arch: 'amd64',
+        ),
         summary: 'summary',
       );
       final mockTransaction = createMockPackageKitTransaction(
@@ -119,7 +123,7 @@ void main() {
       final packageKit =
           PackageKitService(dbus: createMockDbusClient(), client: mockClient);
       await packageKit.activateService();
-      final info = await packageKit.resolve('foo');
+      final info = await packageKit.resolve('foo', 'amd64');
       verify(mockTransaction.resolve(['foo'])).called(1);
       expect(info, equals(mockInfo));
     });
@@ -152,7 +156,7 @@ void main() {
       final packageKit =
           PackageKitService(dbus: createMockDbusClient(), client: mockClient);
       await packageKit.activateService();
-      final info = await packageKit.resolve('foo');
+      final info = await packageKit.resolve('foo', 'amd64');
       expect(info!.packageId.arch, equals('amd64'));
     });
   });

--- a/test/packagekit_service_test.dart
+++ b/test/packagekit_service_test.dart
@@ -104,22 +104,57 @@ void main() {
     expect(packageKit.getTransaction(id), isNull);
   });
 
-  test('resolve', () async {
-    const mockInfo = PackageKitPackageEvent(
-      info: PackageKitInfo.available,
-      packageId: PackageKitPackageId(name: 'foo', version: '1.0'),
-      summary: 'summary',
-    );
-    final mockTransaction = createMockPackageKitTransaction(
-      events: [mockInfo],
-    );
-    final mockClient = createMockPackageKitClient(transaction: mockTransaction);
-    final packageKit =
-        PackageKitService(dbus: createMockDbusClient(), client: mockClient);
-    await packageKit.activateService();
-    final info = await packageKit.resolve('foo');
-    verify(mockTransaction.resolve(['foo'])).called(1);
-    expect(info, equals(mockInfo));
+  group('resolve', () {
+    test('unique package', () async {
+      const mockInfo = PackageKitPackageEvent(
+        info: PackageKitInfo.available,
+        packageId: PackageKitPackageId(name: 'foo', version: '1.0'),
+        summary: 'summary',
+      );
+      final mockTransaction = createMockPackageKitTransaction(
+        events: [mockInfo],
+      );
+      final mockClient =
+          createMockPackageKitClient(transaction: mockTransaction);
+      final packageKit =
+          PackageKitService(dbus: createMockDbusClient(), client: mockClient);
+      await packageKit.activateService();
+      final info = await packageKit.resolve('foo');
+      verify(mockTransaction.resolve(['foo'])).called(1);
+      expect(info, equals(mockInfo));
+    });
+
+    test('multiple architectures', () async {
+      final mockTransaction = createMockPackageKitTransaction(
+        events: const [
+          PackageKitPackageEvent(
+            info: PackageKitInfo.available,
+            packageId: PackageKitPackageId(
+              name: 'foo',
+              version: '1.0',
+              arch: 'amd64',
+            ),
+            summary: 'summary',
+          ),
+          PackageKitPackageEvent(
+            info: PackageKitInfo.available,
+            packageId: PackageKitPackageId(
+              name: 'foo',
+              version: '1.0',
+              arch: 'i386',
+            ),
+            summary: 'summary',
+          )
+        ],
+      );
+      final mockClient =
+          createMockPackageKitClient(transaction: mockTransaction);
+      final packageKit =
+          PackageKitService(dbus: createMockDbusClient(), client: mockClient);
+      await packageKit.activateService();
+      final info = await packageKit.resolve('foo');
+      expect(info!.packageId.arch, equals('amd64'));
+    });
   });
 
   test('cancel', () async {

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -2446,11 +2446,17 @@ class MockPackageKitService extends _i1.Mock implements _i8.PackageKitService {
       ) as _i14.Future<int>);
 
   @override
-  _i14.Future<_i10.PackageKitPackageEvent?> resolve(String? name) =>
+  _i14.Future<_i10.PackageKitPackageEvent?> resolve(
+    String? name, [
+    String? architecture,
+  ]) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolve,
-          [name],
+          [
+            name,
+            architecture,
+          ],
         ),
         returnValue: _i14.Future<_i10.PackageKitPackageEvent?>.value(),
       ) as _i14.Future<_i10.PackageKitPackageEvent?>);


### PR DESCRIPTION
Fix #1485
- reads the local architecture from the snap environment (or from the output of `dpkg --print-architecture`)
- makes sure `resolve()` only returns packages with matching architecture

Adding proper support for foreign architectures requires a bit more care and some UI/UX input - I'd leave that as a separate issue.