### PR TITLE
docs: Fix Weblate link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ PRs will trigger unit and integration tests with and without race detection, lin
 
 ## Translations
 
-Translations are managed using [Weblate](https://hosted.weblate.org/projects/ubuntu-software/app-center/)
+Translations are managed using [Weblate](https://hosted.weblate.org/projects/ubuntu-desktop-translations/app-center/)
 
 ## Contributing to the code
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [codecov-image]: https://codecov.io/gh/ubuntu/app-center/graph/badge.svg?token=E7rXg31KRk
 [codecov-url]: https://codecov.io/gh/ubuntu/app-center
 
-[weblate-image]: https://hosted.weblate.org/widget/ubuntu-software/app-center/svg-badge.svg
-[weblate-url]: https://hosted.weblate.org/engage/ubuntu-software/
+[weblate-image]: https://hosted.weblate.org/widget/ubuntu-desktop-translations/app-center/svg-badge.svg
+[weblate-url]: https://hosted.weblate.org/projects/ubuntu-desktop-translations/app-center/
 
 
 [![Code quality][actions-image]][actions-url]


### PR DESCRIPTION
It looks like that app-center is now under ubuntu-desktop-translations.

/cc @Feichtmeier @d-loose