### PR TITLE
fix: Move share+flag icons to title row

### DIFF
--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -244,7 +244,6 @@ class _Header extends StatelessWidget {
             AppIcon(iconUrl: debModel.component.icon, size: 96),
             const SizedBox(width: 16),
             Expanded(child: AppTitle.fromDeb(debModel.component)),
-            const Spacer(),
             if (debModel.component.website != null)
               YaruIconButton(
                 icon: const Icon(YaruIcons.share),

--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -237,8 +237,13 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        const SizedBox(height: kPagePadding),
         Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            AppIcon(iconUrl: debModel.component.icon, size: 96),
+            const SizedBox(width: 16),
+            Expanded(child: AppTitle.fromDeb(debModel.component)),
             const Spacer(),
             if (debModel.component.website != null)
               YaruIconButton(
@@ -249,15 +254,6 @@ class _Header extends StatelessWidget {
                   );
                 },
               ),
-          ],
-        ),
-        const SizedBox(height: kPagePadding),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            AppIcon(iconUrl: debModel.component.icon, size: 96),
-            const SizedBox(width: 16),
-            Expanded(child: AppTitle.fromDeb(debModel.component)),
           ],
         ),
         const SizedBox(height: kPagePadding),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -508,7 +508,7 @@ class _IconRow extends ConsumerWidget {
 
     return Row(
       children: [
-        if (snap.website != null) ...[
+        if (snap.website != null)
           YaruIconButton(
             icon: const Icon(YaruIcons.share),
             onPressed: () {
@@ -522,8 +522,6 @@ class _IconRow extends ConsumerWidget {
               Clipboard.setData(ClipboardData(text: snap.website!));
             },
           ),
-          const SizedBox(width: 8),
-        ],
         YaruIconButton(
           icon: const Icon(YaruIcons.flag),
           onPressed: () {

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -148,7 +148,6 @@ class _SnapView extends StatelessWidget {
                         Expanded(
                           child: AppTitle.fromSnap(snapData.snap, large: true),
                         ),
-                        const Spacer(),
                         _IconRow(snapData: snapData),
                       ],
                     ),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -130,13 +130,7 @@ class _SnapView extends StatelessWidget {
 
     return Column(
       children: [
-        SizedBox(
-          width: layout.totalWidth,
-          child: Padding(
-            padding: const EdgeInsets.only(top: kPagePadding),
-            child: _Header(snapData: snapData),
-          ),
-        ),
+        const SizedBox(height: kPagePadding),
         Expanded(
           child: SingleChildScrollView(
             child: Center(
@@ -153,6 +147,12 @@ class _SnapView extends StatelessWidget {
                         Expanded(
                           child: AppTitle.fromSnap(snapData.snap, large: true),
                         ),
+                        const Spacer(),
+                        _IconRow(snapData: snapData),
+                        //SizedBox(
+                        //  width: 10,
+                        //  child:
+                        //),
                       ],
                     ),
                     const SizedBox(height: kPagePadding),
@@ -496,8 +496,8 @@ class _RatingsActionButtons extends ConsumerWidget {
   }
 }
 
-class _Header extends ConsumerWidget {
-  const _Header({required this.snapData});
+class _IconRow extends ConsumerWidget {
+  const _IconRow({required this.snapData});
 
   final SnapData snapData;
 
@@ -506,45 +506,38 @@ class _Header extends ConsumerWidget {
     final snap = snapData.storeSnap ?? snapData.localSnap!;
     final l10n = AppLocalizations.of(context);
 
-    return Column(
+    return Row(
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            const Spacer(),
-            if (snap.website != null)
-              YaruIconButton(
-                icon: const Icon(YaruIcons.share),
-                onPressed: () {
-                  final navigationKey =
-                      ref.watch(materialAppNavigatorKeyProvider);
+        if (snap.website != null) ...[
+          YaruIconButton(
+            icon: const Icon(YaruIcons.share),
+            onPressed: () {
+              final navigationKey = ref.watch(materialAppNavigatorKeyProvider);
 
-                  ScaffoldMessenger.of(navigationKey.currentContext!)
-                      .showSnackBar(
-                    SnackBar(
-                      content: Text(l10n.snapPageShareLinkCopiedMessage),
-                    ),
-                  );
-                  Clipboard.setData(ClipboardData(text: snap.website!));
-                },
-              ),
-            YaruIconButton(
-              icon: const Icon(YaruIcons.flag),
-              onPressed: () {
-                showDialog(
-                  context: context,
-                  builder: (context) {
-                    return ResponsiveLayoutBuilder(
-                      builder: (context) =>
-                          SnapReport(name: snapData.snap.titleOrName),
-                    );
-                  },
+              ScaffoldMessenger.of(navigationKey.currentContext!).showSnackBar(
+                SnackBar(
+                  content: Text(l10n.snapPageShareLinkCopiedMessage),
+                ),
+              );
+              Clipboard.setData(ClipboardData(text: snap.website!));
+            },
+          ),
+          const SizedBox(width: 8),
+        ],
+        YaruIconButton(
+          icon: const Icon(YaruIcons.flag),
+          onPressed: () {
+            showDialog(
+              context: context,
+              builder: (context) {
+                return ResponsiveLayoutBuilder(
+                  builder: (context) =>
+                      SnapReport(name: snapData.snap.titleOrName),
                 );
               },
-            ),
-          ],
+            );
+          },
         ),
-        const SizedBox(height: kPagePadding),
       ],
     );
   }

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -139,6 +139,7 @@ class _SnapView extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    const SizedBox(height: kPagePadding),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -149,10 +150,6 @@ class _SnapView extends StatelessWidget {
                         ),
                         const Spacer(),
                         _IconRow(snapData: snapData),
-                        //SizedBox(
-                        //  width: 10,
-                        //  child:
-                        //),
                       ],
                     ),
                     const SizedBox(height: kPagePadding),


### PR DESCRIPTION
Before:
![image](https://github.com/ubuntu/app-center/assets/744771/d09d6015-fd70-4d15-9222-e8ce03449c22)

After:
![image](https://github.com/ubuntu/app-center/assets/744771/47c76d26-a266-434b-86ef-b7c2359c9061)


