### PR TITLE
fix: remove asdf and melos-action from snap workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: asdf-vm/actions/install@v2
-      - uses: bluefireteam/melos-action@v3
       - uses: snapcore/action-build@v1
         id: snapcraft
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
The asdf and melos actions shouldn't be here, as they pollute the snapcraft environment, which caused the recent snap job failures.