### PR TITLE
feat: multisnap progress indicator

### DIFF
--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -189,16 +189,16 @@ class InstallAll extends ConsumerWidget {
         child: Column(
       children: [
         ElevatedButton(
-          onPressed: multiSnapModel.activeChangeIds!.isEmpty
+          onPressed: multiSnapModel.activeChangeIds.isEmpty
               ? multiSnapModel.installAll
               : null,
           child: Text(l10n.installAll),
         ),
-        if (multiSnapModel.activeChangeIds!.isNotEmpty) ...[
+        if (multiSnapModel.activeChangeIds.isNotEmpty) ...[
           const SizedBox(height: kPagePadding),
           LinearProgressIndicator(
               value: ref
-                  .watch(multiProgressProvider(multiSnapModel.activeChangeIds!))
+                  .watch(multiProgressProvider(multiSnapModel.activeChangeIds))
                   .whenOrNull(data: (data) => data))
         ]
       ],

--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -35,8 +35,13 @@ class SearchPage extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (Navigator.of(context).canPop())
-                  const YaruBackButton(
-                    style: YaruBackButtonStyle.rounded,
+                  const Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      YaruBackButton(
+                        style: YaruBackButtonStyle.rounded,
+                      ),
+                    ],
                   ),
                 if (query != null)
                   Text(
@@ -131,7 +136,10 @@ class SearchPage extends StatelessWidget {
                 if (initialCategory == SnapCategoryEnum.gameDev ||
                     initialCategory == SnapCategoryEnum.gameEmulators ||
                     initialCategory == SnapCategoryEnum.gnomeGames ||
-                    initialCategory == SnapCategoryEnum.kdeGames) ...[
+                    initialCategory == SnapCategoryEnum.kdeGames ||
+                    initialCategory == SnapCategoryEnum.gameLaunchers ||
+                    initialCategory ==
+                        SnapCategoryEnum.gameContentCreation) ...[
                   const SizedBox(height: kPagePadding),
                   InstallAll(initialCategory: initialCategory),
                 ]
@@ -173,9 +181,22 @@ class InstallAll extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final multiSnapModel = ref.watch(multiSnapModelProvider(initialCategory!));
     return Center(
-        child: ElevatedButton(
-      onPressed: multiSnapModel.installAll,
-      child: Text(l10n.installAll),
+        child: Column(
+      children: [
+        ElevatedButton(
+          onPressed: multiSnapModel.activeChangeIds!.isEmpty
+              ? multiSnapModel.installAll
+              : null,
+          child: Text(l10n.installAll),
+        ),
+        if (multiSnapModel.activeChangeIds!.isNotEmpty) ...[
+          const SizedBox(height: kPagePadding),
+          LinearProgressIndicator(
+              value: ref
+                  .watch(multiProgressProvider(multiSnapModel.activeChangeIds!))
+                  .whenOrNull(data: (data) => data))
+        ]
+      ],
     ));
   }
 }

--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -188,19 +188,24 @@ class InstallAll extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ElevatedButton(
-          onPressed: multiSnapModel.activeChangeIds.isEmpty
-              ? multiSnapModel.installAll
-              : null,
-          child: Text(l10n.installAll),
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: multiSnapModel.activeChangeIds.isEmpty
+                  ? multiSnapModel.installAll
+                  : null,
+              child: Text(l10n.installAll),
+            ),
+            if (multiSnapModel.activeChangeIds.isNotEmpty) ...[
+              const SizedBox(width: kPagePadding),
+              CircularProgressIndicator(
+                  value: ref
+                      .watch(
+                          multiProgressProvider(multiSnapModel.activeChangeIds))
+                      .whenOrNull(data: (data) => data))
+            ]
+          ],
         ),
-        if (multiSnapModel.activeChangeIds.isNotEmpty) ...[
-          const SizedBox(height: kPagePadding),
-          LinearProgressIndicator(
-              value: ref
-                  .watch(multiProgressProvider(multiSnapModel.activeChangeIds))
-                  .whenOrNull(data: (data) => data))
-        ]
       ],
     );
   }

--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -185,8 +185,8 @@ class InstallAll extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final multiSnapModel = ref.watch(multiSnapModelProvider(initialCategory!));
-    return Center(
-        child: Column(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         ElevatedButton(
           onPressed: multiSnapModel.activeChangeIds.isEmpty
@@ -202,7 +202,7 @@ class InstallAll extends ConsumerWidget {
                   .whenOrNull(data: (data) => data))
         ]
       ],
-    ));
+    );
   }
 }
 

--- a/packages/app_center/lib/src/search/search_page.dart
+++ b/packages/app_center/lib/src/search/search_page.dart
@@ -141,7 +141,12 @@ class SearchPage extends StatelessWidget {
                     initialCategory ==
                         SnapCategoryEnum.gameContentCreation) ...[
                   const SizedBox(height: kPagePadding),
-                  InstallAll(initialCategory: initialCategory),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      InstallAll(initialCategory: initialCategory),
+                    ],
+                  ),
                 ]
               ],
             ),

--- a/packages/app_center/lib/src/snapd/multisnap_model.dart
+++ b/packages/app_center/lib/src/snapd/multisnap_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:app_center/snapd.dart';
 import 'package:app_center/src/snapd/logger.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +17,28 @@ final multiSnapModelProvider =
   )..init(),
 );
 
