### PR TITLE
fix: set standard height for Circular progress indicator everywhere.

### DIFF
--- a/packages/app_center/lib/constants.dart
+++ b/packages/app_center/lib/constants.dart
@@ -8,3 +8,5 @@ const kShimmerBaseLight = Color.fromARGB(120, 228, 228, 228);
 const kShimmerBaseDark = Color.fromARGB(255, 51, 51, 51);
 const kShimmerHighLightLight = Color.fromARGB(200, 247, 247, 247);
 const kShimmerHighLightDark = Color.fromARGB(255, 57, 57, 57);
+
+const kCircularProgressIndicatorHeight = 16.0;

--- a/packages/app_center/lib/src/deb/deb_page.dart
+++ b/packages/app_center/lib/src/deb/deb_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_center/appstream.dart';
+import 'package:app_center/constants.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/src/deb/deb_model.dart';
@@ -173,7 +174,7 @@ class _DebActionButtons extends ConsumerWidget {
                       .whenOrNull(data: (data) => data);
                   return Center(
                     child: SizedBox.square(
-                      dimension: 16,
+                      dimension: kCircularProgressIndicatorHeight,
                       child: YaruCircularProgressIndicator(
                         value: (transaction?.percentage ?? 0) / 100.0,
                         strokeWidth: 2,

--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_center/constants.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/snapd.dart';
@@ -225,7 +226,7 @@ class _ActionButtons extends ConsumerWidget {
       loading: () => (
         l10n.managePageCheckingForUpdates,
         const SizedBox(
-          height: 24,
+          height: kCircularProgressIndicatorHeight,
           child: YaruCircularProgressIndicator(
             strokeWidth: 4,
           ),
@@ -274,7 +275,7 @@ class _ActionButtons extends ConsumerWidget {
                     return Row(
                       children: [
                         SizedBox.square(
-                          dimension: 16,
+                          dimension: kCircularProgressIndicatorHeight,
                           child: YaruCircularProgressIndicator(
                             value: change?.progress,
                             strokeWidth: 2,
@@ -488,7 +489,7 @@ class _ManageSnapTile extends ConsumerWidget {
                         return Row(
                           children: [
                             SizedBox.square(
-                              dimension: 16,
+                              dimension: kCircularProgressIndicatorHeight,
                               child: YaruCircularProgressIndicator(
                                 value: change?.progress,
                                 strokeWidth: 2,

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_center/constants.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/ratings.dart';
@@ -328,7 +329,7 @@ class _SnapActionButtons extends ConsumerWidget {
                   return Row(
                     children: [
                       SizedBox.square(
-                        dimension: 16,
+                        dimension: kCircularProgressIndicatorHeight,
                         child: YaruCircularProgressIndicator(
                           value: change?.progress,
                           strokeWidth: 2,


### PR DESCRIPTION
fixes #1502 by setting standard height for Circular progress indicator, which will not make update button jump out of its height.

![image](https://github.com/ubuntu/app-center/assets/7272358/06cde07a-2c87-4a68-abad-3cb5cb5d6fb0)
