### PR TITLE
fix(snapcraft): revert to original fix ignoring pub errors

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -5,7 +5,6 @@ packages:
 
 command:
   bootstrap:
-    runPubGetInParallel: true
     environment:
       sdk: '>=3.1.0 <4.0.0'
       flutter: 3.16.4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,10 +37,14 @@ parts:
     override-build: |
       set -eux
       dart pub global activate melos
+
+      set +e # ignore pub errors
       # when building locally artifacts can pollute the container and cause builds to fail
       # this helps increase reliability for local builds
       dart pub global run melos clean
       dart pub global run melos bootstrap
+      set -e
+
       cd packages/app_center
       flutter build linux --release -v
       mkdir -p $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,12 +36,12 @@ parts:
     plugin: nil
     override-build: |
       set -eux
-      sed -i 's/runPubGetInParallel: true/runPubGetInParallel: false/g' melos.yaml
       dart pub global activate melos
       # when building locally artifacts can pollute the container and cause builds to fail
       # this helps increase reliability for local builds
       dart pub global run melos clean
       dart pub global run melos bootstrap
+      sed -i 's/runPubGetInParallel: true/runPubGetInParallel: false/g' melos.yaml
       cd packages/app_center
       flutter build linux --release -v
       mkdir -p $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,6 @@ parts:
       # this helps increase reliability for local builds
       dart pub global run melos clean
       dart pub global run melos bootstrap
-      sed -i 's/runPubGetInParallel: true/runPubGetInParallel: false/g' melos.yaml
       cd packages/app_center
       flutter build linux --release -v
       mkdir -p $CRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
Sorry for the noise, seems like disabling parallel `pub get`s doesn't realiably fix the [build issues](https://launchpad.net/~desktop-snappers/+snap/app-center/+build/2396810). This reintroduces the `set +/-e` commands (removed in #1519) to ignore the potential stack overflow during `pub get`.