### PR TITLE
feat: adding a snackbar for feedback on the share button

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -20,6 +20,7 @@
     "snapPagePublishedLabel": "Published",
     "snapPageSummaryLabel": "Summary",
     "snapPageVersionLabel": "Version",
+    "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
     "explorePageLabel": "Explore",
     "explorePageCategoriesLabel": "Categories",
     "managePageCheckForUpdates": "Check for updates",

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_center/src/store/store_app.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -546,14 +547,16 @@ class _Section extends YaruExpandable {
         );
 }
 
-class _Header extends StatelessWidget {
+class _Header extends ConsumerWidget {
   const _Header({required this.snapModel});
 
   final SnapModel snapModel;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final snap = snapModel.storeSnap ?? snapModel.localSnap!;
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       children: [
         Row(
@@ -564,7 +567,15 @@ class _Header extends StatelessWidget {
               YaruIconButton(
                 icon: const Icon(YaruIcons.share),
                 onPressed: () {
-                  // TODO show snackbar
+                  final navigationKey =
+                      ref.watch(materialAppNavigatorKeyProvider);
+
+                  ScaffoldMessenger.of(navigationKey.currentContext!)
+                      .showSnackBar(
+                    SnackBar(
+                      content: Text(l10n.snapPageShareLinkCopiedMessage),
+                    ),
+                  );
                   Clipboard.setData(ClipboardData(text: snap.website!));
                 },
               ),

--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -14,6 +14,10 @@ import 'store_pages.dart';
 import 'store_providers.dart';
 import 'store_routes.dart';
 
+// Making a provider to provide navigatorKeyTwo
+final materialAppNavigatorKeyProvider =
+    Provider((ref) => GlobalKey<NavigatorState>());
+
 class StoreApp extends ConsumerStatefulWidget {
   const StoreApp({super.key});
 
@@ -38,6 +42,7 @@ class _StoreAppState extends ConsumerState<StoreApp> {
         darkTheme: yaru.darkTheme,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: localizationsDelegates,
+        navigatorKey: ref.watch(materialAppNavigatorKeyProvider),
         supportedLocales: supportedLocales,
         home: Scaffold(
           appBar: YaruWindowTitleBar(


### PR DESCRIPTION
In this PR:

- Adding a visual indicator (snackbar) when copying a link through the share button on the snap page.

fix #1462 


[Screencast from 2023-12-11 16-16-07.webm](https://github.com/ubuntu/app-center/assets/20175372/52963295-d806-422e-b590-e3d5673a983a)
