### PR TITLE
fix: plural spelling issue for l10n

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -32,7 +32,7 @@
     "managePageShowDetailsLabel": "Show details",
     "managePageShowSystemSnapsLabel": "Show system snaps",
     "managePageUpdateAllLabel": "Update all",
-    "managePageUpdatedDaysAgo": "Updated {n} days ago",
+    "managePageUpdatedDaysAgo": "Updated {n, plural, =0{{n} day} =1{{n} day} other{{n} days}} ago",
     "@managePageUpdatedDaysAgo": {
         "placeholders": {
             "n": {

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -32,7 +32,7 @@
     "managePageShowDetailsLabel": "Show details",
     "managePageShowSystemSnapsLabel": "Show system snaps",
     "managePageUpdateAllLabel": "Update all",
-    "managePageUpdatedDaysAgo": "Updated {n, plural, =0{{n} day} =1{{n} day} other{{n} days}} ago",
+    "managePageUpdatedDaysAgo": "Updated {n, plural, =1{{n} day} other{{n} days}} ago",
     "@managePageUpdatedDaysAgo": {
         "placeholders": {
             "n": {


### PR DESCRIPTION
In this PR:

- Adding plural for l10n.

fix #1451 

Ex:
Now:
![Screenshot from 2023-11-29 10-43-57](https://github.com/ubuntu/app-center/assets/20175372/8fd3c7c1-713b-4259-b982-626b34d23606)
Before:
![Screenshot from 2023-11-29 10-44-19](https://github.com/ubuntu/app-center/assets/20175372/4adcb95b-0076-4dfa-b45e-fbb001f31a21)



