### PR TITLE
fix: styling improvements

### DIFF
--- a/packages/app_center/lib/constants.dart
+++ b/packages/app_center/lib/constants.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/icons.dart';
 
 const kAppName = 'App Center';
 const kGitHubRepo = 'ubuntu/app-center';
@@ -10,3 +11,11 @@ const kShimmerHighLightLight = Color.fromARGB(200, 247, 247, 247);
 const kShimmerHighLightDark = Color.fromARGB(255, 57, 57, 57);
 
 const kCircularProgressIndicatorHeight = 16.0;
+const kSearchFieldIconConstraints = BoxConstraints(
+  minWidth: 32,
+  minHeight: 32,
+  maxWidth: 32,
+  maxHeight: 32,
+);
+const kSearchFieldStrutStyle = StrutStyle(leading: 0.2);
+const kSearchFieldPrefixIcon = Icon(YaruIcons.search, size: 16);

--- a/packages/app_center/lib/explore/explore_page.dart
+++ b/packages/app_center/lib/explore/explore_page.dart
@@ -123,6 +123,7 @@ class _CategoryList extends StatelessWidget {
           .whereNot((category) => category.hidden)
           .map(
             (category) => InkWell(
+              borderRadius: BorderRadius.circular(kYaruButtonRadius),
               onTap: () => StoreNavigator.pushSearch(
                 context,
                 category: category.categoryName,

--- a/packages/app_center/lib/explore/explore_page.dart
+++ b/packages/app_center/lib/explore/explore_page.dart
@@ -133,7 +133,13 @@ class _CategoryList extends StatelessWidget {
                 children: [
                   Icon(category.icon(true)),
                   const SizedBox(width: 8),
-                  Text(category.localize(AppLocalizations.of(context))),
+                  Expanded(
+                    child: Text(
+                      category.localize(AppLocalizations.of(context)),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -156,8 +156,13 @@ class _ManageView extends ConsumerWidget {
                     // TODO: refactor - extract common text field decoration from
                     // here and the `SearchField` widget
                     child: TextFormField(
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      strutStyle: kSearchFieldStrutStyle,
+                      textAlignVertical: TextAlignVertical.center,
+                      cursorWidth: 1,
                       decoration: InputDecoration(
-                        prefixIcon: const Icon(YaruIcons.search, size: 16),
+                        prefixIcon: kSearchFieldPrefixIcon,
+                        prefixIconConstraints: kSearchFieldIconConstraints,
                         hintText: l10n.managePageSearchFieldSearchHint,
                       ),
                       initialValue: ref.watch(localSnapFilterProvider),

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -241,7 +241,7 @@ class _ActionButtons extends ConsumerWidget {
         const SizedBox(
           height: kCircularProgressIndicatorHeight,
           child: YaruCircularProgressIndicator(
-            strokeWidth: 4,
+            strokeWidth: 2,
           ),
         ),
       ),
@@ -595,7 +595,7 @@ class _ButtonBarForOpen extends ConsumerWidget {
     final snapLauncher = ref.watch(launchProvider(snap));
     final l10n = AppLocalizations.of(context);
 
-    return ButtonBar(
+    return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         Visibility(
@@ -604,14 +604,14 @@ class _ButtonBarForOpen extends ConsumerWidget {
           maintainState: true,
           visible: snapLauncher.isLaunchable,
           child: OutlinedButton(
-            style: const ButtonStyle(
-              padding: MaterialStatePropertyAll(EdgeInsets.zero),
-            ),
             onPressed: snapLauncher.open,
             child: Text(
               l10n.snapActionOpenLabel,
             ),
           ),
+        ),
+        const SizedBox(
+          width: 8,
         ),
         MenuAnchor(
           menuChildren: [

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -129,9 +129,9 @@ class _ManageView extends ConsumerWidget {
             itemCount: manageModel.refreshableSnaps.length,
             itemBuilder: (context, index) => _ManageSnapTile(
               snap: manageModel.refreshableSnaps.elementAt(index),
-              position: detemineTilePosition(
+              position: determinePosition(
                 index: index,
-                snaps: manageModel.refreshableSnaps,
+                length: manageModel.refreshableSnaps.length,
               ),
               showUpdateButton: true,
             ),
@@ -213,8 +213,10 @@ class _ManageView extends ConsumerWidget {
             itemCount: filteredLocalSnaps.length,
             itemBuilder: (context, index) => _ManageSnapTile(
               snap: filteredLocalSnaps.elementAt(index),
-              position:
-                  detemineTilePosition(index: index, snaps: filteredLocalSnaps),
+              position: determinePosition(
+                index: index,
+                length: filteredLocalSnaps.length,
+              ),
             ),
           ),
         ],
@@ -485,16 +487,15 @@ class _ManageSnapTile extends ConsumerWidget {
   }
 }
 
-ManageTilePosition detemineTilePosition({
+ManageTilePosition determinePosition({
   required int index,
-  required Iterable<Snap> snaps,
+  required int length,
 }) {
-  if (snaps.length == 1) {
+  if (length == 1) {
     return ManageTilePosition.single;
   }
 
-  final isLast = index == (snaps.length - 1);
-  if (isLast) {
+  if (index == length - 1) {
     return ManageTilePosition.last;
   }
 
@@ -521,13 +522,10 @@ class _ButtonBarForUpdate extends ConsumerWidget {
         ? ref.watch(activeChangeProvider(activeChangeId))
         : null;
 
-    return ButtonBar(
+    return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        PushButton.outlined(
-          style: const ButtonStyle(
-            padding: MaterialStatePropertyAll(EdgeInsets.zero),
-          ),
+        OutlinedButton(
           onPressed: updatesModel.activeChangeId != null || !snapModel.hasValue
               ? null
               : ref.read(snapModelProvider(snap.name).notifier).refresh,
@@ -564,6 +562,7 @@ class _ButtonBarForUpdate extends ConsumerWidget {
                   ],
                 ),
         ),
+        const SizedBox(width: 8),
         MenuAnchor(
           menuChildren: [
             Visibility(

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -129,13 +129,10 @@ class _ManageView extends ConsumerWidget {
             itemCount: manageModel.refreshableSnaps.length,
             itemBuilder: (context, index) => _ManageSnapTile(
               snap: manageModel.refreshableSnaps.elementAt(index),
-              position: index == (manageModel.refreshableSnaps.length - 1)
-                  ? index == 0
-                      ? ManageTilePosition.single
-                      : ManageTilePosition.last
-                  : index == 0
-                      ? ManageTilePosition.first
-                      : ManageTilePosition.middle,
+              position: detemineTilePosition(
+                index: index,
+                snaps: manageModel.refreshableSnaps,
+              ),
               showUpdateButton: true,
             ),
           ),
@@ -216,13 +213,8 @@ class _ManageView extends ConsumerWidget {
             itemCount: filteredLocalSnaps.length,
             itemBuilder: (context, index) => _ManageSnapTile(
               snap: filteredLocalSnaps.elementAt(index),
-              position: index == (filteredLocalSnaps.length - 1)
-                  ? index == 0
-                      ? ManageTilePosition.single
-                      : ManageTilePosition.last
-                  : index == 0
-                      ? ManageTilePosition.first
-                      : ManageTilePosition.middle,
+              position:
+                  detemineTilePosition(index: index, snaps: filteredLocalSnaps),
             ),
           ),
         ],
@@ -373,7 +365,7 @@ class _ManageSnapTile extends ConsumerWidget {
           ManageTilePosition.middle => BorderRadius.zero,
           ManageTilePosition.last =>
             const BorderRadius.only(bottomLeft: radius, bottomRight: radius),
-          ManageTilePosition.single => BorderRadius.zero,
+          ManageTilePosition.single => const BorderRadius.all(radius),
         },
         border: switch (position) {
           ManageTilePosition.first => Border(
@@ -392,8 +384,7 @@ class _ManageSnapTile extends ConsumerWidget {
               left: border,
               right: border,
             ),
-          ManageTilePosition.single =>
-            const Border.fromBorderSide(BorderSide.none),
+          ManageTilePosition.single => Border.fromBorderSide(border),
         },
       ),
       child: ListTile(
@@ -491,6 +482,26 @@ class _ManageSnapTile extends ConsumerWidget {
             : _ButtonBarForOpen(snap),
       ),
     );
+  }
+}
+
+ManageTilePosition detemineTilePosition({
+  required int index,
+  required Iterable<Snap> snaps,
+}) {
+  if (snaps.length == 1) {
+    return ManageTilePosition.single;
+  }
+
+  final isLast = index == (snaps.length - 1);
+  if (isLast) {
+    return ManageTilePosition.last;
+  }
+
+  if (index == 0) {
+    return ManageTilePosition.first;
+  } else {
+    return ManageTilePosition.middle;
   }
 }
 

--- a/packages/app_center/lib/search/search_field.dart
+++ b/packages/app_center/lib/search/search_field.dart
@@ -1,4 +1,5 @@
 import 'package:app_center/appstream/appstream.dart';
+import 'package:app_center/constants.dart';
 import 'package:app_center/search/search_provider.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/widgets/widgets.dart';
@@ -164,13 +165,12 @@ class _SearchFieldState extends ConsumerState<SearchField> {
               ref.listen(queryProvider, (prev, next) {
                 if (!node.hasPrimaryFocus) controller.text = next ?? '';
               });
-              const iconConstraints = BoxConstraints(
-                minWidth: 32,
-                minHeight: 32,
-                maxWidth: 32,
-                maxHeight: 32,
-              );
+
               return TextField(
+                style: Theme.of(context).textTheme.bodyMedium,
+                strutStyle: kSearchFieldStrutStyle,
+                textAlignVertical: TextAlignVertical.center,
+                cursorWidth: 1,
                 focusNode: node,
                 controller: controller,
                 onChanged: (_) => _optionsAvailable = false,
@@ -179,8 +179,8 @@ class _SearchFieldState extends ConsumerState<SearchField> {
                     : widget.onSearch(query),
                 decoration: InputDecoration(
                   contentPadding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
-                  prefixIcon: const Icon(YaruIcons.search, size: 16),
-                  prefixIconConstraints: iconConstraints,
+                  prefixIcon: kSearchFieldPrefixIcon,
+                  prefixIconConstraints: kSearchFieldIconConstraints,
                   hintText: l10n.searchFieldSearchHint,
                   suffixIcon: AnimatedBuilder(
                     animation: controller,
@@ -192,7 +192,7 @@ class _SearchFieldState extends ConsumerState<SearchField> {
                       );
                     },
                   ),
-                  suffixIconConstraints: iconConstraints,
+                  suffixIconConstraints: kSearchFieldIconConstraints,
                 ),
               );
             },


### PR DESCRIPTION
|                                                   | before| after| 
| ---| ---| ---| 
| explore page category button borderradius |<img width="226" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/30da2412-6094-4c52-834b-7dbfb5e1141c">|<img width="226" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/91092383-a165-4b32-b492-773f29279928">| 
|manage page open button padding               |<img width="120" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/656be384-5de2-4006-b466-7c1ae9ed947a">|<img width="132" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/d0959d90-b086-403a-9875-6cd32bd8258e">|
|search field alignment                                    |<img width="910" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/748e089f-24bf-44ad-bbb3-842caf6a3868">|<img width="910" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/f8f4f9e5-7ae4-4295-a68c-7b4eb39f6421">|
|overflow|<img width="589" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/da2e2bb9-bf6e-4c7e-8557-c75c554b85aa">|<img width="589" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/e4022a42-336a-4346-8839-6449dcee7016">|
|manage: single snap missing border|<img width="862" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/616ed373-cfbe-4395-a18a-5ac3e6bd8a70">|<img width="862" alt="grafik" src="https://github.com/ubuntu/app-center/assets/15329494/c880c59e-e99f-4b8c-8ed2-117f84b6b8a6">|

manage page update button spinner
before

https://github.com/ubuntu/app-center/assets/15329494/ab21b7f3-c785-41b9-95a9-00ec1631fc48

after

https://github.com/ubuntu/app-center/assets/15329494/a1e8bfe7-0cac-4e98-9260-a49758713d90





Closes #1657
Closes #1558
Closes #1719 