### PR TITLE
Add StartupWMClass to .Desktop file

### DIFF
--- a/packages/app_center/assets/app-center.desktop
+++ b/packages/app_center/assets/app-center.desktop
@@ -7,6 +7,7 @@ Terminal=false
 Categories=System;Utility;PackageManager;SoftwareManagement;Network;Settings;
 Keywords=Ubuntu;Applications;Apps;Store;Software;Snaps;
 MimeType=x-scheme-handler/snap;application/vnd.debian.binary-package;
+StartupWMClass=Snap-store
 Name=App Center
 Name[ar]=مركز التطبيقات
 Name[cs]=Centrum aplikací


### PR DESCRIPTION
Fixes instances where the application does not have an icon in the dock and appears with a generic window icon.

----

Whilst this works for the Flutter based branches, it would be worth seeing what the legacy branches (E.G Ubuntu 22.04) configure as their WMClass, as if it doesn't match this may have the potential to cause more regression than fixes.

This PR comes from a user on the support Matrix who confirmed that adding this line as an override fixed their issues with this snap.