### PR TITLE
chore: Format time since last update as days, months or years

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -42,6 +42,30 @@
             }
         }
     },
+    "managePageUpdatedWeeksAgo": "Updated {n, plural, =1{{n} week} other{{n} weeks}} ago",
+    "@managePageUpdatedWeeksAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int"
+            }
+        }
+    },
+    "managePageUpdatedMonthsAgo": "Updated {n, plural, =1{{n} month} other{{n} months}} ago",
+    "@managePageUpdatedMonthsAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int"
+            }
+        }
+    },
+    "managePageUpdatedYearsAgo": "Updated {n, plural, =1{{n} year} other{{n} years}} ago",
+    "@managePageUpdatedYearsAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int"
+            }
+        }
+    },
     "managePageUpdatesAvailable": "Updates available ({n})",
     "@managePageUpdatesAvaialble": {
         "placeholders": {

--- a/packages/app_center/lib/src/manage/manage_l10n.dart
+++ b/packages/app_center/lib/src/manage/manage_l10n.dart
@@ -1,0 +1,23 @@
+import 'package:app_center/l10n.dart';
+
+extension ManagePageUpdateSinceDateTimeAgo on Duration {
+  /// Formats the time since last updates as inDays, weeks, months or years.
+  String managePageUpdateSinceDateTimeAgo(AppLocalizations localizations) {
+    if (inDays < 7) {
+      return localizations.managePageUpdatedDaysAgo(inDays);
+    }
+
+    final weeks = inDays ~/ 7;
+    if (weeks < 5) {
+      return localizations.managePageUpdatedWeeksAgo(weeks);
+    }
+
+    final months = inDays ~/ 30.42;
+    if (months < 12) {
+      return localizations.managePageUpdatedMonthsAgo(months);
+    }
+
+    final years = inDays ~/ 365;
+    return localizations.managePageUpdatedYearsAgo(years);
+  }
+}

--- a/packages/app_center/lib/src/manage/manage_page.dart
+++ b/packages/app_center/lib/src/manage/manage_page.dart
@@ -5,6 +5,7 @@ import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/snapd.dart';
 import 'package:app_center/src/manage/local_snap_providers.dart';
+import 'package:app_center/src/manage/manage_l10n.dart';
 import 'package:app_center/src/manage/manage_model.dart';
 import 'package:app_center/store.dart';
 import 'package:app_center/widgets.dart';
@@ -342,8 +343,8 @@ class _ManageSnapTile extends ConsumerWidget {
     final snapLauncher = ref.watch(launchProvider(snap));
     final l10n = AppLocalizations.of(context);
     final border = BorderSide(color: Theme.of(context).colorScheme.outline);
-    final daysSinceUpdate = snap.installDate != null
-        ? DateTime.now().difference(snap.installDate!).inDays
+    final dateTimeSinceUpdate = snap.installDate != null
+        ? DateTime.now().difference(snap.installDate!)
         : null;
     const radius = Radius.circular(8);
 
@@ -406,9 +407,10 @@ class _ManageSnapTile extends ConsumerWidget {
                 ResponsiveLayoutType.small) ...[
               Expanded(
                 flex: 2,
-                child: daysSinceUpdate != null
+                child: dateTimeSinceUpdate != null
                     ? Text(
-                        l10n.managePageUpdatedDaysAgo(daysSinceUpdate),
+                        dateTimeSinceUpdate
+                            .managePageUpdateSinceDateTimeAgo(l10n),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       )
@@ -442,9 +444,10 @@ class _ManageSnapTile extends ConsumerWidget {
               Row(
                 children: [
                   Expanded(
-                    child: daysSinceUpdate != null
+                    child: dateTimeSinceUpdate != null
                         ? Text(
-                            l10n.managePageUpdatedDaysAgo(daysSinceUpdate),
+                            dateTimeSinceUpdate
+                                .managePageUpdateSinceDateTimeAgo(l10n),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                           )


### PR DESCRIPTION
Hi there ✌️ I'm a huge fan of the new app center. Thank you very much for developing. Maybe I can contribute a little bit?

The time since the last update
is only displayed in days right
now, while it could be nice
to also have it in months and
years.

I was not sure where to put the logic for the formatted string
calculation. If you know a
better place like a /utils directory
 that I might have overseen,
please ping me and I will
change it.

![Bildschirmfoto vom 2024-03-29 08-59-35](https://github.com/ubuntu/app-center/assets/24619905/a0236cc0-4b33-4bc7-9b94-8cca7c20a41f)
