### PR TITLE
chore: remove generated files from coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ migrate_working_dir/
 .pub/
 pubspec.lock
 /build/
-/coverage/
+coverage/
 /doc/
 .fvm
 **/build/

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,6 +1,1 @@
 comment: false
-ignore:
-  - "**/*.freezed.dart"
-  - "**/*.g.dart"
-  - "**/*.mocks.dart"
-  - "**/l10n/*.dart"

--- a/melos.yaml
+++ b/melos.yaml
@@ -31,14 +31,22 @@ scripts:
   # cleanup generated files from coverage
   coverage:cleanup: >
     melos exec --file-exists=coverage/lcov.info -- \
-      lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info
+      lcov --remove coverage/lcov.info \
+        '**/*.freezed.dart' \
+        '**/*.g.dart' \
+        '**/*.mocks.dart' \
+        '**/l10n/*.dart' \
+        '**/*.pb*.dart' \
+        -o coverage/lcov.info
 
   # format all packages
   format: >
     find . -name '*.dart' \
-      ! -name '*.g.dart' \
       ! -name '*.freezed.dart' \
+      ! -name '*.g.dart' \
       ! -name '*.mocks.dart' \
+      ! -path '*/l10n/*.dart' \
+      ! -name '*.pb*.dart' \
       ! -path '*/.*/*' \
       | xargs dart format --set-exit-if-changed
 


### PR DESCRIPTION
* Removes generated protobuf files from coverage in `melos coverage:cleanup`
* Removes unneeded `ignore` rule in codecov.yaml
* Removes generated files from `melos format` for consistency