### PR TITLE
feat: add --updates flag to open manage page

### DIFF
--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -2,6 +2,7 @@ import 'package:app_center/deb/deb.dart';
 import 'package:app_center/games/games.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
+import 'package:app_center/manage/manage_page.dart';
 import 'package:app_center/providers/error_stream_provider.dart';
 import 'package:app_center/search/search.dart';
 import 'package:app_center/snapd/snapd.dart';
@@ -156,6 +157,10 @@ class _StoreAppHome extends ConsumerWidget {
           StoreRoutes.externalTools => MaterialPageRoute(
               settings: settings,
               builder: (_) => const ExternalTools(),
+            ),
+          StoreRoutes.manage => MaterialPageRoute(
+              settings: settings,
+              builder: (_) => const ManagePage(),
             ),
           _ => null,
         },

--- a/packages/app_center/lib/store/store_providers.dart
+++ b/packages/app_center/lib/store/store_providers.dart
@@ -28,6 +28,7 @@ String? _parseRoute(List<String>? args) {
   final parser = ArgParser();
   parser.addOption('snap', valueHelp: 'name', help: 'Show snap details');
   parser.addOption('search', valueHelp: 'query', help: 'Search for snaps');
+  parser.addFlag('updates', negatable: false, help: 'Show manage page');
 
   try {
     if (args?.firstOrNull?.startsWith(_kUrlPrefix) ?? false) {
@@ -52,6 +53,10 @@ String? _parseRoute(List<String>? args) {
     final snap = result['snap'] as String? ?? result.rest.singleOrNull;
     if (snap != null) {
       return StoreRoutes.namedSnap(name: snap);
+    }
+
+    if (result.flag('updates')) {
+      return StoreRoutes.manage;
     }
   } on FormatException {
     // TODO: print usage

--- a/packages/app_center/test/initial_route_test.dart
+++ b/packages/app_center/test/initial_route_test.dart
@@ -86,6 +86,24 @@ void main() {
     ).called(1);
   });
 
+  test('updates', () {
+    final container = ProviderContainer(
+      overrides: [
+        commandLineProvider.overrideWith((ref) => ['--updates']),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final listener = MockInitialRouteListener();
+    container.listen<String?>(
+      initialRouteProvider,
+      listener.call,
+      fireImmediately: true,
+    );
+
+    verify(listener(null, StoreRoutes.manage)).called(1);
+  });
+
   test('no arguments', () {
     final container = ProviderContainer(
       overrides: [commandLineProvider.overrideWith((ref) => [])],


### PR DESCRIPTION
Adds an `--updates` flag that can be used to immediately show the manage page when the app is launched.

The way App Center currently manages routes and pages is a bit messy, so this would place the manage page on top of the navigator stack in the right pane, instead of making it the initial selection in the menu on the left side. See screenshots for more details.
To make this work properly, we'd need to refactor the store navigation and routes quite a bit.

|Proper implementation|Quick implementation (this PR)|
|-|-|
|![Screenshot from 2024-07-09 18-01-29](https://github.com/ubuntu/app-center/assets/113362648/8ac7aa12-43ee-405a-aa3e-24a3ac2bd6c4)|![Screenshot from 2024-07-09 18-01-22](https://github.com/ubuntu/app-center/assets/113362648/02442d5d-6506-425a-863a-6bfbb63e9400)|



Ref #1733
UDENG-3532