### PR TITLE
feat: ctrl+f shortcut to focus search field

### DIFF
--- a/packages/app_center/lib/src/search/search_field.dart
+++ b/packages/app_center/lib/src/search/search_field.dart
@@ -38,12 +38,14 @@ class SearchField extends ConsumerStatefulWidget {
     required this.onSearch,
     required this.onSnapSelected,
     required this.onDebSelected,
+    required this.searchFocus,
     super.key,
   });
 
   final ValueChanged<String> onSearch;
   final ValueChanged<String> onSnapSelected;
   final ValueChanged<String> onDebSelected;
+  final FocusNode searchFocus;
 
   @override
   ConsumerState<SearchField> createState() => _SearchFieldState();
@@ -163,7 +165,7 @@ class _SearchFieldState extends ConsumerState<SearchField> {
             maxHeight: 32,
           );
           return TextField(
-            focusNode: node,
+            focusNode: widget.searchFocus,
             controller: controller,
             onChanged: (_) => _optionsAvailable = false,
             onSubmitted: (query) =>

--- a/packages/app_center/lib/src/search/search_field.dart
+++ b/packages/app_center/lib/src/search/search_field.dart
@@ -154,42 +154,45 @@ class _SearchFieldState extends ConsumerState<SearchField> {
         AutoCompleteSearchOption(query: final query) => widget.onSearch(query),
       },
       fieldViewBuilder: (context, controller, node, onFieldSubmitted) {
-        return Consumer(builder: (context, ref, child) {
-          ref.listen(queryProvider, (prev, next) {
-            if (!node.hasPrimaryFocus) controller.text = next ?? '';
-          });
-          const iconConstraints = BoxConstraints(
-            minWidth: 32,
-            minHeight: 32,
-            maxWidth: 32,
-            maxHeight: 32,
-          );
-          return TextField(
+        return Focus(
             focusNode: widget.searchFocus,
-            controller: controller,
-            onChanged: (_) => _optionsAvailable = false,
-            onSubmitted: (query) =>
-                _optionsAvailable ? onFieldSubmitted() : widget.onSearch(query),
-            decoration: InputDecoration(
-              contentPadding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
-              fillColor: Theme.of(context).dividerColor,
-              prefixIcon: const Icon(YaruIcons.search, size: 16),
-              prefixIconConstraints: iconConstraints,
-              hintText: l10n.searchFieldSearchHint,
-              suffixIcon: AnimatedBuilder(
-                animation: controller,
-                builder: (context, child) {
-                  return YaruIconButton(
-                    icon: const Icon(YaruIcons.edit_clear, size: 16),
-                    onPressed:
-                        controller.text.isEmpty ? null : controller.clear,
-                  );
-                },
-              ),
-              suffixIconConstraints: iconConstraints,
-            ),
-          );
-        });
+            child: Consumer(builder: (context, ref, child) {
+              ref.listen(queryProvider, (prev, next) {
+                if (!node.hasPrimaryFocus) controller.text = next ?? '';
+              });
+              const iconConstraints = BoxConstraints(
+                minWidth: 32,
+                minHeight: 32,
+                maxWidth: 32,
+                maxHeight: 32,
+              );
+              return TextField(
+                focusNode: node,
+                controller: controller,
+                onChanged: (_) => _optionsAvailable = false,
+                onSubmitted: (query) => _optionsAvailable
+                    ? onFieldSubmitted()
+                    : widget.onSearch(query),
+                decoration: InputDecoration(
+                  contentPadding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                  fillColor: Theme.of(context).dividerColor,
+                  prefixIcon: const Icon(YaruIcons.search, size: 16),
+                  prefixIconConstraints: iconConstraints,
+                  hintText: l10n.searchFieldSearchHint,
+                  suffixIcon: AnimatedBuilder(
+                    animation: controller,
+                    builder: (context, child) {
+                      return YaruIconButton(
+                        icon: const Icon(YaruIcons.edit_clear, size: 16),
+                        onPressed:
+                            controller.text.isEmpty ? null : controller.clear,
+                      );
+                    },
+                  ),
+                  suffixIconConstraints: iconConstraints,
+                ),
+              );
+            }));
       },
     );
   }