+final multiProgressProvider =
+    StreamProvider.family.autoDispose<double, List<String>>((ref, ids) {
+  final snapd = getService<SnapdService>();
+
+  final streamController = StreamController<double>.broadcast();
+  final subProgresses = <String, double>{for (final id in ids) id: 0.0};
+  final subscriptions = <String, StreamSubscription<SnapdChange>>{
+    for (final id in ids)
+      id: snapd.watchChange(id).listen((change) {
+        subProgresses[id] = change.progress;
+        streamController.add(subProgresses.values.sum / subProgresses.length);
+      })
+  };
+  ref.onDispose(() {
+    for (final subscription in subscriptions.values) {
+      subscription.cancel();
+    }
+    streamController.close();
+  });
+  return streamController.stream;
+});
+
 class MultiSnapModel extends ChangeNotifier {
   MultiSnapModel({
     required this.snapd,
@@ -24,8 +47,7 @@ class MultiSnapModel extends ChangeNotifier {
   final SnapdService snapd;
   final SnapCategoryEnum category;
 
-  String? get activeChangeId => _activeChangeId;
-  String? _activeChangeId;
+  List<String>? activeChangeIds = [];
 
   AsyncValue<void> get state => _state;
   AsyncValue<void> _state;
@@ -39,6 +61,7 @@ class MultiSnapModel extends ChangeNotifier {
     final storeSnapCompleter = Completer();
     _storeSnapSubscription =
         snapd.getStoreSnaps(category.featuredSnapNames!).listen((snaps) {
+      categorySnaps = [];
       categorySnaps.addAll(snaps);
       if (!storeSnapCompleter.isCompleted) storeSnapCompleter.complete();
       notifyListeners();
@@ -63,7 +86,7 @@ class MultiSnapModel extends ChangeNotifier {
     log.error('Caught exception for snap bundle "$category"', e);
   }
 
-  Future<void> _snapAction(Future<String> Function() action) async {
+  Future<void> _snapAction(Future<List<String>?> Function() action) async {
     try {
       await action.call();
       notifyListeners();
@@ -73,8 +96,10 @@ class MultiSnapModel extends ChangeNotifier {
   }
 
   Future<void> cancel() async {
-    if (activeChangeId == null) return;
-    await snapd.abortChange(activeChangeId!);
+    if (activeChangeIds!.isEmpty) return;
+    for (final changeId in activeChangeIds!) {
+      await snapd.abortChange(changeId);
+    }
   }
 
   Future<void> installAll() {
@@ -83,31 +108,30 @@ class MultiSnapModel extends ChangeNotifier {
     return _snapAction(() => _installAllSnaps(categorySnaps));
   }
 
-  Future<String> _installAllSnaps(List<Snap> snaps) async {
+  Future<List<String>?> _installAllSnaps(List<Snap> snaps) async {
     final classicSnaps = snaps
         .where((snap) => snap.confinement == SnapConfinement.classic)
         .toList();
     final strictSnaps = snaps
         .where((snap) => snap.confinement == SnapConfinement.strict)
         .toList();
-    final changeIds = List<String>.empty(growable: true);
     if (classicSnaps.isNotEmpty) {
       final changeId =
           await snapd.install(classicSnaps.first.name, classic: true);
       final change = await snapd.getChange(changeId);
-      changeIds.add(changeId);
+      activeChangeIds!.add(changeId);
       if (['Do', 'Doing', 'Done'].contains(change.status)) {
         for (var i = 1; i < classicSnaps.length; i++) {
-          changeIds
+          activeChangeIds!
               .add(await snapd.install(classicSnaps[i].name, classic: true));
         }
-        changeIds.add(await snapd
+        activeChangeIds!.add(await snapd
             .installMany(strictSnaps.map((snap) => snap.name).toList()));
       }
     } else {
-      changeIds.add(await snapd
+      activeChangeIds!.add(await snapd
           .installMany(strictSnaps.map((snap) => snap.name).toList()));
     }
-    return changeIds.last;
+    return activeChangeIds;
   }
 }

--- a/packages/app_center/lib/src/snapd/multisnap_model.dart
+++ b/packages/app_center/lib/src/snapd/multisnap_model.dart
@@ -47,7 +47,8 @@ class MultiSnapModel extends ChangeNotifier {
   final SnapdService snapd;
   final SnapCategoryEnum category;
 
-  UnmodifiableListView<String> get activeChangeIds => UnmodifiableListView(_activeChangeIds);
+  UnmodifiableListView<String> get activeChangeIds =>
+      UnmodifiableListView(_activeChangeIds);
   final List<String> _activeChangeIds = [];
 
   AsyncValue<void> get state => _state;
@@ -98,7 +99,7 @@ class MultiSnapModel extends ChangeNotifier {
 
   Future<void> cancel() async {
     if (_activeChangeIds.isEmpty) return;
-    for (final changeId in _activeChangeIds!) {
+    for (final changeId in _activeChangeIds) {
       await snapd.abortChange(changeId);
     }
   }

--- a/packages/app_center/lib/src/snapd/multisnap_model.dart
+++ b/packages/app_center/lib/src/snapd/multisnap_model.dart
@@ -47,7 +47,8 @@ class MultiSnapModel extends ChangeNotifier {
   final SnapdService snapd;
   final SnapCategoryEnum category;
 
-  List<String>? activeChangeIds = [];
+  UnmodifiableListView<String> get activeChangeIds => UnmodifiableListView(_activeChangeIds);
+  final List<String> _activeChangeIds = [];
 
   AsyncValue<void> get state => _state;
   AsyncValue<void> _state;
@@ -96,8 +97,8 @@ class MultiSnapModel extends ChangeNotifier {
   }
 
   Future<void> cancel() async {
-    if (activeChangeIds!.isEmpty) return;
-    for (final changeId in activeChangeIds!) {
+    if (_activeChangeIds.isEmpty) return;
+    for (final changeId in _activeChangeIds!) {
       await snapd.abortChange(changeId);
     }
   }
@@ -119,19 +120,19 @@ class MultiSnapModel extends ChangeNotifier {
       final changeId =
           await snapd.install(classicSnaps.first.name, classic: true);
       final change = await snapd.getChange(changeId);
-      activeChangeIds!.add(changeId);
+      _activeChangeIds.add(changeId);
       if (['Do', 'Doing', 'Done'].contains(change.status)) {
         for (var i = 1; i < classicSnaps.length; i++) {
-          activeChangeIds!
+          _activeChangeIds
               .add(await snapd.install(classicSnaps[i].name, classic: true));
         }
-        activeChangeIds!.add(await snapd
+        _activeChangeIds.add(await snapd
             .installMany(strictSnaps.map((snap) => snap.name).toList()));
       }
     } else {
-      activeChangeIds!.add(await snapd
+      _activeChangeIds.add(await snapd
           .installMany(strictSnaps.map((snap) => snap.name).toList()));
     }
-    return activeChangeIds;
+    return _activeChangeIds;
   }
 }

--- a/packages/app_center/test/test_utils.dart
+++ b/packages/app_center/test/test_utils.dart
@@ -381,5 +381,6 @@ MockPackageKitService createMockPackageKitService({
 @GenerateMocks([MultiSnapModel])
 MultiSnapModel createMockMultiSnapModel() {
   final model = MockMultiSnapModel();
+  when(model.activeChangeIds).thenAnswer((_) => UnmodifiableListView([]));
   return model;
 }

--- a/packages/app_center/test/test_utils.mocks.dart
+++ b/packages/app_center/test/test_utils.mocks.dart
@@ -2656,6 +2656,15 @@ class MockMultiSnapModel extends _i1.Mock implements _i23.MultiSnapModel {
       ) as _i6.SnapCategoryEnum);
 
   @override
+  set activeChangeIds(List<String>? _activeChangeIds) => super.noSuchMethod(
+        Invocation.setter(
+          #activeChangeIds,
+          _activeChangeIds,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   List<_i2.Snap> get categorySnaps => (super.noSuchMethod(
         Invocation.getter(#categorySnaps),
         returnValue: <_i2.Snap>[],

--- a/packages/app_center/test/test_utils.mocks.dart
+++ b/packages/app_center/test/test_utils.mocks.dart
@@ -3,28 +3,29 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i15;
+import 'dart:collection' as _i12;
+import 'dart:ui' as _i16;
 
 import 'package:app_center/appstream.dart' as _i7;
 import 'package:app_center/packagekit.dart' as _i8;
 import 'package:app_center/snapd.dart' as _i6;
-import 'package:app_center/src/deb/deb_model.dart' as _i16;
-import 'package:app_center/src/manage/manage_model.dart' as _i17;
-import 'package:app_center/src/ratings/exports.dart' as _i21;
-import 'package:app_center/src/ratings/ratings_model.dart' as _i12;
+import 'package:app_center/src/deb/deb_model.dart' as _i17;
+import 'package:app_center/src/manage/manage_model.dart' as _i18;
+import 'package:app_center/src/ratings/exports.dart' as _i22;
+import 'package:app_center/src/ratings/ratings_model.dart' as _i13;
 import 'package:app_center/src/ratings/ratings_service.dart' as _i4;
-import 'package:app_center/src/snapd/multisnap_model.dart' as _i23;
+import 'package:app_center/src/snapd/multisnap_model.dart' as _i24;
 import 'package:app_center_ratings_client/app_center_ratings_client.dart'
     as _i11;
-import 'package:app_center_ratings_client/src/chart.dart' as _i22;
+import 'package:app_center_ratings_client/src/chart.dart' as _i23;
 import 'package:appstream/appstream.dart' as _i9;
-import 'package:dbus/dbus.dart' as _i20;
-import 'package:file/file.dart' as _i18;
+import 'package:dbus/dbus.dart' as _i21;
+import 'package:file/file.dart' as _i19;
 import 'package:flutter_riverpod/flutter_riverpod.dart' as _i5;
-import 'package:gtk/src/gtk_application_notifier.dart' as _i19;
+import 'package:gtk/src/gtk_application_notifier.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i13;
+import 'package:mockito/src/dummies.dart' as _i14;
 import 'package:packagekit/packagekit.dart' as _i10;
 import 'package:snapcraft_launcher/snapcraft_launcher.dart' as _i3;
 import 'package:snapd/snapd.dart' as _i2;
@@ -212,6 +213,17 @@ class _FakeRating_15 extends _i1.SmartFake implements _i11.Rating {
         );
 }
 
+class _FakeUnmodifiableListView_16<E> extends _i1.SmartFake
+    implements _i12.UnmodifiableListView<E> {
+  _FakeUnmodifiableListView_16(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [SnapLauncher].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -257,7 +269,7 @@ class MockSnapLauncher extends _i1.Mock implements _i6.SnapLauncher {
 /// A class which mocks [RatingsModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRatingsModel extends _i1.Mock implements _i12.RatingsModel {
+class MockRatingsModel extends _i1.Mock implements _i13.RatingsModel {
   MockRatingsModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -274,7 +286,7 @@ class MockRatingsModel extends _i1.Mock implements _i12.RatingsModel {
   @override
   String get snapId => (super.noSuchMethod(
         Invocation.getter(#snapId),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#snapId),
         ),
@@ -283,7 +295,7 @@ class MockRatingsModel extends _i1.Mock implements _i12.RatingsModel {
   @override
   String get snapRevision => (super.noSuchMethod(
         Invocation.getter(#snapRevision),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#snapRevision),
         ),
@@ -314,27 +326,27 @@ class MockRatingsModel extends _i1.Mock implements _i12.RatingsModel {
       ) as bool);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> castVote(_i12.VoteStatus? castVote) => (super.noSuchMethod(
+  _i15.Future<void> castVote(_i13.VoteStatus? castVote) => (super.noSuchMethod(
         Invocation.method(
           #castVote,
           [castVote],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -343,7 +355,7 @@ class MockRatingsModel extends _i1.Mock implements _i12.RatingsModel {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -390,7 +402,7 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
   @override
   String get snapName => (super.noSuchMethod(
         Invocation.getter(#snapName),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#snapName),
         ),
@@ -454,10 +466,10 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       );
 
   @override
-  _i14.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
+  _i15.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i14.Stream<_i2.SnapdException>.empty(),
-      ) as _i14.Stream<_i2.SnapdException>);
+        returnValue: _i15.Stream<_i2.SnapdException>.empty(),
+      ) as _i15.Stream<_i2.SnapdException>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -466,67 +478,67 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       ) as bool);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose() => (super.noSuchMethod(
+  _i15.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancel() => (super.noSuchMethod(
+  _i15.Future<void> cancel() => (super.noSuchMethod(
         Invocation.method(
           #cancel,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> install() => (super.noSuchMethod(
+  _i15.Future<void> install() => (super.noSuchMethod(
         Invocation.method(
           #install,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> refresh() => (super.noSuchMethod(
+  _i15.Future<void> refresh() => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> remove() => (super.noSuchMethod(
+  _i15.Future<void> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -535,7 +547,7 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -556,7 +568,7 @@ class MockSnapModel extends _i1.Mock implements _i6.SnapModel {
 /// A class which mocks [DebModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDebModel extends _i1.Mock implements _i16.DebModel {
+class MockDebModel extends _i1.Mock implements _i17.DebModel {
   MockDebModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -582,7 +594,7 @@ class MockDebModel extends _i1.Mock implements _i16.DebModel {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -623,11 +635,11 @@ class MockDebModel extends _i1.Mock implements _i16.DebModel {
       ) as bool);
 
   @override
-  _i14.Stream<_i10.PackageKitErrorCodeEvent> get errorStream =>
+  _i15.Stream<_i10.PackageKitErrorCodeEvent> get errorStream =>
       (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i14.Stream<_i10.PackageKitErrorCodeEvent>.empty(),
-      ) as _i14.Stream<_i10.PackageKitErrorCodeEvent>);
+        returnValue: _i15.Stream<_i10.PackageKitErrorCodeEvent>.empty(),
+      ) as _i15.Stream<_i10.PackageKitErrorCodeEvent>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -636,47 +648,47 @@ class MockDebModel extends _i1.Mock implements _i16.DebModel {
       ) as bool);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> install() => (super.noSuchMethod(
+  _i15.Future<void> install() => (super.noSuchMethod(
         Invocation.method(
           #install,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> remove() => (super.noSuchMethod(
+  _i15.Future<void> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancel() => (super.noSuchMethod(
+  _i15.Future<void> cancel() => (super.noSuchMethod(
         Invocation.method(
           #cancel,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -685,7 +697,7 @@ class MockDebModel extends _i1.Mock implements _i16.DebModel {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -715,7 +727,7 @@ class MockDebModel extends _i1.Mock implements _i16.DebModel {
 /// A class which mocks [ManageModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockManageModel extends _i1.Mock implements _i17.ManageModel {
+class MockManageModel extends _i1.Mock implements _i18.ManageModel {
   MockManageModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -766,14 +778,14 @@ class MockManageModel extends _i1.Mock implements _i17.ManageModel {
       ) as bool);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -785,7 +797,7 @@ class MockManageModel extends _i1.Mock implements _i17.ManageModel {
       );
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -794,7 +806,7 @@ class MockManageModel extends _i1.Mock implements _i17.ManageModel {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -845,25 +857,25 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
       );
 
   @override
-  _i14.Future<void> waitChange(String? changeId) => (super.noSuchMethod(
+  _i15.Future<void> waitChange(String? changeId) => (super.noSuchMethod(
         Invocation.method(
           #waitChange,
           [changeId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> loadAuthorization({String? path}) => (super.noSuchMethod(
+  _i15.Future<void> loadAuthorization({String? path}) => (super.noSuchMethod(
         Invocation.method(
           #loadAuthorization,
           [],
           {#path: path},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setAuthorization(
@@ -882,12 +894,12 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
       );
 
   @override
-  _i14.Future<_i2.SnapdSystemInfoResponse> systemInfo() => (super.noSuchMethod(
+  _i15.Future<_i2.SnapdSystemInfoResponse> systemInfo() => (super.noSuchMethod(
         Invocation.method(
           #systemInfo,
           [],
         ),
-        returnValue: _i14.Future<_i2.SnapdSystemInfoResponse>.value(
+        returnValue: _i15.Future<_i2.SnapdSystemInfoResponse>.value(
             _FakeSnapdSystemInfoResponse_9(
           this,
           Invocation.method(
@@ -895,34 +907,34 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             [],
           ),
         )),
-      ) as _i14.Future<_i2.SnapdSystemInfoResponse>);
+      ) as _i15.Future<_i2.SnapdSystemInfoResponse>);
 
   @override
-  _i14.Future<List<_i2.Snap>> getSnaps() => (super.noSuchMethod(
+  _i15.Future<List<_i2.Snap>> getSnaps() => (super.noSuchMethod(
         Invocation.method(
           #getSnaps,
           [],
         ),
-        returnValue: _i14.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
-      ) as _i14.Future<List<_i2.Snap>>);
+        returnValue: _i15.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
+      ) as _i15.Future<List<_i2.Snap>>);
 
   @override
-  _i14.Future<_i2.Snap> getSnap(String? name) => (super.noSuchMethod(
+  _i15.Future<_i2.Snap> getSnap(String? name) => (super.noSuchMethod(
         Invocation.method(
           #getSnap,
           [name],
         ),
-        returnValue: _i14.Future<_i2.Snap>.value(_FakeSnap_0(
+        returnValue: _i15.Future<_i2.Snap>.value(_FakeSnap_0(
           this,
           Invocation.method(
             #getSnap,
             [name],
           ),
         )),
-      ) as _i14.Future<_i2.Snap>);
+      ) as _i15.Future<_i2.Snap>);
 
   @override
-  _i14.Future<List<_i2.SnapApp>> getApps({
+  _i15.Future<List<_i2.SnapApp>> getApps({
     List<String>? names,
     _i2.SnapdAppFilter? filter,
   }) =>
@@ -935,22 +947,22 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<List<_i2.SnapApp>>.value(<_i2.SnapApp>[]),
-      ) as _i14.Future<List<_i2.SnapApp>>);
+        returnValue: _i15.Future<List<_i2.SnapApp>>.value(<_i2.SnapApp>[]),
+      ) as _i15.Future<List<_i2.SnapApp>>);
 
   @override
-  _i14.Future<List<_i2.SnapdCategoryDetails>> getCategories() =>
+  _i15.Future<List<_i2.SnapdCategoryDetails>> getCategories() =>
       (super.noSuchMethod(
         Invocation.method(
           #getCategories,
           [],
         ),
-        returnValue: _i14.Future<List<_i2.SnapdCategoryDetails>>.value(
+        returnValue: _i15.Future<List<_i2.SnapdCategoryDetails>>.value(
             <_i2.SnapdCategoryDetails>[]),
-      ) as _i14.Future<List<_i2.SnapdCategoryDetails>>);
+      ) as _i15.Future<List<_i2.SnapdCategoryDetails>>);
 
   @override
-  _i14.Future<_i2.SnapdConnectionsResponse> getConnections({
+  _i15.Future<_i2.SnapdConnectionsResponse> getConnections({
     String? snap,
     String? interface,
     _i2.SnapdConnectionFilter? filter,
@@ -965,7 +977,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i2.SnapdConnectionsResponse>.value(
+        returnValue: _i15.Future<_i2.SnapdConnectionsResponse>.value(
             _FakeSnapdConnectionsResponse_10(
           this,
           Invocation.method(
@@ -978,25 +990,25 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             },
           ),
         )),
-      ) as _i14.Future<_i2.SnapdConnectionsResponse>);
+      ) as _i15.Future<_i2.SnapdConnectionsResponse>);
 
   @override
-  _i14.Future<String> refreshMany(List<String>? names) => (super.noSuchMethod(
+  _i15.Future<String> refreshMany(List<String>? names) => (super.noSuchMethod(
         Invocation.method(
           #refreshMany,
           [names],
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #refreshMany,
             [names],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> installMany(
+  _i15.Future<String> installMany(
     List<String>? names, {
     bool? classic = false,
   }) =>
@@ -1006,7 +1018,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           [names],
           {#classic: classic},
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #installMany,
@@ -1014,10 +1026,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             {#classic: classic},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> connect(
+  _i15.Future<String> connect(
     String? snap,
     String? plug,
     String? slotSnap,
@@ -1033,7 +1045,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             slot,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #connect,
@@ -1045,10 +1057,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> disconnect(
+  _i15.Future<String> disconnect(
     String? plugSnap,
     String? plug,
     String? slotSnap,
@@ -1064,7 +1076,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             slot,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #disconnect,
@@ -1076,10 +1088,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i2.Snap>> find({
+  _i15.Future<List<_i2.Snap>> find({
     String? query,
     String? name,
     String? category,
@@ -1100,11 +1112,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #scope: scope,
           },
         ),
-        returnValue: _i14.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
-      ) as _i14.Future<List<_i2.Snap>>);
+        returnValue: _i15.Future<List<_i2.Snap>>.value(<_i2.Snap>[]),
+      ) as _i15.Future<List<_i2.Snap>>);
 
   @override
-  _i14.Future<_i2.SnapdLoginResponse> login(
+  _i15.Future<_i2.SnapdLoginResponse> login(
     String? email,
     String? password, {
     String? otp,
@@ -1118,7 +1130,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           ],
           {#otp: otp},
         ),
-        returnValue: _i14.Future<_i2.SnapdLoginResponse>.value(
+        returnValue: _i15.Future<_i2.SnapdLoginResponse>.value(
             _FakeSnapdLoginResponse_11(
           this,
           Invocation.method(
@@ -1130,19 +1142,19 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             {#otp: otp},
           ),
         )),
-      ) as _i14.Future<_i2.SnapdLoginResponse>);
+      ) as _i15.Future<_i2.SnapdLoginResponse>);
 
   @override
-  _i14.Future<dynamic> logout(int? id) => (super.noSuchMethod(
+  _i15.Future<dynamic> logout(int? id) => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [id],
         ),
-        returnValue: _i14.Future<dynamic>.value(),
-      ) as _i14.Future<dynamic>);
+        returnValue: _i15.Future<dynamic>.value(),
+      ) as _i15.Future<dynamic>);
 
   @override
-  _i14.Future<String> install(
+  _i15.Future<String> install(
     String? name, {
     String? channel,
     String? revision,
@@ -1164,7 +1176,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #jailmode: jailmode,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #install,
@@ -1179,10 +1191,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> refresh(
+  _i15.Future<String> refresh(
     String? name, {
     String? channel,
     bool? classic = false,
@@ -1196,7 +1208,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #classic: classic,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #refresh,
@@ -1207,10 +1219,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> remove(
+  _i15.Future<String> remove(
     String? name, {
     bool? purge = false,
   }) =>
@@ -1220,7 +1232,7 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           [name],
           {#purge: purge},
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #remove,
@@ -1228,55 +1240,55 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             {#purge: purge},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> enable(String? name) => (super.noSuchMethod(
+  _i15.Future<String> enable(String? name) => (super.noSuchMethod(
         Invocation.method(
           #enable,
           [name],
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #enable,
             [name],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> disable(String? name) => (super.noSuchMethod(
+  _i15.Future<String> disable(String? name) => (super.noSuchMethod(
         Invocation.method(
           #disable,
           [name],
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #disable,
             [name],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i2.SnapdChange> getChange(String? id) => (super.noSuchMethod(
+  _i15.Future<_i2.SnapdChange> getChange(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getChange,
           [id],
         ),
-        returnValue: _i14.Future<_i2.SnapdChange>.value(_FakeSnapdChange_12(
+        returnValue: _i15.Future<_i2.SnapdChange>.value(_FakeSnapdChange_12(
           this,
           Invocation.method(
             #getChange,
             [id],
           ),
         )),
-      ) as _i14.Future<_i2.SnapdChange>);
+      ) as _i15.Future<_i2.SnapdChange>);
 
   @override
-  _i14.Future<List<_i2.SnapdChange>> getChanges({
+  _i15.Future<List<_i2.SnapdChange>> getChanges({
     _i2.SnapdChangeFilter? filter,
     String? name,
   }) =>
@@ -1290,23 +1302,23 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           },
         ),
         returnValue:
-            _i14.Future<List<_i2.SnapdChange>>.value(<_i2.SnapdChange>[]),
-      ) as _i14.Future<List<_i2.SnapdChange>>);
+            _i15.Future<List<_i2.SnapdChange>>.value(<_i2.SnapdChange>[]),
+      ) as _i15.Future<List<_i2.SnapdChange>>);
 
   @override
-  _i14.Future<_i2.SnapdChange> abortChange(String? id) => (super.noSuchMethod(
+  _i15.Future<_i2.SnapdChange> abortChange(String? id) => (super.noSuchMethod(
         Invocation.method(
           #abortChange,
           [id],
         ),
-        returnValue: _i14.Future<_i2.SnapdChange>.value(_FakeSnapdChange_12(
+        returnValue: _i15.Future<_i2.SnapdChange>.value(_FakeSnapdChange_12(
           this,
           Invocation.method(
             #abortChange,
             [id],
           ),
         )),
-      ) as _i14.Future<_i2.SnapdChange>);
+      ) as _i15.Future<_i2.SnapdChange>);
 
   @override
   void close() => super.noSuchMethod(
@@ -1318,10 +1330,10 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
       );
 
   @override
-  _i14.Stream<List<_i2.Snap>> getCategory(
+  _i15.Stream<List<_i2.Snap>> getCategory(
     String? name, {
     Duration? expiry = const Duration(days: 1),
-    _i18.FileSystem? fs,
+    _i19.FileSystem? fs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1332,14 +1344,14 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #fs: fs,
           },
         ),
-        returnValue: _i14.Stream<List<_i2.Snap>>.empty(),
-      ) as _i14.Stream<List<_i2.Snap>>);
+        returnValue: _i15.Stream<List<_i2.Snap>>.empty(),
+      ) as _i15.Stream<List<_i2.Snap>>);
 
   @override
-  _i14.Stream<_i2.Snap?> getStoreSnap(
+  _i15.Stream<_i2.Snap?> getStoreSnap(
     String? name, {
     Duration? expiry = const Duration(minutes: 1),
-    _i18.FileSystem? fs,
+    _i19.FileSystem? fs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1350,14 +1362,14 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #fs: fs,
           },
         ),
-        returnValue: _i14.Stream<_i2.Snap?>.empty(),
-      ) as _i14.Stream<_i2.Snap?>);
+        returnValue: _i15.Stream<_i2.Snap?>.empty(),
+      ) as _i15.Stream<_i2.Snap?>);
 
   @override
-  _i14.Stream<List<_i2.Snap>> getStoreSnaps(
+  _i15.Stream<List<_i2.Snap>> getStoreSnaps(
     List<String>? names, {
     Duration? expiry = const Duration(minutes: 1),
-    _i18.FileSystem? fs,
+    _i19.FileSystem? fs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1368,11 +1380,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #fs: fs,
           },
         ),
-        returnValue: _i14.Stream<List<_i2.Snap>>.empty(),
-      ) as _i14.Stream<List<_i2.Snap>>);
+        returnValue: _i15.Stream<List<_i2.Snap>>.empty(),
+      ) as _i15.Stream<List<_i2.Snap>>);
 
   @override
-  _i14.Stream<_i2.SnapdChange> watchChange(
+  _i15.Stream<_i2.SnapdChange> watchChange(
     String? id, {
     Duration? interval = const Duration(milliseconds: 100),
   }) =>
@@ -1382,11 +1394,11 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
           [id],
           {#interval: interval},
         ),
-        returnValue: _i14.Stream<_i2.SnapdChange>.empty(),
-      ) as _i14.Stream<_i2.SnapdChange>);
+        returnValue: _i15.Stream<_i2.SnapdChange>.empty(),
+      ) as _i15.Stream<_i2.SnapdChange>);
 
   @override
-  _i14.Stream<List<String>> watchChanges({
+  _i15.Stream<List<String>> watchChanges({
     String? name,
     Duration? interval = const Duration(milliseconds: 100),
   }) =>
@@ -1399,8 +1411,8 @@ class MockSnapdService extends _i1.Mock implements _i6.SnapdService {
             #interval: interval,
           },
         ),
-        returnValue: _i14.Stream<List<String>>.empty(),
-      ) as _i14.Stream<List<String>>);
+        returnValue: _i15.Stream<List<String>>.empty(),
+      ) as _i15.Stream<List<String>>);
 }
 
 /// A class which mocks [UpdatesModel].
@@ -1436,10 +1448,10 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       ) as _i5.AsyncValue<void>);
 
   @override
-  _i14.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
+  _i15.Stream<_i2.SnapdException> get errorStream => (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i14.Stream<_i2.SnapdException>.empty(),
-      ) as _i14.Stream<_i2.SnapdException>);
+        returnValue: _i15.Stream<_i2.SnapdException>.empty(),
+      ) as _i15.Stream<_i2.SnapdException>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -1448,14 +1460,14 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       ) as bool);
 
   @override
-  _i14.Future<void> refresh() => (super.noSuchMethod(
+  _i15.Future<void> refresh() => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool hasUpdate(String? snapName) => (super.noSuchMethod(
@@ -1467,27 +1479,27 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       ) as bool);
 
   @override
-  _i14.Future<void> updateAll() => (super.noSuchMethod(
+  _i15.Future<void> updateAll() => (super.noSuchMethod(
         Invocation.method(
           #updateAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancelChange(String? changeId) => (super.noSuchMethod(
+  _i15.Future<void> cancelChange(String? changeId) => (super.noSuchMethod(
         Invocation.method(
           #cancelChange,
           [changeId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1496,7 +1508,7 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1527,13 +1539,13 @@ class MockUpdatesModel extends _i1.Mock implements _i6.UpdatesModel {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGtkApplicationNotifier extends _i1.Mock
-    implements _i19.GtkApplicationNotifier {
+    implements _i20.GtkApplicationNotifier {
   MockGtkApplicationNotifier() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void addCommandLineListener(_i19.GtkCommandLineListener? listener) =>
+  void addCommandLineListener(_i20.GtkCommandLineListener? listener) =>
       super.noSuchMethod(
         Invocation.method(
           #addCommandLineListener,
@@ -1543,7 +1555,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
       );
 
   @override
-  void removeCommandLineListener(_i19.GtkCommandLineListener? listener) =>
+  void removeCommandLineListener(_i20.GtkCommandLineListener? listener) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCommandLineListener,
@@ -1553,7 +1565,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
       );
 
   @override
-  void addOpenListener(_i19.GtkOpenListener? listener) => super.noSuchMethod(
+  void addOpenListener(_i20.GtkOpenListener? listener) => super.noSuchMethod(
         Invocation.method(
           #addOpenListener,
           [listener],
@@ -1562,7 +1574,7 @@ class MockGtkApplicationNotifier extends _i1.Mock
       );
 
   @override
-  void removeOpenListener(_i19.GtkOpenListener? listener) => super.noSuchMethod(
+  void removeOpenListener(_i20.GtkOpenListener? listener) => super.noSuchMethod(
         Invocation.method(
           #removeOpenListener,
           [listener],
@@ -1686,7 +1698,7 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
   @override
   String get backendAuthor => (super.noSuchMethod(
         Invocation.getter(#backendAuthor),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#backendAuthor),
         ),
@@ -1695,7 +1707,7 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
   @override
   String get backendDescription => (super.noSuchMethod(
         Invocation.getter(#backendDescription),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#backendDescription),
         ),
@@ -1704,7 +1716,7 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
   @override
   String get backendName => (super.noSuchMethod(
         Invocation.getter(#backendName),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#backendName),
         ),
@@ -1713,7 +1725,7 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
   @override
   String get distroId => (super.noSuchMethod(
         Invocation.getter(#distroId),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#distroId),
         ),
@@ -1774,30 +1786,30 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
       ) as int);
 
   @override
-  _i14.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+  _i15.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
         Invocation.getter(#propertiesChanged),
-        returnValue: _i14.Stream<List<String>>.empty(),
-      ) as _i14.Stream<List<String>>);
+        returnValue: _i15.Stream<List<String>>.empty(),
+      ) as _i15.Stream<List<String>>);
 
   @override
-  _i14.Future<void> connect() => (super.noSuchMethod(
+  _i15.Future<void> connect() => (super.noSuchMethod(
         Invocation.method(
           #connect,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i10.PackageKitTransaction> getTransaction(
-          _i20.DBusObjectPath? path) =>
+  _i15.Future<_i10.PackageKitTransaction> getTransaction(
+          _i21.DBusObjectPath? path) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTransaction,
           [path],
         ),
-        returnValue: _i14.Future<_i10.PackageKitTransaction>.value(
+        returnValue: _i15.Future<_i10.PackageKitTransaction>.value(
             _FakePackageKitTransaction_13(
           this,
           Invocation.method(
@@ -1805,16 +1817,16 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
             [path],
           ),
         )),
-      ) as _i14.Future<_i10.PackageKitTransaction>);
+      ) as _i15.Future<_i10.PackageKitTransaction>);
 
   @override
-  _i14.Future<_i10.PackageKitTransaction> createTransaction() =>
+  _i15.Future<_i10.PackageKitTransaction> createTransaction() =>
       (super.noSuchMethod(
         Invocation.method(
           #createTransaction,
           [],
         ),
-        returnValue: _i14.Future<_i10.PackageKitTransaction>.value(
+        returnValue: _i15.Future<_i10.PackageKitTransaction>.value(
             _FakePackageKitTransaction_13(
           this,
           Invocation.method(
@@ -1822,17 +1834,17 @@ class MockPackageKitClient extends _i1.Mock implements _i10.PackageKitClient {
             [],
           ),
         )),
-      ) as _i14.Future<_i10.PackageKitTransaction>);
+      ) as _i15.Future<_i10.PackageKitTransaction>);
 
   @override
-  _i14.Future<void> close() => (super.noSuchMethod(
+  _i15.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [PackageKitTransaction].
@@ -1845,13 +1857,13 @@ class MockPackageKitTransaction extends _i1.Mock
   }
 
   @override
-  _i14.Stream<_i10.PackageKitEvent> get events => (super.noSuchMethod(
+  _i15.Stream<_i10.PackageKitEvent> get events => (super.noSuchMethod(
         Invocation.getter(#events),
-        returnValue: _i14.Stream<_i10.PackageKitEvent>.empty(),
-      ) as _i14.Stream<_i10.PackageKitEvent>);
+        returnValue: _i15.Stream<_i10.PackageKitEvent>.empty(),
+      ) as _i15.Stream<_i10.PackageKitEvent>);
 
   @override
-  set events(_i14.Stream<_i10.PackageKitEvent>? _events) => super.noSuchMethod(
+  set events(_i15.Stream<_i10.PackageKitEvent>? _events) => super.noSuchMethod(
         Invocation.setter(
           #events,
           _events,
@@ -1874,7 +1886,7 @@ class MockPackageKitTransaction extends _i1.Mock
   @override
   String get lastPackage => (super.noSuchMethod(
         Invocation.getter(#lastPackage),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#lastPackage),
         ),
@@ -1936,23 +1948,23 @@ class MockPackageKitTransaction extends _i1.Mock
       ) as Set<_i10.PackageKitTransactionFlag>);
 
   @override
-  _i14.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+  _i15.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
         Invocation.getter(#propertiesChanged),
-        returnValue: _i14.Stream<List<String>>.empty(),
-      ) as _i14.Stream<List<String>>);
+        returnValue: _i15.Stream<List<String>>.empty(),
+      ) as _i15.Stream<List<String>>);
 
   @override
-  _i14.Future<void> cancel() => (super.noSuchMethod(
+  _i15.Future<void> cancel() => (super.noSuchMethod(
         Invocation.method(
           #cancel,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dependsOn(
+  _i15.Future<void> dependsOn(
     Iterable<_i10.PackageKitPackageId>? packageIds, {
     Set<_i10.PackageKitFilter>? filter = const {},
     bool? recursive = false,
@@ -1966,35 +1978,35 @@ class MockPackageKitTransaction extends _i1.Mock
             #recursive: recursive,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getDetails(
+  _i15.Future<void> getDetails(
           Iterable<_i10.PackageKitPackageId>? packageIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDetails,
           [packageIds],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getDetailsLocal(Iterable<String>? paths) =>
+  _i15.Future<void> getDetailsLocal(Iterable<String>? paths) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDetailsLocal,
           [paths],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> downloadPackages(
+  _i15.Future<void> downloadPackages(
     Iterable<_i10.PackageKitPackageId>? packageIds, {
     bool? storeInCache = false,
   }) =>
@@ -2004,34 +2016,34 @@ class MockPackageKitTransaction extends _i1.Mock
           [packageIds],
           {#storeInCache: storeInCache},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getFiles(Iterable<_i10.PackageKitPackageId>? packageIds) =>
+  _i15.Future<void> getFiles(Iterable<_i10.PackageKitPackageId>? packageIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #getFiles,
           [packageIds],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getFilesLocal(Iterable<String>? paths) =>
+  _i15.Future<void> getFilesLocal(Iterable<String>? paths) =>
       (super.noSuchMethod(
         Invocation.method(
           #getFilesLocal,
           [paths],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getPackages(
+  _i15.Future<void> getPackages(
           {Set<_i10.PackageKitFilter>? filter = const {}}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2039,12 +2051,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [],
           {#filter: filter},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getRepositoryList(
+  _i15.Future<void> getRepositoryList(
           {Set<_i10.PackageKitFilter>? filter = const {}}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2052,12 +2064,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [],
           {#filter: filter},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRepositoryEnabled(
+  _i15.Future<void> setRepositoryEnabled(
     String? id,
     bool? enabled,
   ) =>
@@ -2069,12 +2081,12 @@ class MockPackageKitTransaction extends _i1.Mock
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRepositoryData(
+  _i15.Future<void> setRepositoryData(
     String? id,
     String? parameter,
     String? value,
@@ -2088,12 +2100,12 @@ class MockPackageKitTransaction extends _i1.Mock
             value,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeRepository(
+  _i15.Future<void> removeRepository(
     String? id, {
     bool? autoremovePackages = false,
   }) =>
@@ -2103,24 +2115,24 @@ class MockPackageKitTransaction extends _i1.Mock
           [id],
           {#autoremovePackages: autoremovePackages},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getUpdateDetail(
+  _i15.Future<void> getUpdateDetail(
           Iterable<_i10.PackageKitPackageId>? packageIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUpdateDetail,
           [packageIds],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> getUpdates(
+  _i15.Future<void> getUpdates(
           {Set<_i10.PackageKitFilter>? filter = const {}}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2128,12 +2140,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [],
           {#filter: filter},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> installFiles(
+  _i15.Future<void> installFiles(
     Iterable<String>? paths, {
     Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
@@ -2143,12 +2155,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [paths],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> installPackages(
+  _i15.Future<void> installPackages(
     Iterable<_i10.PackageKitPackageId>? packageIds, {
     Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
@@ -2158,23 +2170,23 @@ class MockPackageKitTransaction extends _i1.Mock
           [packageIds],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> refreshCache({bool? force = false}) => (super.noSuchMethod(
+  _i15.Future<void> refreshCache({bool? force = false}) => (super.noSuchMethod(
         Invocation.method(
           #refreshCache,
           [],
           {#force: force},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removePackages(
+  _i15.Future<void> removePackages(
     Iterable<_i10.PackageKitPackageId>? packageIds, {
     Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
     bool? allowDeps = false,
@@ -2190,12 +2202,12 @@ class MockPackageKitTransaction extends _i1.Mock
             #autoremove: autoremove,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> resolve(
+  _i15.Future<void> resolve(
     Iterable<String>? packages, {
     Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
@@ -2205,12 +2217,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [packages],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> searchFiles(
+  _i15.Future<void> searchFiles(
     Iterable<String>? values, {
     Set<_i10.PackageKitFilter>? filter = const {},
   }) =>
@@ -2220,12 +2232,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [values],
           {#filter: filter},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> searchNames(
+  _i15.Future<void> searchNames(
     Iterable<String>? values, {
     Set<_i10.PackageKitFilter>? filter = const {},
   }) =>
@@ -2235,12 +2247,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [values],
           {#filter: filter},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> updatePackages(
+  _i15.Future<void> updatePackages(
     Iterable<_i10.PackageKitPackageId>? packageIds, {
     Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
   }) =>
@@ -2250,12 +2262,12 @@ class MockPackageKitTransaction extends _i1.Mock
           [packageIds],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> upgradeSystem(
+  _i15.Future<void> upgradeSystem(
     String? distroId,
     _i10.PackageKitDistroUpgrade? upgradeKind, {
     Set<_i10.PackageKitTransactionFlag>? transactionFlags = const {},
@@ -2269,9 +2281,9 @@ class MockPackageKitTransaction extends _i1.Mock
           ],
           {#transactionFlags: transactionFlags},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [RatingsService].
@@ -2292,53 +2304,53 @@ class MockRatingsService extends _i1.Mock implements _i4.RatingsService {
       ) as _i11.RatingsClient);
 
   @override
-  _i14.Future<_i11.Rating?> getRating(String? snapId) => (super.noSuchMethod(
+  _i15.Future<_i11.Rating?> getRating(String? snapId) => (super.noSuchMethod(
         Invocation.method(
           #getRating,
           [snapId],
         ),
-        returnValue: _i14.Future<_i11.Rating?>.value(),
-      ) as _i14.Future<_i11.Rating?>);
+        returnValue: _i15.Future<_i11.Rating?>.value(),
+      ) as _i15.Future<_i11.Rating?>);
 
   @override
-  _i14.Future<void> vote(_i21.Vote? vote) => (super.noSuchMethod(
+  _i15.Future<void> vote(_i22.Vote? vote) => (super.noSuchMethod(
         Invocation.method(
           #vote,
           [vote],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> delete() => (super.noSuchMethod(
+  _i15.Future<void> delete() => (super.noSuchMethod(
         Invocation.method(
           #delete,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i21.Vote>> listMyVotes(String? snapFilter) =>
+  _i15.Future<List<_i22.Vote>> listMyVotes(String? snapFilter) =>
       (super.noSuchMethod(
         Invocation.method(
           #listMyVotes,
           [snapFilter],
         ),
-        returnValue: _i14.Future<List<_i21.Vote>>.value(<_i21.Vote>[]),
-      ) as _i14.Future<List<_i21.Vote>>);
+        returnValue: _i15.Future<List<_i22.Vote>>.value(<_i22.Vote>[]),
+      ) as _i15.Future<List<_i22.Vote>>);
 
   @override
-  _i14.Future<List<_i21.Vote>> getSnapVotes(String? snapId) =>
+  _i15.Future<List<_i22.Vote>> getSnapVotes(String? snapId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getSnapVotes,
           [snapId],
         ),
-        returnValue: _i14.Future<List<_i21.Vote>>.value(<_i21.Vote>[]),
-      ) as _i14.Future<List<_i21.Vote>>);
+        returnValue: _i15.Future<List<_i22.Vote>>.value(<_i22.Vote>[]),
+      ) as _i15.Future<List<_i22.Vote>>);
 }
 
 /// A class which mocks [RatingsClient].
@@ -2350,33 +2362,33 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
   }
 
   @override
-  _i14.Future<String> authenticate(String? id) => (super.noSuchMethod(
+  _i15.Future<String> authenticate(String? id) => (super.noSuchMethod(
         Invocation.method(
           #authenticate,
           [id],
         ),
-        returnValue: _i14.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i14.dummyValue<String>(
           this,
           Invocation.method(
             #authenticate,
             [id],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> delete(String? token) => (super.noSuchMethod(
+  _i15.Future<void> delete(String? token) => (super.noSuchMethod(
         Invocation.method(
           #delete,
           [token],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i22.ChartData>> getChart(
-    _i22.Timeframe? timeframe,
+  _i15.Future<List<_i23.ChartData>> getChart(
+    _i23.Timeframe? timeframe,
     String? token,
   ) =>
       (super.noSuchMethod(
@@ -2388,11 +2400,11 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
           ],
         ),
         returnValue:
-            _i14.Future<List<_i22.ChartData>>.value(<_i22.ChartData>[]),
-      ) as _i14.Future<List<_i22.ChartData>>);
+            _i15.Future<List<_i23.ChartData>>.value(<_i23.ChartData>[]),
+      ) as _i15.Future<List<_i23.ChartData>>);
 
   @override
-  _i14.Future<_i11.Rating> getRating(
+  _i15.Future<_i11.Rating> getRating(
     String? snapId,
     String? token,
   ) =>
@@ -2404,7 +2416,7 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
             token,
           ],
         ),
-        returnValue: _i14.Future<_i11.Rating>.value(_FakeRating_15(
+        returnValue: _i15.Future<_i11.Rating>.value(_FakeRating_15(
           this,
           Invocation.method(
             #getRating,
@@ -2414,10 +2426,10 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
             ],
           ),
         )),
-      ) as _i14.Future<_i11.Rating>);
+      ) as _i15.Future<_i11.Rating>);
 
   @override
-  _i14.Future<List<_i21.Vote>> getSnapVotes(
+  _i15.Future<List<_i22.Vote>> getSnapVotes(
     String? snapId,
     String? token,
   ) =>
@@ -2429,11 +2441,11 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
             token,
           ],
         ),
-        returnValue: _i14.Future<List<_i21.Vote>>.value(<_i21.Vote>[]),
-      ) as _i14.Future<List<_i21.Vote>>);
+        returnValue: _i15.Future<List<_i22.Vote>>.value(<_i22.Vote>[]),
+      ) as _i15.Future<List<_i22.Vote>>);
 
   @override
-  _i14.Future<List<_i21.Vote>> listMyVotes(
+  _i15.Future<List<_i22.Vote>> listMyVotes(
     String? snapIdFilter,
     String? token,
   ) =>
@@ -2445,11 +2457,11 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
             token,
           ],
         ),
-        returnValue: _i14.Future<List<_i21.Vote>>.value(<_i21.Vote>[]),
-      ) as _i14.Future<List<_i21.Vote>>);
+        returnValue: _i15.Future<List<_i22.Vote>>.value(<_i22.Vote>[]),
+      ) as _i15.Future<List<_i22.Vote>>);
 
   @override
-  _i14.Future<void> vote(
+  _i15.Future<void> vote(
     String? snapId,
     int? snapRevision,
     bool? voteUp,
@@ -2465,9 +2477,9 @@ class MockRatingsClient extends _i1.Mock implements _i11.RatingsClient {
             token,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [AppstreamService].
@@ -2491,25 +2503,25 @@ class MockAppstreamService extends _i1.Mock implements _i7.AppstreamService {
       ) as int);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i9.AppstreamComponent>> search(String? search) =>
+  _i15.Future<List<_i9.AppstreamComponent>> search(String? search) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [search],
         ),
-        returnValue: _i14.Future<List<_i9.AppstreamComponent>>.value(
+        returnValue: _i15.Future<List<_i9.AppstreamComponent>>.value(
             <_i9.AppstreamComponent>[]),
-      ) as _i14.Future<List<_i9.AppstreamComponent>>);
+      ) as _i15.Future<List<_i9.AppstreamComponent>>);
 
   @override
   _i9.AppstreamComponent getFromId(String? id) => (super.noSuchMethod(
@@ -2542,11 +2554,11 @@ class MockPackageKitService extends _i1.Mock implements _i8.PackageKitService {
       ) as bool);
 
   @override
-  _i14.Stream<_i10.PackageKitErrorCodeEvent> get errorStream =>
+  _i15.Stream<_i10.PackageKitErrorCodeEvent> get errorStream =>
       (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i14.Stream<_i10.PackageKitErrorCodeEvent>.empty(),
-      ) as _i14.Stream<_i10.PackageKitErrorCodeEvent>);
+        returnValue: _i15.Stream<_i10.PackageKitErrorCodeEvent>.empty(),
+      ) as _i15.Stream<_i10.PackageKitErrorCodeEvent>);
 
   @override
   _i10.PackageKitTransaction? getTransaction(int? id) =>
@@ -2556,57 +2568,57 @@ class MockPackageKitService extends _i1.Mock implements _i8.PackageKitService {
       )) as _i10.PackageKitTransaction?);
 
   @override
-  _i14.Future<void> activateService() => (super.noSuchMethod(
+  _i15.Future<void> activateService() => (super.noSuchMethod(
         Invocation.method(
           #activateService,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> waitTransaction(int? id) => (super.noSuchMethod(
+  _i15.Future<void> waitTransaction(int? id) => (super.noSuchMethod(
         Invocation.method(
           #waitTransaction,
           [id],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancelTransaction(int? id) => (super.noSuchMethod(
+  _i15.Future<void> cancelTransaction(int? id) => (super.noSuchMethod(
         Invocation.method(
           #cancelTransaction,
           [id],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> install(_i10.PackageKitPackageId? packageId) =>
+  _i15.Future<int> install(_i10.PackageKitPackageId? packageId) =>
       (super.noSuchMethod(
         Invocation.method(
           #install,
           [packageId],
         ),
-        returnValue: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<int> remove(_i10.PackageKitPackageId? packageId) =>
+  _i15.Future<int> remove(_i10.PackageKitPackageId? packageId) =>
       (super.noSuchMethod(
         Invocation.method(
           #remove,
           [packageId],
         ),
-        returnValue: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i10.PackageKitPackageEvent?> resolve(
+  _i15.Future<_i10.PackageKitPackageEvent?> resolve(
     String? name, [
     String? architecture,
   ]) =>
@@ -2618,24 +2630,24 @@ class MockPackageKitService extends _i1.Mock implements _i8.PackageKitService {
             architecture,
           ],
         ),
-        returnValue: _i14.Future<_i10.PackageKitPackageEvent?>.value(),
-      ) as _i14.Future<_i10.PackageKitPackageEvent?>);
+        returnValue: _i15.Future<_i10.PackageKitPackageEvent?>.value(),
+      ) as _i15.Future<_i10.PackageKitPackageEvent?>);
 
   @override
-  _i14.Future<void> dispose() => (super.noSuchMethod(
+  _i15.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [MultiSnapModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMultiSnapModel extends _i1.Mock implements _i23.MultiSnapModel {
+class MockMultiSnapModel extends _i1.Mock implements _i24.MultiSnapModel {
   MockMultiSnapModel() {
     _i1.throwOnMissingStub(this);
   }
@@ -2656,15 +2668,6 @@ class MockMultiSnapModel extends _i1.Mock implements _i23.MultiSnapModel {
       ) as _i6.SnapCategoryEnum);
 
   @override
-  set activeChangeIds(List<String>? _activeChangeIds) => super.noSuchMethod(
-        Invocation.setter(
-          #activeChangeIds,
-          _activeChangeIds,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
   List<_i2.Snap> get categorySnaps => (super.noSuchMethod(
         Invocation.getter(#categorySnaps),
         returnValue: <_i2.Snap>[],
@@ -2678,6 +2681,15 @@ class MockMultiSnapModel extends _i1.Mock implements _i23.MultiSnapModel {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i12.UnmodifiableListView<String> get activeChangeIds => (super.noSuchMethod(
+        Invocation.getter(#activeChangeIds),
+        returnValue: _FakeUnmodifiableListView_16<String>(
+          this,
+          Invocation.getter(#activeChangeIds),
+        ),
+      ) as _i12.UnmodifiableListView<String>);
 
   @override
   _i5.AsyncValue<void> get state => (super.noSuchMethod(
@@ -2695,47 +2707,47 @@ class MockMultiSnapModel extends _i1.Mock implements _i23.MultiSnapModel {
       ) as bool);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose() => (super.noSuchMethod(
+  _i15.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancel() => (super.noSuchMethod(
+  _i15.Future<void> cancel() => (super.noSuchMethod(
         Invocation.method(
           #cancel,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> installAll() => (super.noSuchMethod(
+  _i15.Future<void> installAll() => (super.noSuchMethod(
         Invocation.method(
           #installAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -2744,7 +2756,7 @@ class MockMultiSnapModel extends _i1.Mock implements _i23.MultiSnapModel {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/packages/app_center_ratings_client/lib/src/chart.freezed.dart
+++ b/packages/app_center_ratings_client/lib/src/chart.freezed.dart
@@ -12,7 +12,7 @@ part of 'chart.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$ChartData {

--- a/packages/app_center_ratings_client/lib/src/user.freezed.dart
+++ b/packages/app_center_ratings_client/lib/src/user.freezed.dart
@@ -12,7 +12,7 @@ part of 'user.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$Vote {


### PR DESCRIPTION
![Screenshot from 2024-04-10 14-42-16](https://github.com/ubuntu/app-center/assets/105805873/23cd9366-3dbd-4a73-b033-15297bc41e57)
![Screenshot from 2024-04-10 14-42-02](https://github.com/ubuntu/app-center/assets/105805873/48ea8087-fb3a-47cd-8599-f3ae9a6a9997)

Right now:
- button state and progress bar are not persistent when switching tabs. This means that it returns to the original state of enabled and no progress, the elements are kept only when clicking on a snap in the snap grid
- Clicking install on a bundle that has a snap already installed just installs the ones missing. If all of them are already installed, the button ignores the clicks but remains enabled

Feedback and ideas are welcomed for this behaviour