### PR TITLE
fix(ci): temporarily skip apt update if it fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: asdf-vm/actions/install@v2
       - uses: bluefireteam/melos-action@v2
-      - run: sudo apt update && sudo apt install -y lcov
+      - run: sudo apt update || true && sudo apt install -y lcov
       - run: melos coverage
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: asdf-vm/actions/install@v2
       - uses: bluefireteam/melos-action@v3
-      - run: sudo apt update
+      - run: sudo apt update || true
       - run: sudo apt install -y clang cmake libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xvfb
       - run: |
           cd packages/app_center && \


### PR DESCRIPTION
Unblocks the CI until the microsoft mirror issue is resolved. (CLA check will still fail, but at least the tests should run).