--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -9,6 +9,7 @@ import 'package:app_center/src/store/store_pages.dart';
 import 'package:app_center/src/store/store_providers.dart';
 import 'package:app_center/src/store/store_routes.dart';
 import 'package:flutter/material.dart' hide AboutDialog, showAboutDialog;
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -29,6 +30,7 @@ class StoreApp extends ConsumerStatefulWidget {
 
 class _StoreAppState extends ConsumerState<StoreApp> {
   final _navigatorKey = GlobalKey<NavigatorState>();
+  final searchFocus = FocusNode();
 
   NavigatorState get _navigator => _navigatorKey.currentState!;
 
@@ -38,67 +40,74 @@ class _StoreAppState extends ConsumerState<StoreApp> {
       next.whenData((route) => _navigator.pushNamed(route));
     });
 
-    return YaruTheme(
-      builder: (context, yaru, child) => MaterialApp(
-        theme: yaru.theme,
-        darkTheme: yaru.darkTheme,
-        debugShowCheckedModeBanner: false,
-        localizationsDelegates: localizationsDelegates,
-        navigatorKey: ref.watch(materialAppNavigatorKeyProvider),
-        supportedLocales: supportedLocales,
-        home: YaruWindowTitleSetter(
-          child: Scaffold(
-            appBar: YaruWindowTitleBar(
-              title: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
-                child: SearchField(
-                  onSearch: (query) =>
-                      _navigator.pushAndRemoveSearch(query: query),
-                  onSnapSelected: (name) => _navigator.pushSnap(name: name),
-                  onDebSelected: (id) => _navigator.pushDeb(id: id),
+    return CallbackShortcuts(
+        bindings: <ShortcutActivator, VoidCallback>{
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyF):
+              searchFocus.requestFocus
+        },
+        child: YaruTheme(
+          builder: (context, yaru, child) => MaterialApp(
+            theme: yaru.theme,
+            darkTheme: yaru.darkTheme,
+            debugShowCheckedModeBanner: false,
+            localizationsDelegates: localizationsDelegates,
+            navigatorKey: ref.watch(materialAppNavigatorKeyProvider),
+            supportedLocales: supportedLocales,
+            home: YaruWindowTitleSetter(
+              child: Scaffold(
+                appBar: YaruWindowTitleBar(
+                  title: ConstrainedBox(
+                    constraints:
+                        const BoxConstraints(maxWidth: kSearchBarWidth),
+                    child: SearchField(
+                      onSearch: (query) =>
+                          _navigator.pushAndRemoveSearch(query: query),
+                      onSnapSelected: (name) => _navigator.pushSnap(name: name),
+                      onDebSelected: (id) => _navigator.pushDeb(id: id),
+                      searchFocus: searchFocus,
+                    ),
+                  ),
+                ),
+                body: YaruMasterDetailPage(
+                  navigatorKey: _navigatorKey,
+                  navigatorObservers: [StoreObserver(ref)],
+                  initialRoute: ref.watch(initialRouteProvider),
+                  controller: ref.watch(yaruPageControllerProvider),
+                  tileBuilder: (context, index, selected, availableWidth) =>
+                      pages[index].tileBuilder(context, selected),
+                  pageBuilder: (context, index) =>
+                      pages[index].pageBuilder(context),
+                  layoutDelegate: const YaruMasterFixedPaneDelegate(
+                    paneWidth: kPaneWidth,
+                  ),
+                  breakpoint: 0, // always landscape
+                  onGenerateRoute: (settings) =>
+                      switch (StoreRoutes.routeOf(settings)) {
+                    StoreRoutes.deb => MaterialPageRoute(
+                        settings: settings,
+                        builder: (_) => DebPage(
+                              id: StoreRoutes.debOf(settings)!,
+                            )),
+                    StoreRoutes.snap => MaterialPageRoute(
+                        settings: settings,
+                        builder: (_) => SnapPage(
+                          snapName: StoreRoutes.snapOf(settings)!,
+                        ),
+                      ),
+                    StoreRoutes.search => MaterialPageRoute(
+                        settings: settings,
+                        builder: (_) => SearchPage(
+                          query: StoreRoutes.queryOf(settings),
+                          category: StoreRoutes.categoryOf(settings),
+                        ),
+                      ),
+                    _ => null,
+                  },
                 ),
               ),
             ),
-            body: YaruMasterDetailPage(
-              navigatorKey: _navigatorKey,
-              navigatorObservers: [StoreObserver(ref)],
-              initialRoute: ref.watch(initialRouteProvider),
-              controller: ref.watch(yaruPageControllerProvider),
-              tileBuilder: (context, index, selected, availableWidth) =>
-                  pages[index].tileBuilder(context, selected),
-              pageBuilder: (context, index) =>
-                  pages[index].pageBuilder(context),
-              layoutDelegate: const YaruMasterFixedPaneDelegate(
-                paneWidth: kPaneWidth,
-              ),
-              breakpoint: 0, // always landscape
-              onGenerateRoute: (settings) =>
-                  switch (StoreRoutes.routeOf(settings)) {
-                StoreRoutes.deb => MaterialPageRoute(
-                    settings: settings,
-                    builder: (_) => DebPage(
-                          id: StoreRoutes.debOf(settings)!,
-                        )),
-                StoreRoutes.snap => MaterialPageRoute(
-                    settings: settings,
-                    builder: (_) => SnapPage(
-                      snapName: StoreRoutes.snapOf(settings)!,
-                    ),
-                  ),
-                StoreRoutes.search => MaterialPageRoute(
-                    settings: settings,
-                    builder: (_) => SearchPage(
-                      query: StoreRoutes.queryOf(settings),
-                      category: StoreRoutes.categoryOf(settings),
-                    ),
-                  ),
-                _ => null,
-              },
-            ),
           ),
-        ),
-      ),
-    );
+        ));
   }
 }
 

--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -43,7 +43,10 @@ class _StoreAppState extends ConsumerState<StoreApp> {
     return CallbackShortcuts(
         bindings: <ShortcutActivator, VoidCallback>{
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyF):
-              searchFocus.requestFocus
+              () {
+            searchFocus.requestFocus();
+            searchFocus.nextFocus();
+          }
         },
         child: YaruTheme(
           builder: (context, yaru, child) => MaterialApp(

--- a/packages/app_center/test/search_field_test.dart
+++ b/packages/app_center/test/search_field_test.dart
@@ -50,6 +50,7 @@ void main() {
             onSearch: (_) {},
             onSnapSelected: (_) {},
             onDebSelected: (_) {},
+            searchFocus: FocusNode(),
           ),
         ),
       );
@@ -88,6 +89,7 @@ void main() {
             onSearch: (_) {},
             onSnapSelected: (_) {},
             onDebSelected: (_) {},
+            searchFocus: FocusNode(),
           ),
         ),
       );
@@ -134,6 +136,7 @@ void main() {
             onSearch: mockSearchCallback.call,
             onSnapSelected: mockSelectedCallback.call,
             onDebSelected: (_) {},
+            searchFocus: FocusNode(),
           ),
         ),
       );
@@ -164,6 +167,7 @@ void main() {
             onSearch: mockSearchCallback.call,
             onSnapSelected: mockSelectedCallback.call,
             onDebSelected: (_) {},
+            searchFocus: FocusNode(),
           ),
         ),
       );
@@ -195,6 +199,7 @@ void main() {
             onSearch: mockSearchCallback.call,
             onSnapSelected: mockSelectedCallback.call,
             onDebSelected: (_) {},
+            searchFocus: FocusNode(),
           ),
         ),
       );


### PR DESCRIPTION
This pull request adds a keyboard shortcut to focus the search text field by clicking ctrl+f
For some reason the formatting (indenting) destroys the diff look. And kind of makes sense because I made the `YaruTheme` a child of the `CallbackShortcuts`. Is there a formatting helper or a guide for this? I could push directly to this branch to fix these code formatting issues if needed
Also, unit tests are failing because I changed the SearchField constructor signature so I have to rewrite the unit tests for them to succeed. I can do that in a separate commit if you're ok with it.