### PR TITLE
fix: updating the background color of the content pages

### DIFF
--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -37,7 +37,7 @@ class _StoreAppState extends ConsumerState<StoreApp> {
 
     return YaruTheme(
       builder: (context, yaru, child) => MaterialApp(
-        theme: yaru.theme,
+        theme: yaru.theme?.copyWith(scaffoldBackgroundColor: Colors.white),
         darkTheme: yaru.darkTheme,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: localizationsDelegates,


### PR DESCRIPTION
In this PR:

- Updating the background color of the content pages in the light theme.

fix #1529 