### PR TITLE
feat: reducing the breakpoint

### DIFF
--- a/packages/app_center/lib/layout.dart
+++ b/packages/app_center/lib/layout.dart
@@ -10,7 +10,7 @@ const kIconSize = 56.0;
 const kCardSizeNormal = Size(416.0, 170.0);
 const kCardSizeWide = Size(548.0, 170.0);
 
-const kBreakPointSmall = 1280.0;
+const kBreakPointSmall = 1080.0;
 const kBreakPointLarge = 1680.0;
 
 enum ResponsiveLayoutType {


### PR DESCRIPTION
In this PR:

- Reducing the breakpoint, so the app isn't shown as a 1 column page if the window is larger then 1080px.

Before:
![Screenshot from 2024-05-02 04-29-10](https://github.com/ubuntu/app-center/assets/20175372/52b57f46-ad63-462e-afc9-b931400a890e)

After:
![Screenshot from 2024-05-02 04-29-21](https://github.com/ubuntu/app-center/assets/20175372/363e77ec-450a-4300-b6c3-c3ce96f74ad7)