### PR TITLE
fix: Move back button to the title bar

### DIFF
--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -238,9 +238,8 @@ class _Header extends StatelessWidget {
     return Column(
       children: [
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            const YaruBackButton(style: YaruBackButtonStyle.rounded),
+            const Spacer(),
             if (debModel.component.website != null)
               YaruIconButton(
                 icon: const Icon(YaruIcons.share),

--- a/packages/app_center/lib/games/games_page_external_tools.dart
+++ b/packages/app_center/lib/games/games_page_external_tools.dart
@@ -5,7 +5,6 @@ import 'package:app_center/snapd/snap_category_enum.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yaru/yaru.dart';
 
 class ExternalTools extends StatelessWidget {
   const ExternalTools({super.key});
@@ -17,19 +16,6 @@ class ExternalTools extends StatelessWidget {
       builder: (context) => Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: kPagePadding) +
-                ResponsiveLayout.of(context).padding,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (Navigator.of(context).canPop())
-                  const YaruBackButton(
-                    style: YaruBackButtonStyle.rounded,
-                  ),
-              ],
-            ),
-          ),
           Padding(
             padding: ResponsiveLayout.of(context).padding,
             child: Column(

--- a/packages/app_center/lib/search/search_page.dart
+++ b/packages/app_center/lib/search/search_page.dart
@@ -34,10 +34,6 @@ class SearchPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                if (Navigator.of(context).canPop())
-                  const YaruBackButton(
-                    style: YaruBackButtonStyle.rounded,
-                  ),
                 if (query != null)
                   Text(
                     l10n.searchPageTitle(query!),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -511,7 +511,6 @@ class _Header extends ConsumerWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            const YaruBackButton(style: YaruBackButtonStyle.rounded),
             const Spacer(),
             if (snap.website != null)
               YaruIconButton(

--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -24,6 +24,8 @@ final materialAppNavigatorKeyProvider =
 final yaruPageControllerProvider =
     Provider((ref) => YaruPageController(length: pages.length));
 
+final routeNameProvider = StateProvider<String?>((ref) => null);
+
 class StoreApp extends ConsumerStatefulWidget {
   const StoreApp({super.key});
 
@@ -102,14 +104,33 @@ class _StoreAppHome extends ConsumerWidget {
 
     return Scaffold(
       appBar: _TitleBar(
-        title: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
-          child: SearchField(
-            onSearch: (query) => navigator.pushAndRemoveSearch(query: query),
-            onSnapSelected: (name) => navigator.pushSnap(name: name),
-            onDebSelected: (id) => navigator.pushDeb(id: id),
-            searchFocus: searchFocus,
-          ),
+        title: Row(
+          children: [
+            Consumer(
+              builder: (_, ref, __) {
+                final routeName = ref.watch(routeNameProvider);
+                final canPop = routeName != null && routeName != '/';
+                return canPop
+                    ? YaruBackButton(
+                        style: YaruBackButtonStyle.rounded,
+                        onPressed: navigatorKey.currentState?.pop,
+                      )
+                    : const SizedBox();
+              },
+            ),
+            const Spacer(),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
+              child: SearchField(
+                onSearch: (query) =>
+                    navigator.pushAndRemoveSearch(query: query),
+                onSnapSelected: (name) => navigator.pushSnap(name: name),
+                onDebSelected: (id) => navigator.pushDeb(id: id),
+                searchFocus: searchFocus,
+              ),
+            ),
+            const Spacer(),
+          ],
         ),
       ),
       body: YaruMasterDetailPage(

--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -106,18 +106,7 @@ class _StoreAppHome extends ConsumerWidget {
       appBar: _TitleBar(
         title: Row(
           children: [
-            Consumer(
-              builder: (_, ref, __) {
-                final routeName = ref.watch(routeNameProvider);
-                final canPop = routeName != null && routeName != '/';
-                return canPop
-                    ? YaruBackButton(
-                        style: YaruBackButtonStyle.rounded,
-                        onPressed: navigatorKey.currentState?.pop,
-                      )
-                    : const SizedBox();
-              },
-            ),
+            _MaybeBackButton(navigatorKey),
             const Spacer(),
             ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
@@ -216,4 +205,22 @@ class _TitleBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => const Size(0, kYaruTitleBarHeight);
+}
+
+class _MaybeBackButton extends ConsumerWidget {
+  const _MaybeBackButton(this.navigatorKey);
+
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final routeName = ref.watch(routeNameProvider);
+    final canPop = routeName != null && routeName != '/';
+    return canPop
+        ? YaruBackButton(
+            style: YaruBackButtonStyle.rounded,
+            onPressed: navigatorKey.currentState?.pop,
+          )
+        : const SizedBox();
+  }
 }

--- a/packages/app_center/lib/store/store_observer.dart
+++ b/packages/app_center/lib/store/store_observer.dart
@@ -1,6 +1,5 @@
 import 'package:app_center/search/search.dart';
 import 'package:app_center/store/store.dart';
-import 'package:app_center/store/store_routes.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/packages/app_center/lib/store/store_observer.dart
+++ b/packages/app_center/lib/store/store_observer.dart
@@ -1,4 +1,5 @@
 import 'package:app_center/search/search.dart';
+import 'package:app_center/store/store.dart';
 import 'package:app_center/store/store_routes.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,5 +15,28 @@ class StoreObserver extends NavigatorObserver {
         ? StoreRoutes.queryOf(previousRoute.settings)
         : null;
     ref.read(queryProvider.notifier).state = query ?? '';
+    _updateRouteNameProvider(previousRoute);
+  }
+
+  @override
+  void didPush(Route<void> route, Route<void>? previousRoute) {
+    _updateRouteNameProvider(route);
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _updateRouteNameProvider(previousRoute);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    _updateRouteNameProvider(newRoute);
+  }
+
+  void _updateRouteNameProvider(Route<dynamic>? route) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      final routeName = route?.settings.name;
+      ref.read(routeNameProvider.notifier).state = routeName;
+    });
   }
 }


### PR DESCRIPTION
This moves up the back button to the title bar.

![image](https://github.com/ubuntu/app-center/assets/744771/5cc926cd-3ca3-4029-94df-e18a0f9b201d)

Supersedes: #1664
Fixes: #1727

Follow up: Move flag and share icons to be at the same height as the title