### PR TITLE
ci: Produce snap artifact every build, not just on manual runs

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: snapcore/action-build@v1
         id: snapcraft
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'workflow_dispatch'
         with:
           name: 'snap'
           path: ${{steps.snapcraft.outputs.snap}}


### PR DESCRIPTION
The workflow that builds the Snap only actually uploads the artifact on manual runs. It would be useful to produce an artifact every build to aid in testing ability, especially for those who don't want to checkout the code themselves.

This PR removes the `workflow_dispatch` condition of the artifact upload so that it should produce an artifact every time it runs.

You can even see the artifact produced for this PR with this change!: https://github.com/ubuntu/app-center/actions/runs/7890140289?pr=1599