### PR TITLE
fix: link not usable on snap page description

### DIFF
--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -240,6 +240,8 @@ class _SnapView extends ConsumerWidget {
                             ),
                             const SizedBox(height: kPagePadding),
                             MarkdownBody(
+                              onTapLink: (text, href, title) =>
+                                  launchUrlString(href!),
                               data: snapModel.snap.description,
                             ),
                           ],


### PR DESCRIPTION
In this PR:

- The snap page description often contains a link about the said snap, until now, the links were clickable but didn't do anything. Now, they open the link URL.


fix #1510 