### PR TITLE
[snap]: fix hardcoded app icon

### DIFF
--- a/packages/app_center/assets/app-center.desktop
+++ b/packages/app_center/assets/app-center.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Version=1.0
 Exec=snap-store %U
-Icon=software-store
+Icon=bin/data/flutter_assets/assets/app-center.png
 Terminal=false
 Categories=System;Utility;PackageManager;SoftwareManagement;Network;Settings;
 Keywords=Ubuntu;Applications;Apps;Store;Software;Snaps;


### PR DESCRIPTION
Fixes #1514 

![image](https://github.com/ubuntu/app-center/assets/72045785/19acc1d9-deb7-42b6-85ec-3273af45fc19)
