### PR TITLE
fix: sidebar navigation highlight

### DIFF
--- a/packages/app_center/lib/src/explore/explore_page.dart
+++ b/packages/app_center/lib/src/explore/explore_page.dart
@@ -1,6 +1,7 @@
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/snapd.dart';
+import 'package:app_center/src/store/store_pages.dart';
 import 'package:app_center/store.dart';
 import 'package:app_center/widgets.dart';
 import 'package:collection/collection.dart';
@@ -172,8 +173,14 @@ class _CategoryBanner extends ConsumerWidget {
       snaps: featuredSnaps?.take(kNumberOfBannerSnaps).toList() ?? [],
       slogan: category.slogan(l10n),
       buttonLabel: category.buttonLabel(l10n),
-      onPressed: () =>
-          StoreNavigator.pushSearch(context, category: category.categoryName),
+      onPressed: () {
+        if (displayedCategories.contains(category)) {
+          ref.read(yaruPageControllerProvider).index =
+              displayedCategories.indexOf(category) + 1;
+        } else {
+          StoreNavigator.pushSearch(context, category: category.categoryName);
+        }
+      },
       colors: category.bannerColors,
     );
   }

--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -17,6 +17,9 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 final materialAppNavigatorKeyProvider =
     Provider((ref) => GlobalKey<NavigatorState>());
 
+final yaruPageControllerProvider =
+    Provider((ref) => YaruPageController(length: pages.length));
+
 class StoreApp extends ConsumerStatefulWidget {
   const StoreApp({super.key});
 
@@ -60,7 +63,7 @@ class _StoreAppState extends ConsumerState<StoreApp> {
               navigatorKey: _navigatorKey,
               navigatorObservers: [StoreObserver(ref)],
               initialRoute: ref.watch(initialRouteProvider),
-              length: pages.length,
+              controller: ref.watch(yaruPageControllerProvider),
               tileBuilder: (context, index, selected, availableWidth) =>
                   pages[index].tileBuilder(context, selected),
               pageBuilder: (context, index) =>

--- a/packages/app_center/lib/src/store/store_pages.dart
+++ b/packages/app_center/lib/src/store/store_pages.dart
@@ -8,6 +8,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+final displayedCategories = [
+  SnapCategoryEnum.featured,
+  SnapCategoryEnum.productivity,
+  SnapCategoryEnum.development,
+  SnapCategoryEnum.games,
+];
+
 typedef StorePage = ({
   Widget Function(BuildContext context, bool selected) tileBuilder,
   WidgetBuilder pageBuilder,
@@ -21,12 +28,7 @@ final pages = <StorePage>[
         ),
     pageBuilder: (_) => const ExplorePage(),
   ),
-  for (final category in [
-    SnapCategoryEnum.featured,
-    SnapCategoryEnum.productivity,
-    SnapCategoryEnum.development,
-    SnapCategoryEnum.games,
-  ])
+  for (final category in displayedCategories)
     (
       tileBuilder: (context, selected) => YaruMasterTile(
             leading: Icon(category.icon(true)),


### PR DESCRIPTION
In this PR:

- Open the correct section when clicking on a banner button from the explore page.

fix #1379 