### PR TITLE
fix: ErrorWidget breaking the about page UI.

### DIFF
--- a/packages/app_center/lib/src/about/about_page.dart
+++ b/packages/app_center/lib/src/about/about_page.dart
@@ -121,7 +121,7 @@ class _ContributorView extends ConsumerWidget {
         const SizedBox(height: 8),
         state.when(
           data: (contributors) => _ContributorWrap(contributors),
-          error: (error, stackTrace) => ErrorWidget(error),
+          error: (error, stackTrace) => Text(error.toString()),
           loading: () => Shimmer.fromColors(
             baseColor: light ? kShimmerBaseLight : kShimmerBaseDark,
             highlightColor:


### PR DESCRIPTION
In this PR:

- Refactor an `ErrorWidget` to a `Text` widget when the app-center can't communicate with Github; the `ErrorWidget` was breaking the UIs with no possibility to see the rest of the content after the contributors.

fix #1506 

Before:
![Screenshot from 2023-11-28 11-41-52](https://github.com/ubuntu/app-center/assets/20175372/a00d9fc7-7c4d-4211-8e88-7eb328db8a4c)

After:
![Screenshot from 2023-11-28 11-41-40](https://github.com/ubuntu/app-center/assets/20175372/fe701a61-cc57-418e-99b9-dc0c5a94338d)