### PR TITLE
feat: add ErrorObserver

### DIFF
--- a/packages/app_center/lib/error/error.dart
+++ b/packages/app_center/lib/error/error.dart
@@ -1,0 +1,1 @@
+export 'error_observer.dart';

--- a/packages/app_center/lib/error/error_observer.dart
+++ b/packages/app_center/lib/error/error_observer.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+class ErrorObserver extends ProviderObserver {
+  final log = Logger('error_observer');
+  @override
+  void providerDidFail(
+    ProviderBase<Object?> provider,
+    Object error,
+    StackTrace stackTrace,
+    ProviderContainer container,
+  ) {
+    log.error('Provider $provider failed', error);
+  }
+}

--- a/packages/app_center/lib/main.dart
+++ b/packages/app_center/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:app_center/appstream/appstream.dart';
 import 'package:app_center/config.dart';
+import 'package:app_center/error/error.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/packagekit/packagekit.dart';
 import 'package:app_center/providers/error_stream_provider.dart';
@@ -77,7 +78,12 @@ Future<void> main(List<String> args) async {
   await runZonedGuarded(
     () async {
       await YaruWindowTitleBar.ensureInitialized();
-      runApp(const ProviderScope(child: StoreApp()));
+      runApp(
+        ProviderScope(
+          observers: [ErrorObserver()],
+          child: const StoreApp(),
+        ),
+      );
     },
     (error, stackTrace) {
       log.error('Error propagated to top-level', error, stackTrace);


### PR DESCRIPTION
Adds a `ProviderObserver` that logs provider build errors. This mostly concerns exceptions thrown due to connection errors (ratings backend or snapd unavailable), but potentially other errors we're not aware of that might be useful for debugging.