### PR TITLE
feat(updates_model): call refreshMany with empty list

### DIFF
--- a/packages/app_center/lib/src/snapd/updates_model.dart
+++ b/packages/app_center/lib/src/snapd/updates_model.dart
@@ -53,7 +53,7 @@ class UpdatesModel extends ChangeNotifier {
   Future<void> updateAll() async {
     if (_refreshableSnaps == null) return;
     try {
-      final changeId = await snapd.refreshMany(refreshableSnapNames.toList());
+      final changeId = await snapd.refreshMany([]);
       _activeChangeId = changeId;
       notifyListeners();
       await snapd.waitChange(changeId);

--- a/packages/app_center/test/updates_model_test.dart
+++ b/packages/app_center/test/updates_model_test.dart
@@ -28,7 +28,7 @@ void main() {
     final model = UpdatesModel(service);
     await model.refresh();
     await model.updateAll();
-    verify(service.refreshMany(const ['firefox'])).called(1);
+    verify(service.refreshMany(const [])).called(1);
   });
 
   group('error stream', () {


### PR DESCRIPTION
This essentially invokes `snap refresh` when pressing the "Update All" button, so that currently running snaps won't block the others from being updated. Snaps that couldn't be updated will remain in the "Updates available" list afterwards.

While this solution isn't ideal, I still think it's a slight improvement over the current behavior where an error message is shown and the user cannot proceed with the update. I'd return to this with a cleaner solution after doing some refactoring and figuring out some UX issues.

Ref: #1656