### PR TITLE
snap_page: version not updated based on channel

### DIFF
--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -121,7 +121,7 @@ class _SnapView extends ConsumerWidget {
       ),
       (
         label: l10n.snapPageVersionLabel,
-        value: Text(snapModel.channelInfo!.version),
+        value: Text(snapModel.channelInfo?.version ?? snapModel.snap.version),
       ),
       (
         label: l10n.snapPagePublishedLabel,

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -121,7 +121,7 @@ class _SnapView extends ConsumerWidget {
       ),
       (
         label: l10n.snapPageVersionLabel,
-        value: Text(snapModel.snap.version),
+        value: Text(snapModel.channelInfo!.version),
       ),
       (
         label: l10n.snapPagePublishedLabel,

--- a/packages/app_center/test/snap_page_test.dart
+++ b/packages/app_center/test/snap_page_test.dart
@@ -79,6 +79,7 @@ void expectSnapInfos(
   expect(find.text(tester.l10n.snapPageConfinementLabel), findsOneWidget);
   expect(find.text(tester.l10n.snapPageDescriptionLabel), findsOneWidget);
   expect(find.text(tester.l10n.snapPageLicenseLabel), findsOneWidget);
+  expect(find.text(tester.l10n.snapPageVersionLabel), findsOneWidget);
   expect(find.text(tester.l10n.snapPagePublishedLabel), findsOneWidget);
 
   final snapChannel = snap.channels[channel];


### PR DESCRIPTION
In my previous PR, I added a new entry in the `snapInfoBar`, that was `version`. But, I showed it from `snap.version`, which didn't update when the channel is changed. So, changed the version to `channel.version`. Sorry for the previous inconvenience. 

EDIT: for local snaps, the channels doesn't exit which fails the test. So, if `channelInfo.version` doesn't exist, fallbacking to `snap.version`.