### PR TITLE
feat: adding the report feature for snaps

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -173,7 +173,28 @@
                 "type": "int"
             }
         }
-    }
-
+    },
+    "snapReportLabel": "Report {snapName}",
+    "@snapReportLabel": {
+        "placeholders": {
+            "snapName": {
+                "type": "String"
+            }
+        }
+    },
+    "snapReportSelectReportReasonLabel": "Choose a reason for reporting this snap",
+    "snapReportSelectAnOptionLabel": "Select an option",
+    "snapReportOptionCopyrightViolation": "Copyright or trademark violation",
+    "snapReportOptionStoreViolation": "Snap Store terms of service violation",
+    "snapReportDetailsLabel": "Please provide more detailed reason to your report",
+    "snapReportOptionalEmailAddressLabel": "Your email (optional)",
+    "snapReportCancelButtonLabel": "Cancel",
+    "snapReportSubmitButtonLabel": "Submit report",
+    "snapReportEnterValidEmailError": "Enter a valid email address",
+    "snapReportDetailsHint": "Comment...",
+    "snapReportPrivacyAgreementLabel": "In submitting this form, I confirm that I have read and agree to ",
+    "snapReportPrivacyAgreementCanonicalPrivacyNotice": "Canonical’s Privacy Notice ",
+    "snapReportPrivacyAgreementAndLabel": "and ",
+    "snapReportPrivacyAgreementPrivacyPolicy": "Privacy Policy"
 
 }

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -587,7 +587,10 @@ class _Header extends ConsumerWidget {
                 showDialog(
                   context: context,
                   builder: (context) {
-                    return SnapReport(name: snapModel.snap.titleOrName);
+                    return ResponsiveLayoutBuilder(
+                      builder: (context) =>
+                          SnapReport(name: snapModel.snap.titleOrName),
+                    );
                   },
                 );
               },

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -4,6 +4,7 @@ import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/ratings.dart';
 import 'package:app_center/snapd.dart';
+import 'package:app_center/src/snapd/snap_report.dart';
 import 'package:app_center/src/store/store_app.dart';
 import 'package:app_center/widgets.dart';
 import 'package:collection/collection.dart';
@@ -563,6 +564,7 @@ class _Header extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             const YaruBackButton(),
+            const Spacer(),
             if (snap.website != null)
               YaruIconButton(
                 icon: const Icon(YaruIcons.share),
@@ -579,6 +581,17 @@ class _Header extends ConsumerWidget {
                   Clipboard.setData(ClipboardData(text: snap.website!));
                 },
               ),
+            YaruIconButton(
+              icon: const Icon(YaruIcons.flag),
+              onPressed: () {
+                showDialog(
+                  context: context,
+                  builder: (context) {
+                    return SnapReport(name: snapModel.snap.titleOrName);
+                  },
+                );
+              },
+            ),
           ],
         ),
         const SizedBox(height: kPagePadding),

