### PR TITLE
chore: swapping to org owned repo

### DIFF
--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   dbus: ^0.7.10
   app_center_ratings_client:
     git:
-      url: https://github.com/matthew-hagemann/app_center_ratings_client.dart.git
+      url: https://github.com/canonical/app_center_ratings_client.dart.git
       ref: main
   crypto: ^3.0.3
   file: ^6.1.4


### PR DESCRIPTION
I've transferred ownership of the ratings client code to the org. This just swaps it from pointing at my fork to the org's copy. We still need to get this up into the pm at some point. 

https://github.com/canonical/app_center_ratings_client.dart