### PR TITLE
Show "App Center" in Gnome Shell activities view

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -1,4 +1,5 @@
 {
+    "appCenterLabel": "App Center",
     "appstreamSearchGreylist": "app;application;package;program;programme;suite;tool",
     "snapPageChannelLabel": "Channel",
     "snapPageConfinementLabel": "Confinement",

--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -43,55 +43,72 @@ class _StoreAppState extends ConsumerState<StoreApp> {
         localizationsDelegates: localizationsDelegates,
         navigatorKey: ref.watch(materialAppNavigatorKeyProvider),
         supportedLocales: supportedLocales,
-        home: Scaffold(
-          appBar: YaruWindowTitleBar(
-            title: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
-              child: SearchField(
-                onSearch: (query) =>
-                    _navigator.pushAndRemoveSearch(query: query),
-                onSnapSelected: (name) => _navigator.pushSnap(name: name),
-                onDebSelected: (id) => _navigator.pushDeb(id: id),
+        home: YaruWindowTitleSetter(
+          child: Scaffold(
+            appBar: YaruWindowTitleBar(
+              title: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
+                child: SearchField(
+                  onSearch: (query) =>
+                      _navigator.pushAndRemoveSearch(query: query),
+                  onSnapSelected: (name) => _navigator.pushSnap(name: name),
+                  onDebSelected: (id) => _navigator.pushDeb(id: id),
+                ),
               ),
             ),
-          ),
-          body: YaruMasterDetailPage(
-            navigatorKey: _navigatorKey,
-            navigatorObservers: [StoreObserver(ref)],
-            initialRoute: ref.watch(initialRouteProvider),
-            length: pages.length,
-            tileBuilder: (context, index, selected, availableWidth) =>
-                pages[index].tileBuilder(context, selected),
-            pageBuilder: (context, index) => pages[index].pageBuilder(context),
-            layoutDelegate: const YaruMasterFixedPaneDelegate(
-              paneWidth: kPaneWidth,
+            body: YaruMasterDetailPage(
+              navigatorKey: _navigatorKey,
+              navigatorObservers: [StoreObserver(ref)],
+              initialRoute: ref.watch(initialRouteProvider),
+              length: pages.length,
+              tileBuilder: (context, index, selected, availableWidth) =>
+                  pages[index].tileBuilder(context, selected),
+              pageBuilder: (context, index) =>
+                  pages[index].pageBuilder(context),
+              layoutDelegate: const YaruMasterFixedPaneDelegate(
+                paneWidth: kPaneWidth,
+              ),
+              breakpoint: 0, // always landscape
+              onGenerateRoute: (settings) =>
+                  switch (StoreRoutes.routeOf(settings)) {
+                StoreRoutes.deb => MaterialPageRoute(
+                    settings: settings,
+                    builder: (_) => DebPage(
+                          id: StoreRoutes.debOf(settings)!,
+                        )),
+                StoreRoutes.snap => MaterialPageRoute(
+                    settings: settings,
+                    builder: (_) => SnapPage(
+                      snapName: StoreRoutes.snapOf(settings)!,
+                    ),
+                  ),
+                StoreRoutes.search => MaterialPageRoute(
+                    settings: settings,
+                    builder: (_) => SearchPage(
+                      query: StoreRoutes.queryOf(settings),
+                      category: StoreRoutes.categoryOf(settings),
+                    ),
+                  ),
+                _ => null,
+              },
             ),
-            breakpoint: 0, // always landscape
-            onGenerateRoute: (settings) =>
-                switch (StoreRoutes.routeOf(settings)) {
-              StoreRoutes.deb => MaterialPageRoute(
-                  settings: settings,
-                  builder: (_) => DebPage(
-                        id: StoreRoutes.debOf(settings)!,
-                      )),
-              StoreRoutes.snap => MaterialPageRoute(
-                  settings: settings,
-                  builder: (_) => SnapPage(
-                    snapName: StoreRoutes.snapOf(settings)!,
-                  ),
-                ),
-              StoreRoutes.search => MaterialPageRoute(
-                  settings: settings,
-                  builder: (_) => SearchPage(
-                    query: StoreRoutes.queryOf(settings),
-                    category: StoreRoutes.categoryOf(settings),
-                  ),
-                ),
-              _ => null,
-            },
           ),
         ),
       ),
     );
+  }
+}
+
+class YaruWindowTitleSetter extends StatelessWidget {
+  const YaruWindowTitleSetter({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    YaruWindow.of(context).setTitle(l10n.appCenterLabel);
+
+    return child;
   }
 }

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -49,7 +49,8 @@ dependencies:
   yaru: ^1.2.0
   yaru_icons: ^2.2.2
   yaru_test: ^0.1.5
-  yaru_widgets: ^3.3.0
+  yaru_widgets: ^3.4.0
+  yaru_window: ^0.2.0
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
Currently, the window in the Activities view in Gnome Shell has "snap-store" as its name, which is incorrect because this is the brand-new "App Center". The reason is that the Activities view shows the window title, but the app center doesn't set it, so it is set to the binary name.

The patch uses the translations from the .desktop file, thus it doesn't require extra effort to ensure that the name shown in the Activities view is correctly translated.

fix #1425