### PR TITLE
tests: regenerate snapd mocks

### DIFF
--- a/packages/app_center/test/snapd_cache_test.mocks.dart
+++ b/packages/app_center/test/snapd_cache_test.mocks.dart
@@ -317,6 +317,7 @@ class MockSnapdClient extends _i1.Mock implements _i2.SnapdClient {
     String? category,
     String? section,
     _i2.SnapFindFilter? filter,
+    _i2.SnapFindScope? scope,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -328,6 +329,7 @@ class MockSnapdClient extends _i1.Mock implements _i2.SnapdClient {
             #category: category,
             #section: section,
             #filter: filter,
+            #scope: scope,
           },
         ),
         returnValue: _i3.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),

--- a/packages/app_center/test/snapd_watcher_test.mocks.dart
+++ b/packages/app_center/test/snapd_watcher_test.mocks.dart
@@ -317,6 +317,7 @@ class MockSnapdClient extends _i1.Mock implements _i2.SnapdClient {
     String? category,
     String? section,
     _i2.SnapFindFilter? filter,
+    _i2.SnapFindScope? scope,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -328,6 +329,7 @@ class MockSnapdClient extends _i1.Mock implements _i2.SnapdClient {
             #category: category,
             #section: section,
             #filter: filter,
+            #scope: scope,
           },
         ),
         returnValue: _i3.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),

--- a/packages/app_center/test/test_utils.mocks.dart
+++ b/packages/app_center/test/test_utils.mocks.dart
@@ -1063,6 +1063,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
     String? category,
     String? section,
     _i2.SnapFindFilter? filter,
+    _i2.SnapFindScope? scope,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1074,6 +1075,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #category: category,
             #section: section,
             #filter: filter,
+            #scope: scope,
           },
         ),
         returnValue: _i14.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),


### PR DESCRIPTION
`package:snapd/snapd.dart` added more options to the find method
Regenerating mocks added these lines
Is this the right way to regenerate mocks on the main branch? Via PR?