### PR TITLE
fix: using the new parameter for the MenuButtonBuilder

### DIFF
--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -51,6 +51,7 @@ class SearchPage extends StatelessWidget {
                   Consumer(builder: (context, ref, child) {
                     final sortOrder = ref.watch(snapSortOrderProvider);
                     return MenuButtonBuilder<SnapSortOrder?>(
+                      expanded: false,
                       values: const [
                         null,
                         SnapSortOrder.alphabeticalAsc,

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   ubuntu_logger: ^0.1.0
   ubuntu_service: ^0.3.0
   ubuntu_test: ^0.1.0-0
-  ubuntu_widgets: ^0.3.1
+  ubuntu_widgets: ^0.3.2
   url_launcher: ^6.2.1
   xdg_directories: ^1.0.3
   yaru: ^1.2.0


### PR DESCRIPTION
In this PR:

- Using the new parameter `expanded` from the `MenuButtonBuilder` to follow implementation of canonical/ubuntu-flutter-plugins#372