### PR TITLE
snap_page: show the old rev to new rev change...

### DIFF
--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -119,6 +119,7 @@ class _ManageView extends ConsumerWidget {
           SliverList.builder(
             itemCount: manageModel.refreshableSnaps.length,
             itemBuilder: (context, index) => _ManageSnapTile(
+              updated: false,
               snap: manageModel.refreshableSnaps.elementAt(index),
               position: index == (manageModel.refreshableSnaps.length - 1)
                   ? index == 0
@@ -331,14 +332,17 @@ class _ManageSnapTile extends ConsumerWidget {
     required this.snap,
     this.position = ManageTilePosition.middle,
     this.showUpdateButton = false,
+    this.updated = true,
   });
 
   final Snap snap;
   final ManageTilePosition position;
   final bool showUpdateButton;
+  final bool updated;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final snapModel = ref.watch(snapModelProvider(snap.name));
     final snapLauncher = ref.watch(launchProvider(snap));
     final l10n = AppLocalizations.of(context);
     final border = BorderSide(color: Theme.of(context).colorScheme.outline);
@@ -425,7 +429,10 @@ class _ManageSnapTile extends ConsumerWidget {
             children: [
               Text(snap.channel),
               const SizedBox(width: 4),
-              Text(snap.version),
+              updated
+                  ? Text(snap.version)
+                  : Text(
+                      '${snap.revision} => ${snapModel.availableChannels?[snap.channel]?.revision}'),
             ],
           ),
           if (ResponsiveLayout.of(context).type == ResponsiveLayoutType.small)


### PR DESCRIPTION
This shows the change in this update

![image](https://github.com/ubuntu/app-center/assets/72045785/2dbe1a1c-fa80-45b1-9985-a05e61c34106)


@anasereijo do you have a better design idea for this?