--- a/packages/app_center/lib/src/snapd/snap_report.dart
+++ b/packages/app_center/lib/src/snapd/snap_report.dart
@@ -1,0 +1,202 @@
+import 'package:app_center/l10n.dart';
+import 'package:app_center/src/snapd/logger.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+class SnapReport extends StatefulWidget {
+  const SnapReport({required this.name, super.key});
+
+  final String name;
+
+  @override
+  State<SnapReport> createState() => _SnapReportState();
+}
+
+class _SnapReportState extends State<SnapReport> {
+  String? selectedReason;
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _detailsController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
+    final titleTextStyle = textTheme.headlineSmall!;
+
+    return Dialog(
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        width: double.infinity,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(l10n.snapReportLabel(widget.name), style: titleTextStyle),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 10.0),
+                child: Divider(),
+              ),
+              Text(l10n.snapReportSelectReportReasonLabel),
+              MenuButtonBuilder(
+                entries: <String>[
+                  l10n.snapReportOptionCopyrightViolation,
+                  l10n.snapReportOptionStoreViolation,
+                ].map<MenuButtonEntry<String>>((value) {
+                  return MenuButtonEntry<String>(
+                    value: value,
+                    child: Text(value),
+                  );
+                }).toList(),
+                itemBuilder: (context, value, child) => Text(value),
+                selected: selectedReason,
+                onSelected: (value) {
+                  setState(() {
+                    selectedReason = value;
+                  });
+                },
+                menuPosition: PopupMenuPosition.under,
+                itemStyle: MenuItemButton.styleFrom(
+                  maximumSize: const Size.fromHeight(100),
+                ),
+                child: Text(
+                  selectedReason ?? l10n.snapReportSelectAnOptionLabel,
+                ),
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              Text(l10n.snapReportDetailsLabel),
+              SizedBox(
+                height: 100,
+                child: TextField(
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlignVertical: TextAlignVertical.top,
+                  decoration: InputDecoration(
+                    contentPadding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                    fillColor: Theme.of(context).dividerColor,
+                    floatingLabelBehavior: FloatingLabelBehavior.never,
+                    isDense: true,
+                    hintText: l10n.snapReportDetailsHint,
+                  ),
+                  controller: _detailsController,
+                  expands: true,
+                  maxLines: null,
+                ),
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              Text(
+                l10n.snapReportOptionalEmailAddressLabel,
+              ),
+              TextFormField(
+                decoration: InputDecoration(
+                  contentPadding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                  fillColor: Theme.of(context).dividerColor,
+                  floatingLabelBehavior: FloatingLabelBehavior.never,
+                  hintText: 'email@exemple.com',
+                ),
+                validator: (value) {
+                  const pattern =
+                      r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$';
+                  final regex = RegExp(pattern);
+                  if (!regex.hasMatch(value!)) {
+                    return l10n.snapReportEnterValidEmailError;
+                  } else {
+                    return null;
+                  }
+                },
+                controller: _emailController,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 20.0),
+                child: RichText(
+                  text: TextSpan(
+                    children: [
+                      TextSpan(
+                        text: l10n.snapReportPrivacyAgreementLabel,
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      TextSpan(
+                          text: l10n
+                              .snapReportPrivacyAgreementCanonicalPrivacyNotice,
+                          style: TextStyle(
+                            color: Theme.of(context).primaryColor,
+                            decoration: TextDecoration.underline,
+                          ),
+                          recognizer: TapGestureRecognizer()
+                            ..onTap = () async {
+                              await launchUrlString(
+                                  'https://ubuntu.com/legal/data-privacy/contact');
+                            }),
+                      TextSpan(
+                        text: l10n.snapReportPrivacyAgreementAndLabel,
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      TextSpan(
+                          text: l10n.snapReportPrivacyAgreementPrivacyPolicy,
+                          style: TextStyle(
+                            color: Theme.of(context).primaryColor,
+                            decoration: TextDecoration.underline,
+                          ),
+                          recognizer: TapGestureRecognizer()
+                            ..onTap = () async {
+                              await launchUrlString(
+                                  'https://ubuntu.com/legal/data-privacy');
+                            }),
+                    ],
+                  ),
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(l10n.snapReportCancelButtonLabel),
+                  ),
+                  const SizedBox(width: 20.0),
+                  ElevatedButton(
+                    onPressed: () async {
+                      if (selectedReason == null ||
+                          _detailsController.text.isEmpty) {
+                        return;
+                      }
+
+                      const url =
+                          'https://docs.google.com/forms/d/e/1FAIpQLSelELZwXzvnDkx52GL7cpnQyWdc_Te6APDs843gIKRBHbh6jA/formResponse';
+
+                      final headers = {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                      };
+                      final requestBody = <String, String>{
+                        'entry.1703677219': widget.name.toLowerCase(),
+                        'entry.1193754313': selectedReason!,
+                        'entry.1170971435': _detailsController.text,
+                        'entry.1424146082': _emailController.text,
+                      };
+
+                      final response = await http.post(Uri.parse(url),
+                          headers: headers, body: requestBody);
+                      if (response.statusCode != 200) {
+                        log.error(
+                            'Snap reporting for snap "${widget.name}" failed with HTTP Code ${response.statusCode}');
+                      }
+                      if (mounted) {
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    child: Text(l10n.snapReportSubmitButtonLabel),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/app_center/lib/src/snapd/snap_report.dart
+++ b/packages/app_center/lib/src/snapd/snap_report.dart
@@ -1,4 +1,5 @@
 import 'package:app_center/l10n.dart';
+import 'package:app_center/layout.dart';
 import 'package:app_center/src/snapd/logger.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -25,11 +26,12 @@ class _SnapReportState extends State<SnapReport> {
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     final titleTextStyle = textTheme.headlineSmall!;
+    final layout = ResponsiveLayout.of(context);
 
     return Dialog(
       child: Container(
-        padding: const EdgeInsets.all(16.0),
-        width: double.infinity,
+        width: layout.cardSize.width * 2 + kCardSpacing,
+        padding: const EdgeInsets.all(kCardSpacing),
         child: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -39,7 +41,10 @@ class _SnapReportState extends State<SnapReport> {
                 padding: EdgeInsets.symmetric(vertical: 10.0),
                 child: Divider(),
               ),
-              Text(l10n.snapReportSelectReportReasonLabel),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: kCardMargin),
+                child: Text(l10n.snapReportSelectReportReasonLabel),
+              ),
               MenuButtonBuilder(
                 entries: <String>[
                   l10n.snapReportOptionCopyrightViolation,
@@ -66,9 +71,12 @@ class _SnapReportState extends State<SnapReport> {
                 ),
               ),
               const SizedBox(
-                height: 20,
+                height: kPagePadding,
               ),
-              Text(l10n.snapReportDetailsLabel),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: kCardMargin),
+                child: Text(l10n.snapReportDetailsLabel),
+              ),
               SizedBox(
                 height: 100,
                 child: TextField(
@@ -87,10 +95,13 @@ class _SnapReportState extends State<SnapReport> {
                 ),
               ),
               const SizedBox(
-                height: 20,
+                height: kPagePadding,
               ),
-              Text(
-                l10n.snapReportOptionalEmailAddressLabel,
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: kCardMargin),
+                child: Text(
+                  l10n.snapReportOptionalEmailAddressLabel,
+                ),
               ),
               TextFormField(
                 decoration: InputDecoration(
@@ -112,7 +123,7 @@ class _SnapReportState extends State<SnapReport> {
                 controller: _emailController,
               ),
               Padding(
-                padding: const EdgeInsets.symmetric(vertical: 20.0),
+                padding: const EdgeInsets.symmetric(vertical: kPagePadding),
                 child: RichText(
                   text: TextSpan(
                     children: [
@@ -154,11 +165,11 @@ class _SnapReportState extends State<SnapReport> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  TextButton(
+                  OutlinedButton(
                     onPressed: () => Navigator.of(context).pop(),
                     child: Text(l10n.snapReportCancelButtonLabel),
                   ),
-                  const SizedBox(width: 20.0),
+                  const SizedBox(width: kPagePadding),
                   ElevatedButton(
                     onPressed: () async {
                       if (selectedReason == null ||

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -1,10 +1,10 @@
 name: app_center
 description: App Center
 version: 1.0.0
-publish_to: "none"
+publish_to: 'none'
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: '>=3.1.0 <4.0.0'
   flutter: 3.16.4
 
 dependencies:

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -1,10 +1,10 @@
 name: app_center
 description: App Center
 version: 1.0.0
-publish_to: 'none'
+publish_to: "none"
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
+  sdk: ">=3.1.0 <4.0.0"
   flutter: 3.16.4
 
 dependencies:
@@ -29,6 +29,7 @@ dependencies:
   glib: ^0.0.1
   gtk: ^2.1.0
   handy_window: ^0.3.1
+  http: ^1.1.2
   intl: ^0.18.1
   jwt_decode: ^0.3.1
   meta: ^1.9.1


### PR DESCRIPTION
In this PR:

- Adding the UI and the necessary functionality to be able to report a Snap. It use the same principle as snapcraft.io

There was no Figma file, so I improvised some visual aspects to be as close as possible from snapcraft.io, but with Yaru theming.

![Screenshot 2023-12-26 at 13 50 39](https://github.com/ubuntu/app-center/assets/20175372/b385d56d-2581-4ffb-ba6c-a3b51ad8da7c)


fix #1490 
