### PR TITLE
feat: connect to ratings service via TLS

### DIFF
--- a/packages/app_center/lib/config.dart
+++ b/packages/app_center/lib/config.dart
@@ -1,26 +1,25 @@
 import 'dart:io';
+
 import 'package:meta/meta.dart';
 
-const String url = 'RATINGS_SERVICE_URL';
-const int port = 443;
-
 class ConfigService {
+  ConfigService({@visibleForTesting Map<String, String>? env})
+      : _env = env ?? Platform.environment;
+  final Map<String, String> _env;
+
   String _ratingsServiceUrl = 'localhost';
   int _ratingsServicePort = 8080;
-
-  @visibleForTesting
-  Map<String, String>? testEnvironment;
+  bool _ratingsServiceUseTls = false;
 
   void load() {
-    final env = testEnvironment ?? Platform.environment;
-
-    _ratingsServiceUrl = env[url] ?? _ratingsServiceUrl;
-
-    if (env.containsKey(url)) {
-      _ratingsServicePort = port;
-    }
+    _ratingsServiceUrl = _env['RATINGS_SERVICE_URL'] ?? _ratingsServiceUrl;
+    _ratingsServicePort =
+        int.tryParse(_env['RATINGS_SERVICE_PORT'] ?? '') ?? _ratingsServicePort;
+    _ratingsServiceUseTls =
+        _env['RATINGS_SERVICE_USE_TLS']?.toLowerCase() == 'true';
   }
 
   String get ratingServiceUrl => _ratingsServiceUrl;
   int get ratingsServicePort => _ratingsServicePort;
+  bool get ratingsServiceUseTls => _ratingsServiceUseTls;
 }

--- a/packages/app_center/lib/main.dart
+++ b/packages/app_center/lib/main.dart
@@ -48,6 +48,7 @@ Future<void> main(List<String> args) async {
     RatingsClient(
       config.ratingServiceUrl,
       config.ratingsServicePort,
+      config.ratingsServiceUseTls,
     ),
   );
   registerServiceInstance(config);

--- a/packages/app_center/test/config_service_test.dart
+++ b/packages/app_center/test/config_service_test.dart
@@ -2,21 +2,25 @@ import 'package:app_center/config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('env vars not set', () {
+  test('default values', () {
     final configService = ConfigService();
-    configService.testEnvironment = {};
     configService.load();
-    expect(configService.ratingServiceUrl, 'localhost');
-    expect(configService.ratingsServicePort, 8080);
+    expect(configService.ratingServiceUrl, equals('localhost'));
+    expect(configService.ratingsServicePort, equals(8080));
+    expect(configService.ratingsServiceUseTls, isFalse);
   });
 
-  test('env vars set', () {
-    final configService = ConfigService();
-    configService.testEnvironment = {
-      'RATINGS_SERVICE_URL': 'test.url',
-    };
+  test('custom values', () {
+    final configService = ConfigService(
+      env: {
+        'RATINGS_SERVICE_URL': 'test.url',
+        'RATINGS_SERVICE_PORT': '443',
+        'RATINGS_SERVICE_USE_TLS': 'true',
+      },
+    );
     configService.load();
-    expect(configService.ratingServiceUrl, 'test.url');
-    expect(configService.ratingsServicePort, 443);
+    expect(configService.ratingServiceUrl, equals('test.url'));
+    expect(configService.ratingsServicePort, equals(443));
+    expect(configService.ratingsServiceUseTls, isTrue);
   });
 }

--- a/packages/app_center_ratings_client/lib/src/ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/src/ratings_client.dart
@@ -14,12 +14,14 @@ import 'package:grpc/grpc.dart';
 import 'package:meta/meta.dart';
 
 class RatingsClient {
-  RatingsClient(String serverUrl, int port) {
+  RatingsClient(String serverUrl, int port, bool useTls) {
     final channel = ClientChannel(
       serverUrl,
       port: port,
-      options: const ChannelOptions(
-        credentials: ChannelCredentials.insecure(),
+      options: ChannelOptions(
+        credentials: useTls
+            ? const ChannelCredentials.secure()
+            : const ChannelCredentials.insecure(),
       ),
     );
     _appClient = app_pb.AppClient(channel);

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,8 @@ apps:
     command: bin/snap-store
     environment:
       RATINGS_SERVICE_URL: 'ratings.ubuntu.com'
+      RATINGS_SERVICE_PORT: '443'
+      RATINGS_SERVICE_USE_TLS: 'true'
     desktop: bin/data/flutter_assets/assets/app-center.desktop
     extensions: [gnome]
     plugs:


### PR DESCRIPTION
`ratings.ubuntu.com` now serves gRPC over TLS. This PR adds the necessary configuration options that can be set via the environment and provides the corresponding values in the snapcraft.yaml.