### PR TITLE
fix(snapcraft): remove `refresh-mode`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ confinement: strict
 base: core22
 grade: stable
 version: git
-assumes: [snapd2.57] # Needed for ignore-running refresh-mode
 
 parts:
   flutter-git:
@@ -60,7 +59,6 @@ apps:
       RATINGS_SERVICE_USE_TLS: 'true'
     desktop: bin/data/flutter_assets/assets/app-center.desktop
     extensions: [gnome]
-    refresh-mode: ignore-running
     plugs:
       - appstream-metadata
       - desktop


### PR DESCRIPTION
According to the snapcraft.yaml reference:

> `apps.<app-name>.refresh-mode`
> Controls whether the daemon should be restarted during a snap refresh.
> Type: string
> Requires daemon to be set in app metadata. Can be one of the following:
> endure, restart, or ignore-running (defaults to restart)

So it seems like we can't use this for a desktop app. In the meantime we've already merged #1663 as a fix for #1643.

This reverts commit 80e36895890f1357e216bdb676024b09b636a9f5.