### PR TITLE
chore: update flutter, yaru, handy_window

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.16.4-stable
+flutter 3.19.3-stable

--- a/melos.yaml
+++ b/melos.yaml
@@ -7,7 +7,7 @@ command:
   bootstrap:
     environment:
       sdk: '>=3.1.0 <4.0.0'
-      flutter: 3.16.4
+      flutter: '>=3.19.0'
 
     dev_dependencies:
       ubuntu_lints: ^0.3.0

--- a/packages/app_center/integration_test/app_center_test.dart
+++ b/packages/app_center/integration_test/app_center_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
-import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru/icons.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 import '../test/test_utils.dart';

--- a/packages/app_center/lib/main.dart
+++ b/packages/app_center/lib/main.dart
@@ -19,7 +19,7 @@ import 'package:snapcraft_launcher/snapcraft_launcher.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 Future<void> main(List<String> args) async {
   await YaruWindowTitleBar.ensureInitialized();

--- a/packages/app_center/lib/src/about/about_page.dart
+++ b/packages/app_center/lib/src/about/about_page.dart
@@ -9,8 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github/github.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:url_launcher/url_launcher_string.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 class AboutPage extends StatelessWidget {
   const AboutPage({super.key});

--- a/packages/app_center/lib/src/deb/deb_page.dart
+++ b/packages/app_center/lib/src/deb/deb_page.dart
@@ -16,8 +16,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:url_launcher/url_launcher_string.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 const _kPrimaryButtonMaxWidth = 136.0;
 

--- a/packages/app_center/lib/src/explore/explore_page.dart
+++ b/packages/app_center/lib/src/explore/explore_page.dart
@@ -6,7 +6,7 @@ import 'package:app_center/widgets.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru/yaru.dart';
 
 const kNumberOfBannerSnaps = 3;
 

--- a/packages/app_center/lib/src/games/games_page_external_tools.dart
+++ b/packages/app_center/lib/src/games/games_page_external_tools.dart
@@ -5,7 +5,7 @@ import 'package:app_center/src/snapd/snap_category_enum.dart';
 import 'package:app_center/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 class ExternalTools extends StatelessWidget {
   const ExternalTools({super.key});

--- a/packages/app_center/lib/src/games/games_page_featured.dart
+++ b/packages/app_center/lib/src/games/games_page_featured.dart
@@ -4,8 +4,7 @@ import 'package:app_center/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:snapd/snapd.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 class FeaturedCarousel extends ConsumerStatefulWidget {
   const FeaturedCarousel({

--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -12,8 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 class ManagePage extends ConsumerStatefulWidget {
   const ManagePage({super.key});

--- a/packages/app_center/lib/src/search/search_field.dart
+++ b/packages/app_center/lib/src/search/search_field.dart
@@ -7,8 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:snapd/snapd.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 sealed class AutoCompleteOption {
   String get title => switch (this) {

--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -10,7 +10,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 // TODO: break down into smaller widgets
 class SearchPage extends StatelessWidget {

--- a/packages/app_center/lib/src/snapd/snap_category_enum.dart
+++ b/packages/app_center/lib/src/snapd/snap_category_enum.dart
@@ -1,7 +1,7 @@
 import 'package:app_center/l10n.dart';
 import 'package:flutter/widgets.dart';
 import 'package:snapd/snapd.dart';
-import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru/icons.dart';
 
 extension SnapCategoryX on SnapCategory {
   SnapCategoryEnum get categoryEnum => name.toSnapCategoryEnum();

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -18,8 +18,7 @@ import 'package:intl/intl.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:url_launcher/url_launcher_string.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 const _kPrimaryButtonMaxWidth = 136.0;
 const _kChannelDropdownWidth = 220.0;

--- a/packages/app_center/lib/src/snapd/snap_report.dart
+++ b/packages/app_center/lib/src/snapd/snap_report.dart
@@ -197,6 +197,8 @@ class _SnapReportState extends State<SnapReport> {
                             'Snap reporting for snap "${widget.name}" failed with HTTP Code ${response.statusCode}');
                       }
                       if (mounted) {
+                        // TODO: fix async gap
+                        // ignore: use_build_context_synchronously
                         Navigator.of(context).pop();
                       }
                     },

--- a/packages/app_center/lib/src/store/store_app.dart
+++ b/packages/app_center/lib/src/store/store_app.dart
@@ -13,7 +13,6 @@ import 'package:flutter/material.dart' hide AboutDialog, showAboutDialog;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru/yaru.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 // Making a provider to provide navigatorKeyTwo
 final materialAppNavigatorKeyProvider =

--- a/packages/app_center/lib/src/store/store_pages.dart
+++ b/packages/app_center/lib/src/store/store_pages.dart
@@ -7,7 +7,7 @@ import 'package:app_center/search.dart';
 import 'package:app_center/snapd.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 final displayedCategories = [
   SnapCategoryEnum.featured,

--- a/packages/app_center/lib/src/widgets/app_card.dart
+++ b/packages/app_center/lib/src/widgets/app_card.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:snapd/snapd.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 class AppCard extends StatelessWidget {
   const AppCard({

--- a/packages/app_center/lib/src/widgets/app_icon.dart
+++ b/packages/app_center/lib/src/widgets/app_icon.dart
@@ -4,7 +4,7 @@ import 'package:app_center/xdg_cache_manager.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru/icons.dart';
 
 class AppIcon extends StatelessWidget {
   const AppIcon({

--- a/packages/app_center/lib/src/widgets/dialogs.dart
+++ b/packages/app_center/lib/src/widgets/dialogs.dart
@@ -1,7 +1,7 @@
 import 'package:app_center/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru/icons.dart';
 
 const kMaxWidth = 500.0;
 

--- a/packages/app_center/lib/src/widgets/screenshot_gallery.dart
+++ b/packages/app_center/lib/src/widgets/screenshot_gallery.dart
@@ -2,8 +2,7 @@ import 'package:app_center/xdg_cache_manager.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
+import 'package:yaru/yaru.dart';
 
 class ScreenshotGallery extends StatelessWidget {
   const ScreenshotGallery({

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.1.0 <4.0.0'
-  flutter: 3.16.4
+  flutter: '>=3.19.0'
 
 dependencies:
   app_center_ratings_client: ^1.0.0
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.17.2
   crypto: ^3.0.3
   dbus: ^0.7.10
-  file: ^6.1.4
+  file: ^7.0.0
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.3.1
@@ -28,7 +28,7 @@ dependencies:
   github: ^9.20.0
   glib: ^0.0.1
   gtk: ^2.1.0
-  handy_window: ^0.3.1
+  handy_window: ^0.4.0
   http: ^1.1.2
   intl: ^0.18.1
   jwt_decode: ^0.3.1
@@ -44,13 +44,11 @@ dependencies:
   ubuntu_logger: ^0.1.0
   ubuntu_service: ^0.3.0
   ubuntu_test: ^0.1.0-0
-  ubuntu_widgets: ^0.3.2
+  ubuntu_widgets: ^0.4.0
   url_launcher: ^6.2.1
   xdg_directories: ^1.0.3
-  yaru: ^1.2.0
-  yaru_icons: ^2.3.0
-  yaru_test: ^0.1.5
-  yaru_widgets: ^3.4.0
+  yaru: ^4.0.0
+  yaru_test: ^0.1.6
   yaru_window: ^0.2.0
 
 dev_dependencies:

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -7,8 +7,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:snapd/snapd.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_test/yaru_test.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'test_utils.dart';
 

--- a/packages/app_center/test/snap_page_test.dart
+++ b/packages/app_center/test/snap_page_test.dart
@@ -10,8 +10,7 @@ import 'package:intl/intl.dart';
 import 'package:mockito/mockito.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
-import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/widgets.dart';
+import 'package:yaru/yaru.dart';
 
 import 'test_utils.dart';
 

--- a/packages/app_center/test/store_app_test.dart
+++ b/packages/app_center/test/store_app_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gtk/gtk.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:yaru_widgets/widgets.dart';
+import 'package:yaru/yaru.dart';
 
 import 'test_utils.dart';
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ version: git
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.16.4
+    source-tag: 3.19.3
     source-depth: 1
     plugin: nil
     override-build: |


### PR DESCRIPTION
- for yaru yaru test and ubuntu widgets needed an update
- for which flutter  and file needed to be updated
- additionally updated handy_window to align gtk theme with yaru.dart

@BLKKKBVSIK 
looked for the workflow files, but apparently didnt find where you set up the flutter version? in some other repo/script?