### PR TITLE
fix: Manage page: button content aligment is not consistent

### DIFF
--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -467,6 +467,7 @@ class _ManageSnapTile extends ConsumerWidget {
   ButtonBar buildButtonBarForUpdate(WidgetRef ref, AppLocalizations l10n,
       SnapLauncher snapLauncher, BuildContext context) {
     return ButtonBar(
+      buttonPadding: EdgeInsets.zero,
       mainAxisSize: MainAxisSize.min,
       children: [
         Consumer(
@@ -519,12 +520,16 @@ class _ManageSnapTile extends ConsumerWidget {
                             l10n.snapActionUpdateLabel,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.start,
                           ),
                         ),
                       ],
                     ),
             );
           },
+        ),
+        const SizedBox(
+          width: 8,
         ),
         MenuAnchor(
           menuChildren: [
@@ -565,6 +570,7 @@ class _ManageSnapTile extends ConsumerWidget {
   ButtonBar buildButtonBarForOpen(WidgetRef ref, AppLocalizations l10n,
       SnapLauncher snapLauncher, BuildContext context) {
     return ButtonBar(
+      buttonPadding: EdgeInsets.zero,
       mainAxisSize: MainAxisSize.min,
       children: [
         Visibility(
@@ -576,6 +582,9 @@ class _ManageSnapTile extends ConsumerWidget {
             onPressed: snapLauncher.open,
             child: Text(l10n.snapActionOpenLabel),
           ),
+        ),
+        const SizedBox(
+          width: 8,
         ),
         MenuAnchor(
           menuChildren: [


### PR DESCRIPTION
I have fixed the issue with text alignment in Manage Page now they are alligned properly
![image](https://github.com/ubuntu/app-center/assets/77945559/7971dcfe-3d22-4cea-8c48-05119baa5ce4)
this issue was due to button bar that adds padding to button themes by default of 8.0 so i set 
`buttonPadding: EdgeInsets.zero`, & then added `8.0` spacing between buttons using `Sizedbox`