### PR TITLE
fix: Manage page: Hide cancel button when updates are not in progress.

### DIFF
--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -238,8 +238,9 @@ class _ActionButtons extends ConsumerWidget {
     final updatesInprogress = updatesModel.refreshableSnapNames.isNotEmpty &&
         !updatesModel.state.isLoading &&
         updatesModel.activeChangeId != null;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
       children: [
         PushButton.outlined(
           onPressed:
@@ -259,7 +260,6 @@ class _ActionButtons extends ConsumerWidget {
             ],
           ),
         ),
-        const SizedBox(width: 8),
         PushButton.elevated(
           onPressed: updatesModel.refreshableSnapNames.isNotEmpty &&
                   !updatesModel.state.isLoading &&
@@ -308,7 +308,6 @@ class _ActionButtons extends ConsumerWidget {
                   ],
                 ),
         ),
-        if (updatesInprogress) const SizedBox(width: 8),
         if (updatesInprogress)
           PushButton.outlined(
             onPressed: () => ref

--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -308,19 +308,18 @@ class _ActionButtons extends ConsumerWidget {
                   ],
                 ),
         ),
-        const SizedBox(width: 8),
-        PushButton.outlined(
-          onPressed: updatesInprogress
-              ? () => ref
-                  .read(updatesModelProvider)
-                  .cancelChange(updatesModel.activeChangeId!)
-              : null,
-          child: Text(
-            l10n.snapActionCancelLabel,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+        if (updatesInprogress) const SizedBox(width: 8),
+        if (updatesInprogress)
+          PushButton.outlined(
+            onPressed: () => ref
+                .read(updatesModelProvider)
+                .cancelChange(updatesModel.activeChangeId!),
+            child: Text(
+              l10n.snapActionCancelLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
-        ),
       ],
     );
   }


### PR DESCRIPTION
> One thing to amend is that the cancel button should be hidden until the 'Update all' is trigged, as it can be misleading for the users to have a cancel button without context.

As per the comments form #1536, this PR will hide cancel button when updates are not in progress.