### PR TITLE
Add launcher for "updates"

### DIFF
--- a/packages/app_center/assets/app-center-updates.desktop
+++ b/packages/app_center/assets/app-center-updates.desktop
@@ -1,4 +1,7 @@
 [Desktop Entry]
+# This desktop entry is required to allow Snapd Desktop Integration
+# to open the Snap Center in the "updates" page when the user
+# clicks "Show updates" in a notification. DO NOT DELETE.
 Type=Application
 Version=1.0
 Exec=snap-store --updates %U

--- a/packages/app_center/assets/app-center-updates.desktop
+++ b/packages/app_center/assets/app-center-updates.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Exec=snap-store --updates %U
+Icon=bin/data/flutter_assets/assets/app-center.png
+Terminal=false
+Categories=System;Utility;PackageManager;SoftwareManagement;Network;Settings;
+Keywords=Ubuntu;Applications;Apps;Store;Software;Snaps;
+Name=App Center Updates
+NoDisplay=true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,19 +60,26 @@ parts:
 apps:
   snap-store:
     command: bin/snap-store
-    environment:
+    environment: &store_env
       RATINGS_SERVICE_URL: 'ratings.ubuntu.com'
       RATINGS_SERVICE_PORT: '443'
       RATINGS_SERVICE_USE_TLS: 'true'
     desktop: bin/data/flutter_assets/assets/app-center.desktop
     extensions: [gnome]
-    plugs:
+    plugs: &store_plugs
       - appstream-metadata
       - desktop
       - desktop-launch
       - network
       - snapd-control
       - packagekit-control
+
+  show-updates:
+    command: bin/snap-store --updates
+    desktop: bin/data/flutter_assets/assets/app-center-updates.desktop
+    environment: *store_env
+    extensions: [gnome]
+    plugs: *store_plugs
 
 slots:
   packagekit-svc:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,6 +74,10 @@ apps:
       - snapd-control
       - packagekit-control
 
+# This entry, along with the corresponding .desktop file, is required
+# to allow Snapd Desktop Integration to open the Snap Center in the
+# "updates" page when the user clicks "Show updates" in a notification.
+# DO NOT DELETE.
   show-updates:
     command: bin/snap-store --updates
     desktop: bin/data/flutter_assets/assets/app-center-updates.desktop


### PR DESCRIPTION
This patch adds an extra, invisible, .desktop file that opens the store in the "updates" page directly. This is needed because in the new Refresh App Awareness, we want to allow the user to open the snap-center in the "updates" page directly from a "pending update" notification, but since it is `snapd-desktop-integration` the application that opens it, and it is inside another snap, the only way that it has to launch the `snap-center` is using the `desktop-launch` DBus interface. This interface, unfortunately, doesn't allow to pass parameters, only allows to pass the name of a `.desktop` file to launch, so this workaround is needed.