### PR TITLE
snap_page: use mouse hand instead of pointer for voting icons

### DIFF
--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -454,6 +454,7 @@ class _RatingsActionButtons extends ConsumerWidget {
                     ),
                   ),
                   child: YaruIconButton(
+                    mouseCursor: SystemMouseCursors.click,
                     icon: Icon(
                       ratingsModel.vote == VoteStatus.up
                           ? Icons.thumb_up
@@ -486,6 +487,7 @@ class _RatingsActionButtons extends ConsumerWidget {
                     ),
                   ),
                   child: YaruIconButton(
+                    mouseCursor: SystemMouseCursors.click,
                     icon: Icon(
                       ratingsModel.vote == VoteStatus.down
                           ? Icons.thumb_down


### PR DESCRIPTION
### before: 

![Screenshot from 2024-01-07 15-00-22](https://github.com/ubuntu/app-center/assets/72045785/dbf6c773-b17f-400a-ac7e-12f6a9be82ab)

### after:

![Screenshot from 2024-01-07 15-18-25](https://github.com/ubuntu/app-center/assets/72045785/71e75844-2418-4adc-b651-d8f5e0f21dcd)

