### PR TITLE
fix: unify divider thickness

### DIFF
--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -346,120 +346,131 @@ class _ManageSnapTile extends ConsumerWidget {
     final daysSinceUpdate = snap.installDate != null
         ? DateTime.now().difference(snap.installDate!).inDays
         : null;
+    const radius = Radius.circular(8);
 
-    return ListTile(
-      key: ValueKey(snap.id),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      shape: switch (position) {
-        ManageTilePosition.first => RoundedRectangleBorder(
-            borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(8),
-              topRight: Radius.circular(8),
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: switch (position) {
+          ManageTilePosition.first =>
+            const BorderRadius.only(topLeft: radius, topRight: radius),
+          ManageTilePosition.middle => BorderRadius.zero,
+          ManageTilePosition.last =>
+            const BorderRadius.only(bottomLeft: radius, bottomRight: radius),
+          ManageTilePosition.single => BorderRadius.zero,
+        },
+        border: switch (position) {
+          ManageTilePosition.first => Border(
+              top: border,
+              left: border,
+              right: border,
+              bottom: border,
             ),
-            side: border,
-          ),
-        ManageTilePosition.middle => RoundedRectangleBorder(
-            side: border,
-          ),
-        ManageTilePosition.last => RoundedRectangleBorder(
-            borderRadius: const BorderRadius.only(
-              bottomLeft: Radius.circular(8),
-              bottomRight: Radius.circular(8),
+          ManageTilePosition.middle => Border(
+              left: border,
+              right: border,
+              bottom: border,
             ),
-            side: border,
-          ),
-        ManageTilePosition.single => RoundedRectangleBorder(
-            borderRadius: const BorderRadius.all(Radius.circular(8)),
-            side: border,
-          ),
-      },
-      leading: Clickable(
-        onTap: () => StoreNavigator.pushSnap(context, name: snap.name),
-        child: AppIcon(iconUrl: snap.iconUrl, size: 40),
+          ManageTilePosition.last => Border(
+              bottom: border,
+              left: border,
+              right: border,
+            ),
+          ManageTilePosition.single =>
+            const Border.fromBorderSide(BorderSide.none),
+        },
       ),
-      title: Row(
-        children: [
-          Expanded(
-            flex: 2,
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: Clickable(
-                onTap: () => StoreNavigator.pushSnap(context, name: snap.name),
-                child: Text(
-                  snap.titleOrName,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+      child: ListTile(
+        key: ValueKey(snap.id),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        leading: Clickable(
+          onTap: () => StoreNavigator.pushSnap(context, name: snap.name),
+          child: AppIcon(iconUrl: snap.iconUrl, size: 40),
+        ),
+        title: Row(
+          children: [
+            Expanded(
+              flex: 2,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Clickable(
+                  onTap: () =>
+                      StoreNavigator.pushSnap(context, name: snap.name),
+                  child: Text(
+                    snap.titleOrName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
               ),
             ),
-          ),
-          if (ResponsiveLayout.of(context).type !=
-              ResponsiveLayoutType.small) ...[
-            Expanded(
-              flex: 2,
-              child: daysSinceUpdate != null
-                  ? Text(
-                      l10n.managePageUpdatedDaysAgo(daysSinceUpdate),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    )
-                  : const SizedBox(),
-            ),
-            Expanded(
-              child: snap.installedSize != null
-                  ? Text(
-                      context.formatByteSize(
-                        snap.installedSize!,
-                        precision: 0,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    )
-                  : const SizedBox(),
-            ),
-          ],
-        ],
-      ),
-      subtitle: Column(
-        children: [
-          Row(
-            children: [
-              Text(snap.channel),
-              const SizedBox(width: 4),
-              Text(snap.version),
+            if (ResponsiveLayout.of(context).type !=
+                ResponsiveLayoutType.small) ...[
+              Expanded(
+                flex: 2,
+                child: daysSinceUpdate != null
+                    ? Text(
+                        l10n.managePageUpdatedDaysAgo(daysSinceUpdate),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : const SizedBox(),
+              ),
+              Expanded(
+                child: snap.installedSize != null
+                    ? Text(
+                        context.formatByteSize(
+                          snap.installedSize!,
+                          precision: 0,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : const SizedBox(),
+              ),
             ],
-          ),
-          if (ResponsiveLayout.of(context).type == ResponsiveLayoutType.small)
+          ],
+        ),
+        subtitle: Column(
+          children: [
             Row(
               children: [
-                Expanded(
-                  child: daysSinceUpdate != null
-                      ? Text(
-                          l10n.managePageUpdatedDaysAgo(daysSinceUpdate),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        )
-                      : const SizedBox(),
-                ),
-                Expanded(
-                  child: snap.installedSize != null
-                      ? Text(
-                          context.formatByteSize(
-                            snap.installedSize!,
-                            precision: 0,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        )
-                      : const SizedBox(),
-                ),
+                Text(snap.channel),
+                const SizedBox(width: 4),
+                Text(snap.version),
               ],
-            )
-        ],
+            ),
+            if (ResponsiveLayout.of(context).type == ResponsiveLayoutType.small)
+              Row(
+                children: [
+                  Expanded(
+                    child: daysSinceUpdate != null
+                        ? Text(
+                            l10n.managePageUpdatedDaysAgo(daysSinceUpdate),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          )
+                        : const SizedBox(),
+                  ),
+                  Expanded(
+                    child: snap.installedSize != null
+                        ? Text(
+                            context.formatByteSize(
+                              snap.installedSize!,
+                              precision: 0,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          )
+                        : const SizedBox(),
+                  ),
+                ],
+              )
+          ],
+        ),
+        trailing: showUpdateButton
+            ? buildButtonBarForUpdate(ref, l10n, snapLauncher, context)
+            : buildButtonBarForOpen(ref, l10n, snapLauncher, context),
       ),
-      trailing: showUpdateButton
-          ? buildButtonBarForUpdate(ref, l10n, snapLauncher, context)
-          : buildButtonBarForOpen(ref, l10n, snapLauncher, context),
     );
   }
 

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -195,7 +195,7 @@ class _SnapView extends ConsumerWidget {
                       ],
                     ),
                     const SizedBox(height: 32),
-                    const Divider(height: 2),
+                    const Divider(),
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 32),
                       child: _SnapInfoBar(
@@ -204,7 +204,7 @@ class _SnapView extends ConsumerWidget {
                         layout: layout,
                       ),
                     ),
-                    const Divider(height: 2),
+                    const Divider(),
                     const SizedBox(height: 48),
                     if (snapModel.hasGallery) ...[
                       _Section(
@@ -224,7 +224,7 @@ class _SnapView extends ConsumerWidget {
                           ),
                         ),
                       ),
-                      const Divider(height: 2),
+                      const Divider(),
                       const SizedBox(height: 48),
                     ],
                     _Section(

--- a/packages/app_center/lib/src/store/store_pages.dart
+++ b/packages/app_center/lib/src/store/store_pages.dart
@@ -41,7 +41,7 @@ final pages = <StorePage>[
     pageBuilder: (_) => const SizedBox.shrink(),
   ),
   (
-    tileBuilder: (context, selected) => const Divider(height: 1),
+    tileBuilder: (context, selected) => const Divider(),
     pageBuilder: (_) => const SizedBox.shrink(),
   ),
   (


### PR DESCRIPTION
The borders are sometimes 2 sometimes 1 pixel thick.
In yaru.dart we unified this to 1.

This unifies the dividers in the store app to 1.

This is mostly visible on the manage page.

Before:
![grafik](https://github.com/ubuntu/app-center/assets/15329494/90ca60c1-3798-4131-9030-11c3fc4ff8e7)


After:
![grafik](https://github.com/ubuntu/app-center/assets/15329494/08e84da5-303f-45a0-bed3-6b11a1ab10b6)
