### PR TITLE
feat(snap_model): add support for sortedChannels

### DIFF
--- a/packages/app_center/lib/src/snapd/snap_model.dart
+++ b/packages/app_center/lib/src/snapd/snap_model.dart
@@ -77,6 +77,7 @@ class SnapModel extends ChangeNotifier {
   }
 
   Map<String, SnapChannel>? get availableChannels => storeSnap?.channels;
+  List<String>? get availableTracks => storeSnap?.tracks;
 
   StreamSubscription<Snap?>? _storeSnapSubscription;
   StreamSubscription<SnapdChange>? _activeChangeSubscription;
@@ -84,6 +85,26 @@ class SnapModel extends ChangeNotifier {
   Stream<SnapdException> get errorStream => _errorStreamController.stream;
   final StreamController<SnapdException> _errorStreamController =
       StreamController.broadcast();
+
+  Map<String, SnapChannel>? getSortedChannels() {
+    if (availableTracks == null || availableChannels == null) {
+      return null;
+    }
+    // ignore: omit_local_variable_types
+    final Map<String, SnapChannel> sortedChannels = {};
+    const risks = ['stable', 'candidate', 'beta', 'edge'];
+    if (availableTracks != null && availableChannels != null) {
+      for (final track in availableTracks!) {
+        for (final risk in risks) {
+          final key = '$track/$risk';
+          if (availableChannels!.containsKey('$track/$risk')) {
+            sortedChannels[key] = availableChannels![key]!;
+          }
+        }
+      }
+    }
+    return sortedChannels;
+  }
 
   Future<void> init() async {
     final storeSnapCompleter = Completer();

--- a/packages/app_center/lib/src/snapd/snap_page.dart
+++ b/packages/app_center/lib/src/snapd/snap_page.dart
@@ -630,13 +630,15 @@ class _ChannelDropdown extends StatelessWidget {
         SizedBox(
           width: _kChannelDropdownWidth,
           child: MenuButtonBuilder(
-            entries: model.availableChannels!.entries
+            entries: model
+                .getSortedChannels()!
+                .entries
                 .map(
-              (channelEntry) => MenuButtonEntry(
-                value: channelEntry.key,
-                child: _ChannelDropdownEntry(channelEntry: channelEntry),
-              ),
-            )
+                  (channelEntry) => MenuButtonEntry(
+                    value: channelEntry.key,
+                    child: _ChannelDropdownEntry(channelEntry: channelEntry),
+                  ),
+                )
                 .fold(
               <MenuButtonEntry<String>>[],
               (p, e) =>


### PR DESCRIPTION
Currently snapd returns channels sorted in alphabetical order. This PR tries to sort the channels in the order of their risks. This should've been implemented in the `Snap` model itself of `snapd.dart`.

Closes #1531 