### PR TITLE
feat: Add rated category snaps to the Games tab

### DIFF
--- a/packages/app_center/lib/games/games_page.dart
+++ b/packages/app_center/lib/games/games_page.dart
@@ -39,8 +39,16 @@ class GamesPage extends ConsumerWidget {
             const SizedBox(height: kPagePadding),
           ],
         ),
-        const CategorySnapList(
-          category: SnapCategoryEnum.games,
+        const RatedCategorySnapList(
+          categories: {
+            SnapCategoryEnum.games,
+            SnapCategoryEnum.kdeGames,
+            SnapCategoryEnum.gnomeGames,
+            SnapCategoryEnum.gameLaunchers,
+            SnapCategoryEnum.gameEmulators,
+            SnapCategoryEnum.gameContentCreation,
+            SnapCategoryEnum.gameDev,
+          },
         ),
         SliverList.list(
           children: [

--- a/packages/app_center/lib/games/games_page.dart
+++ b/packages/app_center/lib/games/games_page.dart
@@ -40,15 +40,7 @@ class GamesPage extends ConsumerWidget {
           ],
         ),
         const RatedCategorySnapList(
-          categories: [
-            SnapCategoryEnum.games,
-            SnapCategoryEnum.kdeGames,
-            SnapCategoryEnum.gnomeGames,
-            SnapCategoryEnum.gameLaunchers,
-            SnapCategoryEnum.gameEmulators,
-            SnapCategoryEnum.gameContentCreation,
-            SnapCategoryEnum.gameDev,
-          ],
+          categories: [SnapCategoryEnum.games],
         ),
         SliverList.list(
           children: [

--- a/packages/app_center/lib/games/games_page.dart
+++ b/packages/app_center/lib/games/games_page.dart
@@ -40,7 +40,7 @@ class GamesPage extends ConsumerWidget {
           ],
         ),
         const RatedCategorySnapList(
-          categories: {
+          categories: [
             SnapCategoryEnum.games,
             SnapCategoryEnum.kdeGames,
             SnapCategoryEnum.gnomeGames,
@@ -48,7 +48,7 @@ class GamesPage extends ConsumerWidget {
             SnapCategoryEnum.gameEmulators,
             SnapCategoryEnum.gameContentCreation,
             SnapCategoryEnum.gameDev,
-          },
+          ],
         ),
         SliverList.list(
           children: [

--- a/packages/app_center/lib/games/games_page_featured.dart
+++ b/packages/app_center/lib/games/games_page_featured.dart
@@ -22,7 +22,7 @@ class FeaturedCarousel extends ConsumerStatefulWidget {
 
 class _FeaturedCarouselState extends ConsumerState<FeaturedCarousel> {
   late YaruCarouselController controller;
-  late Iterable<Snap> snaps;
+  Iterable<Snap> snaps = [];
 
   @override
   Widget build(BuildContext context) {

--- a/packages/app_center/lib/ratings/rated_category_model.dart
+++ b/packages/app_center/lib/ratings/rated_category_model.dart
@@ -1,0 +1,35 @@
+import 'package:app_center/ratings/ratings_service.dart';
+import 'package:app_center/snapd/snapd.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:snapd/snapd.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+part 'rated_category_model.g.dart';
+
+@riverpod
+class RatedCategoryModel extends _$RatedCategoryModel {
+  late final _ratings = getService<RatingsService>();
+  late final _snapd = getService<SnapdService>();
+
+  @override
+  Future<List<Snap>> build(
+    List<SnapCategoryEnum> categories,
+    int numberOfSnaps,
+  ) async {
+    final snaps = <Snap>[];
+
+    for (final category in categories) {
+      final chart = await _ratings.getChart(category);
+      var i = 0;
+      while (snaps.length < numberOfSnaps && i < chart.length) {
+        final snap = await _snapd.findById(chart[i].rating.snapId);
+        if (snap != null && snap.screenshotUrls.isNotEmpty) {
+          snaps.add(snap);
+        }
+        i++;
+      }
+    }
+
+    return snaps;
+  }
+}

--- a/packages/app_center/lib/ratings/rated_category_model.dart
+++ b/packages/app_center/lib/ratings/rated_category_model.dart
@@ -20,13 +20,11 @@ class RatedCategoryModel extends _$RatedCategoryModel {
 
     for (final category in categories) {
       final chart = await _ratings.getChart(category);
-      var i = 0;
-      while (snaps.length < numberOfSnaps && i < chart.length) {
+      for (var i = 0; snaps.length < numberOfSnaps && i < chart.length; i++) {
         final snap = await _snapd.findById(chart[i].rating.snapId);
         if (snap != null && snap.screenshotUrls.isNotEmpty) {
           snaps.add(snap);
         }
-        i++;
       }
     }
 

--- a/packages/app_center/lib/ratings/rated_category_model.g.dart
+++ b/packages/app_center/lib/ratings/rated_category_model.g.dart
@@ -7,7 +7,7 @@ part of 'rated_category_model.dart';
 // **************************************************************************
 
 String _$ratedCategoryModelHash() =>
-    r'ff7cf67846bd5a4878b79315160604ee9b62df5b';
+    r'5fad0c098fbb1b6f11ea7904a51da353c3826e84';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/packages/app_center/lib/ratings/rated_category_model.g.dart
+++ b/packages/app_center/lib/ratings/rated_category_model.g.dart
@@ -1,0 +1,199 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rated_category_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$ratedCategoryModelHash() =>
+    r'ff7cf67846bd5a4878b79315160604ee9b62df5b';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$RatedCategoryModel
+    extends BuildlessAutoDisposeAsyncNotifier<List<Snap>> {
+  late final List<SnapCategoryEnum> categories;
+  late final int numberOfSnaps;
+
+  FutureOr<List<Snap>> build(
+    List<SnapCategoryEnum> categories,
+    int numberOfSnaps,
+  );
+}
+
+/// See also [RatedCategoryModel].
+@ProviderFor(RatedCategoryModel)
+const ratedCategoryModelProvider = RatedCategoryModelFamily();
+
+/// See also [RatedCategoryModel].
+class RatedCategoryModelFamily extends Family<AsyncValue<List<Snap>>> {
+  /// See also [RatedCategoryModel].
+  const RatedCategoryModelFamily();
+
+  /// See also [RatedCategoryModel].
+  RatedCategoryModelProvider call(
+    List<SnapCategoryEnum> categories,
+    int numberOfSnaps,
+  ) {
+    return RatedCategoryModelProvider(
+      categories,
+      numberOfSnaps,
+    );
+  }
+
+  @override
+  RatedCategoryModelProvider getProviderOverride(
+    covariant RatedCategoryModelProvider provider,
+  ) {
+    return call(
+      provider.categories,
+      provider.numberOfSnaps,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'ratedCategoryModelProvider';
+}
+
+/// See also [RatedCategoryModel].
+class RatedCategoryModelProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    RatedCategoryModel, List<Snap>> {
+  /// See also [RatedCategoryModel].
+  RatedCategoryModelProvider(
+    List<SnapCategoryEnum> categories,
+    int numberOfSnaps,
+  ) : this._internal(
+          () => RatedCategoryModel()
+            ..categories = categories
+            ..numberOfSnaps = numberOfSnaps,
+          from: ratedCategoryModelProvider,
+          name: r'ratedCategoryModelProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$ratedCategoryModelHash,
+          dependencies: RatedCategoryModelFamily._dependencies,
+          allTransitiveDependencies:
+              RatedCategoryModelFamily._allTransitiveDependencies,
+          categories: categories,
+          numberOfSnaps: numberOfSnaps,
+        );
+
+  RatedCategoryModelProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.categories,
+    required this.numberOfSnaps,
+  }) : super.internal();
+
+  final List<SnapCategoryEnum> categories;
+  final int numberOfSnaps;
+
+  @override
+  FutureOr<List<Snap>> runNotifierBuild(
+    covariant RatedCategoryModel notifier,
+  ) {
+    return notifier.build(
+      categories,
+      numberOfSnaps,
+    );
+  }
+
+  @override
+  Override overrideWith(RatedCategoryModel Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: RatedCategoryModelProvider._internal(
+        () => create()
+          ..categories = categories
+          ..numberOfSnaps = numberOfSnaps,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        categories: categories,
+        numberOfSnaps: numberOfSnaps,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<RatedCategoryModel, List<Snap>>
+      createElement() {
+    return _RatedCategoryModelProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is RatedCategoryModelProvider &&
+        other.categories == categories &&
+        other.numberOfSnaps == numberOfSnaps;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, categories.hashCode);
+    hash = _SystemHash.combine(hash, numberOfSnaps.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin RatedCategoryModelRef on AutoDisposeAsyncNotifierProviderRef<List<Snap>> {
+  /// The parameter `categories` of this provider.
+  List<SnapCategoryEnum> get categories;
+
+  /// The parameter `numberOfSnaps` of this provider.
+  int get numberOfSnaps;
+}
+
+class _RatedCategoryModelProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<RatedCategoryModel,
+        List<Snap>> with RatedCategoryModelRef {
+  _RatedCategoryModelProviderElement(super.provider);
+
+  @override
+  List<SnapCategoryEnum> get categories =>
+      (origin as RatedCategoryModelProvider).categories;
+  @override
+  int get numberOfSnaps => (origin as RatedCategoryModelProvider).numberOfSnaps;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/app_center/lib/ratings/ratings_service.dart
+++ b/packages/app_center/lib/ratings/ratings_service.dart
@@ -37,42 +37,10 @@ class RatingsService {
 
   Future<List<ratings.ChartData>> getChart(SnapCategoryEnum category) async {
     await _ensureValidToken();
-
-    final categoryToChart = {
-      SnapCategoryEnum.artAndDesign: ratings.Category.ART_AND_DESIGN,
-      SnapCategoryEnum.booksAndReference: ratings.Category.BOOK_AND_REFERENCE,
-      SnapCategoryEnum.development: ratings.Category.DEVELOPMENT,
-      SnapCategoryEnum.devicesAndIot: ratings.Category.DEVICES_AND_IOT,
-      SnapCategoryEnum.education: ratings.Category.EDUCATION,
-      SnapCategoryEnum.entertainment: ratings.Category.ENTERTAINMENT,
-      SnapCategoryEnum.featured: ratings.Category.FEATURED,
-      SnapCategoryEnum.finance: ratings.Category.FINANCE,
-      SnapCategoryEnum.gameContentCreation: ratings.Category.GAMES,
-      SnapCategoryEnum.gameDev: ratings.Category.GAMES,
-      SnapCategoryEnum.gameEmulators: ratings.Category.GAMES,
-      SnapCategoryEnum.gameLaunchers: ratings.Category.GAMES,
-      SnapCategoryEnum.games: ratings.Category.GAMES,
-      SnapCategoryEnum.gnomeGames: ratings.Category.GAMES,
-      SnapCategoryEnum.healthAndFitness: ratings.Category.HEALTH_AND_FITNESS,
-      SnapCategoryEnum.kdeGames: ratings.Category.GAMES,
-      SnapCategoryEnum.musicAndAudio: ratings.Category.MUSIC_AND_AUDIO,
-      SnapCategoryEnum.newsAndWeather: ratings.Category.NEWS_AND_WEATHER,
-      SnapCategoryEnum.personalisation: ratings.Category.PERSONALISATION,
-      SnapCategoryEnum.photoAndVideo: ratings.Category.PHOTO_AND_VIDEO,
-      SnapCategoryEnum.productivity: ratings.Category.PRODUCTIVITY,
-      SnapCategoryEnum.science: ratings.Category.SCIENCE,
-      SnapCategoryEnum.security: ratings.Category.SECURITY,
-      SnapCategoryEnum.serverAndCloud: ratings.Category.SERVER_AND_CLOUD,
-      SnapCategoryEnum.social: ratings.Category.SOCIAL,
-      // SnapCategoryEnum.ubuntuDesktop: 0, // no valid mapping
-      // SnapCategoryEnum.unknown: 0, // no valid mapping
-      SnapCategoryEnum.utilities: ratings.Category.UTILITIES,
-    };
-
     return client.getChart(
       ratings.Timeframe.unspecified,
       _jwt!,
-      categoryToChart[category],
+      category.toProto(),
     );
   }
 
@@ -95,4 +63,41 @@ class RatingsService {
     await _ensureValidToken();
     return client.getSnapVotes(snapId, _jwt!);
   }
+}
+
+extension CategoryToChartConversion on SnapCategoryEnum {
+  ratings.Category toProto() => switch (this) {
+        SnapCategoryEnum.artAndDesign => ratings.Category.ART_AND_DESIGN,
+        SnapCategoryEnum.booksAndReference =>
+          ratings.Category.BOOK_AND_REFERENCE,
+        SnapCategoryEnum.development => ratings.Category.DEVELOPMENT,
+        SnapCategoryEnum.devicesAndIot => ratings.Category.DEVICES_AND_IOT,
+        SnapCategoryEnum.education => ratings.Category.EDUCATION,
+        SnapCategoryEnum.entertainment => ratings.Category.ENTERTAINMENT,
+        SnapCategoryEnum.featured => ratings.Category.FEATURED,
+        SnapCategoryEnum.finance => ratings.Category.FINANCE,
+        SnapCategoryEnum.gameDev => ratings.Category.GAMES,
+        SnapCategoryEnum.gameEmulators => ratings.Category.GAMES,
+        SnapCategoryEnum.games => ratings.Category.GAMES,
+        SnapCategoryEnum.gnomeGames => ratings.Category.GAMES,
+        SnapCategoryEnum.kdeGames => ratings.Category.GAMES,
+        SnapCategoryEnum.gameLaunchers => ratings.Category.GAMES,
+        SnapCategoryEnum.gameContentCreation => ratings.Category.GAMES,
+        SnapCategoryEnum.healthAndFitness =>
+          ratings.Category.HEALTH_AND_FITNESS,
+        SnapCategoryEnum.musicAndAudio => ratings.Category.MUSIC_AND_AUDIO,
+        SnapCategoryEnum.newsAndWeather => ratings.Category.NEWS_AND_WEATHER,
+        SnapCategoryEnum.personalisation => ratings.Category.PERSONALISATION,
+        SnapCategoryEnum.photoAndVideo => ratings.Category.PHOTO_AND_VIDEO,
+        SnapCategoryEnum.productivity => ratings.Category.PRODUCTIVITY,
+        SnapCategoryEnum.science => ratings.Category.SCIENCE,
+        SnapCategoryEnum.security => ratings.Category.SECURITY,
+        SnapCategoryEnum.serverAndCloud => ratings.Category.SERVER_AND_CLOUD,
+        SnapCategoryEnum.social => ratings.Category.SOCIAL,
+        SnapCategoryEnum.utilities => ratings.Category.UTILITIES,
+        SnapCategoryEnum.unknown =>
+          throw ArgumentError('Category $this cannot be converted'),
+        SnapCategoryEnum.ubuntuDesktop =>
+          throw ArgumentError('Category $this cannot be converted'),
+      };
 }

--- a/packages/app_center/lib/ratings/ratings_service.dart
+++ b/packages/app_center/lib/ratings/ratings_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:app_center/snapd/snap_category_enum.dart';
 import 'package:app_center_ratings_client/app_center_ratings_client.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
@@ -33,9 +34,9 @@ class RatingsService {
     return client.getRating(snapId, _jwt!);
   }
 
-  Future<List<ChartData>> getChart() async {
+  Future<List<ChartData>> getChart(SnapCategoryEnum category) async {
     await _ensureValidToken();
-    return client.getChart(Timeframe.unspecified, _jwt!);
+    return client.getChart(Timeframe.unspecified, _jwt!, category.index);
   }
 
   Future<void> vote(Vote vote) async {

--- a/packages/app_center/lib/ratings/ratings_service.dart
+++ b/packages/app_center/lib/ratings/ratings_service.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:app_center/snapd/snap_category_enum.dart';
-import 'package:app_center_ratings_client/app_center_ratings_client.dart';
+import 'package:app_center_ratings_client/app_center_ratings_client.dart'
+    as ratings;
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -13,7 +14,7 @@ class RatingsService {
   RatingsService(this.client, {@visibleForTesting String? id})
       : _id = id ?? _generateId();
 
-  final RatingsClient client;
+  final ratings.RatingsClient client;
   String? _jwt;
   final String _id;
 
@@ -29,17 +30,53 @@ class RatingsService {
     }
   }
 
-  Future<Rating?> getRating(String snapId) async {
+  Future<ratings.Rating?> getRating(String snapId) async {
     await _ensureValidToken();
     return client.getRating(snapId, _jwt!);
   }
 
-  Future<List<ChartData>> getChart(SnapCategoryEnum category) async {
+  Future<List<ratings.ChartData>> getChart(SnapCategoryEnum category) async {
     await _ensureValidToken();
-    return client.getChart(Timeframe.unspecified, _jwt!, category.index);
+
+    final categoryToChart = {
+      SnapCategoryEnum.artAndDesign: ratings.Category.ART_AND_DESIGN,
+      SnapCategoryEnum.booksAndReference: ratings.Category.BOOK_AND_REFERENCE,
+      SnapCategoryEnum.development: ratings.Category.DEVELOPMENT,
+      SnapCategoryEnum.devicesAndIot: ratings.Category.DEVICES_AND_IOT,
+      SnapCategoryEnum.education: ratings.Category.EDUCATION,
+      SnapCategoryEnum.entertainment: ratings.Category.ENTERTAINMENT,
+      SnapCategoryEnum.featured: ratings.Category.FEATURED,
+      SnapCategoryEnum.finance: ratings.Category.FINANCE,
+      SnapCategoryEnum.gameContentCreation: ratings.Category.GAMES,
+      SnapCategoryEnum.gameDev: ratings.Category.GAMES,
+      SnapCategoryEnum.gameEmulators: ratings.Category.GAMES,
+      SnapCategoryEnum.gameLaunchers: ratings.Category.GAMES,
+      SnapCategoryEnum.games: ratings.Category.GAMES,
+      SnapCategoryEnum.gnomeGames: ratings.Category.GAMES,
+      SnapCategoryEnum.healthAndFitness: ratings.Category.HEALTH_AND_FITNESS,
+      SnapCategoryEnum.kdeGames: ratings.Category.GAMES,
+      SnapCategoryEnum.musicAndAudio: ratings.Category.MUSIC_AND_AUDIO,
+      SnapCategoryEnum.newsAndWeather: ratings.Category.NEWS_AND_WEATHER,
+      SnapCategoryEnum.personalisation: ratings.Category.PERSONALISATION,
+      SnapCategoryEnum.photoAndVideo: ratings.Category.PHOTO_AND_VIDEO,
+      SnapCategoryEnum.productivity: ratings.Category.PRODUCTIVITY,
+      SnapCategoryEnum.science: ratings.Category.SCIENCE,
+      SnapCategoryEnum.security: ratings.Category.SECURITY,
+      SnapCategoryEnum.serverAndCloud: ratings.Category.SERVER_AND_CLOUD,
+      SnapCategoryEnum.social: ratings.Category.SOCIAL,
+      // SnapCategoryEnum.ubuntuDesktop: 0, // no valid mapping
+      // SnapCategoryEnum.unknown: 0, // no valid mapping
+      SnapCategoryEnum.utilities: ratings.Category.UTILITIES,
+    };
+
+    return client.getChart(
+      ratings.Timeframe.unspecified,
+      _jwt!,
+      categoryToChart[category],
+    );
   }
 
-  Future<void> vote(Vote vote) async {
+  Future<void> vote(ratings.Vote vote) async {
     await _ensureValidToken();
     await client.vote(vote.snapId, vote.snapRevision, vote.voteUp, _jwt!);
   }
@@ -49,12 +86,12 @@ class RatingsService {
     await client.delete(_jwt!);
   }
 
-  Future<List<Vote>> listMyVotes(String snapFilter) async {
+  Future<List<ratings.Vote>> listMyVotes(String snapFilter) async {
     await _ensureValidToken();
     return client.listMyVotes(snapFilter, _jwt!);
   }
 
-  Future<List<Vote>> getSnapVotes(String snapId) async {
+  Future<List<ratings.Vote>> getSnapVotes(String snapId) async {
     await _ensureValidToken();
     return client.getSnapVotes(snapId, _jwt!);
   }

--- a/packages/app_center/lib/ratings/ratings_service.dart
+++ b/packages/app_center/lib/ratings/ratings_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:app_center_ratings_client/app_center_ratings_client.dart';
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:glib/glib.dart';
 import 'package:jwt_decode/jwt_decode.dart';
@@ -30,6 +31,11 @@ class RatingsService {
   Future<Rating?> getRating(String snapId) async {
     await _ensureValidToken();
     return client.getRating(snapId, _jwt!);
+  }
+
+  Future<List<ChartData>> getChart() async {
+    await _ensureValidToken();
+    return client.getChart(Timeframe.unspecified, _jwt!);
   }
 
   Future<void> vote(Vote vote) async {

--- a/packages/app_center/lib/snapd/snapd_service.dart
+++ b/packages/app_center/lib/snapd/snapd_service.dart
@@ -16,7 +16,9 @@ class SnapdService extends SnapdClient with SnapdCache, SnapdWatcher {
     Map<String, dynamic> result;
     try {
       result = await getAssertions(
-          assertion: 'snap-declaration', params: queryParams);
+        assertion: 'snap-declaration',
+        params: queryParams,
+      );
     } on Exception catch (_) {
       return null;
     }

--- a/packages/app_center/lib/snapd/snapd_service.dart
+++ b/packages/app_center/lib/snapd/snapd_service.dart
@@ -1,5 +1,6 @@
 import 'package:app_center/snapd/snapd_cache.dart';
 import 'package:app_center/snapd/snapd_watcher.dart';
+import 'package:collection/collection.dart';
 import 'package:snapd/snapd.dart';
 
 class SnapdService extends SnapdClient with SnapdCache, SnapdWatcher {
@@ -17,7 +18,6 @@ class SnapdService extends SnapdClient with SnapdCache, SnapdWatcher {
     final declaration = SnapDeclaration.fromJson(result);
     final findResult = await find(name: declaration.snapName);
     return findResult
-        .where((element) => element.id == declaration.snapId)
-        .firstOrNull;
+        .singleWhereOrNull((element) => element.id == declaration.snapId);
   }
 }

--- a/packages/app_center/lib/snapd/snapd_service.dart
+++ b/packages/app_center/lib/snapd/snapd_service.dart
@@ -5,4 +5,19 @@ import 'package:snapd/snapd.dart';
 class SnapdService extends SnapdClient with SnapdCache, SnapdWatcher {
   Future<void> waitChange(String changeId) =>
       watchChange(changeId).firstWhere((change) => change.ready);
+
+  Future<Snap?> findById(String snapId) async {
+    final queryParams = {
+      'series': '16',
+      'remote': 'true',
+      'snap-id': snapId,
+    };
+    final result =
+        await getAssertions(assertion: 'snap-declaration', params: queryParams);
+    final declaration = SnapDeclaration.fromJson(result);
+    final findResult = await find(name: declaration.snapName);
+    return findResult
+        .where((element) => element.id == declaration.snapId)
+        .firstOrNull;
+  }
 }

--- a/packages/app_center/lib/snapd/snapd_service.dart
+++ b/packages/app_center/lib/snapd/snapd_service.dart
@@ -13,8 +13,14 @@ class SnapdService extends SnapdClient with SnapdCache, SnapdWatcher {
       'remote': 'true',
       'snap-id': snapId,
     };
-    final result =
-        await getAssertions(assertion: 'snap-declaration', params: queryParams);
+    Map<String, dynamic> result;
+    try {
+      result = await getAssertions(
+          assertion: 'snap-declaration', params: queryParams);
+    } on Exception catch (_) {
+      return null;
+    }
+
     if (result.isEmpty) {
       return null;
     }

--- a/packages/app_center/lib/snapd/snapd_service.dart
+++ b/packages/app_center/lib/snapd/snapd_service.dart
@@ -15,6 +15,9 @@ class SnapdService extends SnapdClient with SnapdCache, SnapdWatcher {
     };
     final result =
         await getAssertions(assertion: 'snap-declaration', params: queryParams);
+    if (result.isEmpty) {
+      return null;
+    }
     final declaration = SnapDeclaration.fromJson(result);
     final findResult = await find(name: declaration.snapName);
     return findResult

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -118,7 +118,7 @@
     "developmentPageLabel": "Development",
     "gamesPageLabel": "Games",
     "gamesPageTitle": "What's Hot",
-    "gamesPageTop": "Top Games",
+    "gamesPageTop": "Top Rated",
     "gamesPageFeatured": "Featured Titles",
     "gamesPageBundles": "App Bundles",
     "unknownPublisher": "Unknown publisher",

--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -4,6 +4,7 @@ import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/ratings/ratings.dart';
 import 'package:app_center/snapd/snapd.dart';
+import 'package:app_center/widgets/small_banner.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:appstream/appstream.dart';
 import 'package:flutter/material.dart';
@@ -92,26 +93,17 @@ class AppCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final banner = YaruBanner(
-      padding: const EdgeInsets.all(kCardSpacing),
-      onTap: onTap,
-      color: Theme.of(context).cardColor,
-      child: Flex(
-        direction: compact ? Axis.vertical : Axis.horizontal,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          AppIcon(iconUrl: iconUrl),
-          const SizedBox(width: 16, height: 16),
-          Expanded(
-            child: _AppCardBody(
-              title: title,
-              summary: rating > 0 ? '' : summary,
-              footer: footer,
-            ),
-          ),
-        ],
+    final appContent = [
+      AppIcon(iconUrl: iconUrl),
+      const SizedBox(width: 16, height: 16),
+      Expanded(
+        child: _AppCardBody(
+          title: title,
+          summary: rating > 0 ? '' : summary,
+          footer: footer,
+        ),
       ),
-    );
+    ];
 
     return rating > 0
         ? Flex(
@@ -119,20 +111,38 @@ class AppCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Center(
-                  child: Text(
-                rating.toString(),
-                style: const TextStyle(
-                  fontSize: 24.0,
-                  fontWeight: FontWeight.w500,
+                child: Text(
+                  rating.toString(),
+                  style: const TextStyle(
+                    fontSize: 24.0,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
-              )),
+              ),
               const SizedBox(
                 width: 16,
               ),
-              Expanded(child: banner),
+              Expanded(
+                child: SmallBanner(
+                  onTap: onTap,
+                  child: Flex(
+                    direction: Axis.horizontal,
+                    children: appContent,
+                  ),
+                ),
+              ),
             ],
           )
-        : banner;
+        : YaruBanner(
+            padding: const EdgeInsets.all(kCardSpacing),
+            onTap: onTap,
+            color: Theme.of(context).cardColor,
+            child: Flex(
+              direction: compact ? Axis.vertical : Axis.horizontal,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: appContent,
+            ),
+          );
   }
 }
 

--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -114,13 +114,13 @@ class AppCard extends StatelessWidget {
                 child: Text(
                   rating.toString(),
                   style: const TextStyle(
-                    fontSize: 24.0,
+                    fontSize: 16.0,
                     fontWeight: FontWeight.w500,
                   ),
                 ),
               ),
               const SizedBox(
-                width: 16,
+                width: 4,
               ),
               Expanded(
                 child: SmallBanner(

--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -93,9 +93,10 @@ class AppCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final appContent = [
       AppIcon(iconUrl: iconUrl),
-      const SizedBox(width: 16, height: 16),
+      const SizedBox(width: kCardSpacing, height: kCardSpacing),
       Expanded(
         child: _AppCardBody(
           title: title,
@@ -113,10 +114,7 @@ class AppCard extends StatelessWidget {
               Center(
                 child: Text(
                   rating.toString(),
-                  style: const TextStyle(
-                    fontSize: 16.0,
-                    fontWeight: FontWeight.w500,
-                  ),
+                  style: theme.textTheme.titleMedium,
                 ),
               ),
               const SizedBox(

--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -22,7 +22,7 @@ class AppCard extends StatelessWidget {
     this.compact = false,
     this.iconUrl,
     this.footer,
-    this.rating = 0,
+    this.rank = 0,
   });
 
   AppCard.fromSnap({
@@ -39,7 +39,7 @@ class AppCard extends StatelessWidget {
 
   AppCard.fromRatedSnap({
     required Snap snap,
-    required int rating,
+    required int rank,
     VoidCallback? onTap,
   }) : this(
           key: ValueKey(snap.id),
@@ -48,7 +48,7 @@ class AppCard extends StatelessWidget {
           iconUrl: snap.iconUrl,
           footer: _RatingsInfo(snap: snap),
           onTap: onTap,
-          rating: rating,
+          rank: rank,
         );
 
   AppCard.fromDeb({
@@ -89,7 +89,7 @@ class AppCard extends StatelessWidget {
   final bool compact;
   final String? iconUrl;
   final Widget? footer;
-  final int rating;
+  final int rank;
 
   @override
   Widget build(BuildContext context) {
@@ -100,20 +100,20 @@ class AppCard extends StatelessWidget {
       Expanded(
         child: _AppCardBody(
           title: title,
-          summary: rating > 0 ? '' : summary,
+          summary: rank > 0 ? '' : summary,
           footer: footer,
         ),
       ),
     ];
 
-    return rating > 0
+    return rank > 0
         ? Flex(
             direction: Axis.horizontal,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Center(
                 child: Text(
-                  rating.toString(),
+                  rank.toString(),
                   style: theme.textTheme.titleMedium,
                 ),
               ),

--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -21,6 +21,7 @@ class AppCard extends StatelessWidget {
     this.compact = false,
     this.iconUrl,
     this.footer,
+    this.rating = 0,
   });
 
   AppCard.fromSnap({
@@ -33,6 +34,20 @@ class AppCard extends StatelessWidget {
           iconUrl: snap.iconUrl,
           footer: _RatingsInfo(snap: snap),
           onTap: onTap,
+        );
+
+  AppCard.fromRatedSnap({
+    required Snap snap,
+    required int rating,
+    VoidCallback? onTap,
+  }) : this(
+          key: ValueKey(snap.id),
+          title: AppTitle.fromSnap(snap),
+          summary: snap.summary,
+          iconUrl: snap.iconUrl,
+          footer: _RatingsInfo(snap: snap),
+          onTap: onTap,
+          rating: rating,
         );
 
   AppCard.fromDeb({
@@ -73,12 +88,14 @@ class AppCard extends StatelessWidget {
   final bool compact;
   final String? iconUrl;
   final Widget? footer;
+  final int rating;
 
   @override
   Widget build(BuildContext context) {
-    return YaruBanner(
+    final banner = YaruBanner(
       padding: const EdgeInsets.all(kCardSpacing),
       onTap: onTap,
+      color: Theme.of(context).cardColor,
       child: Flex(
         direction: compact ? Axis.vertical : Axis.horizontal,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -88,13 +105,34 @@ class AppCard extends StatelessWidget {
           Expanded(
             child: _AppCardBody(
               title: title,
-              summary: summary,
+              summary: rating > 0 ? '' : summary,
               footer: footer,
             ),
           ),
         ],
       ),
     );
+
+    return rating > 0
+        ? Flex(
+            direction: Axis.horizontal,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                  child: Text(
+                rating.toString(),
+                style: const TextStyle(
+                  fontSize: 24.0,
+                  fontWeight: FontWeight.w500,
+                ),
+              )),
+              const SizedBox(
+                width: 16,
+              ),
+              Expanded(child: banner),
+            ],
+          )
+        : banner;
   }
 }
 
@@ -168,14 +206,16 @@ class _AppCardBody extends StatelessWidget {
             child: title,
           ),
         ),
-        const SizedBox(height: 12),
-        Flexible(
-          child: Text(
-            summary,
-            maxLines: maxlines,
-            overflow: TextOverflow.ellipsis,
+        if (summary.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Flexible(
+            child: Text(
+              summary,
+              maxLines: maxlines,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
-        ),
+        ],
         if (footer != null) ...[
           const SizedBox(height: 8),
           footer!,

--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -22,7 +22,6 @@ class AppCard extends StatelessWidget {
     this.compact = false,
     this.iconUrl,
     this.footer,
-    this.rank = 0,
   });
 
   AppCard.fromSnap({
@@ -35,20 +34,6 @@ class AppCard extends StatelessWidget {
           iconUrl: snap.iconUrl,
           footer: _RatingsInfo(snap: snap),
           onTap: onTap,
-        );
-
-  AppCard.fromRatedSnap({
-    required Snap snap,
-    required int rank,
-    VoidCallback? onTap,
-  }) : this(
-          key: ValueKey(snap.id),
-          title: AppTitle.fromSnap(snap),
-          summary: snap.summary,
-          iconUrl: snap.iconUrl,
-          footer: _RatingsInfo(snap: snap),
-          onTap: onTap,
-          rank: rank,
         );
 
   AppCard.fromDeb({
@@ -89,58 +74,104 @@ class AppCard extends StatelessWidget {
   final bool compact;
   final String? iconUrl;
   final Widget? footer;
+
+  @override
+  Widget build(BuildContext context) {
+    return YaruBanner(
+      padding: const EdgeInsets.all(kCardSpacing),
+      onTap: onTap,
+      color: Theme.of(context).cardColor,
+      child: Flex(
+        direction: compact ? Axis.vertical : Axis.horizontal,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppIcon(iconUrl: iconUrl),
+          const SizedBox(width: kCardSpacing, height: kCardSpacing),
+          Expanded(
+            child: _AppCardBody(
+              title: title,
+              summary: summary,
+              footer: footer,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class RankedAppCard extends StatelessWidget {
+  const RankedAppCard({
+    required this.title,
+    required this.summary,
+    required this.rank,
+    this.onTap,
+    this.compact = false,
+    this.iconUrl,
+    this.footer,
+    super.key,
+  });
+
+  RankedAppCard.fromRankedSnap({
+    required Snap snap,
+    required int rank,
+    VoidCallback? onTap,
+  }) : this(
+          key: ValueKey(snap.id),
+          title: AppTitle.fromSnap(snap),
+          summary: snap.summary,
+          iconUrl: snap.iconUrl,
+          footer: _RatingsInfo(snap: snap),
+          onTap: onTap,
+          rank: rank,
+        );
+
+  final AppTitle title;
+  final String summary;
+  final VoidCallback? onTap;
+  final bool compact;
+  final String? iconUrl;
+  final Widget? footer;
   final int rank;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final appContent = [
-      AppIcon(iconUrl: iconUrl),
-      const SizedBox(width: kCardSpacing, height: kCardSpacing),
-      Expanded(
-        child: _AppCardBody(
-          title: title,
-          summary: rank > 0 ? '' : summary,
-          footer: footer,
-        ),
-      ),
-    ];
 
-    return rank > 0
-        ? Flex(
-            direction: Axis.horizontal,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Center(
-                child: Text(
-                  rank.toString(),
-                  style: theme.textTheme.titleMedium,
-                ),
-              ),
-              const SizedBox(
-                width: 4,
-              ),
-              Expanded(
-                child: SmallBanner(
-                  onTap: onTap,
-                  child: Flex(
-                    direction: Axis.horizontal,
-                    children: appContent,
+    return Flex(
+      direction: Axis.horizontal,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Center(
+          child: Text(
+            rank.toString(),
+            style: theme.textTheme.titleMedium,
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        Expanded(
+          child: SmallBanner(
+            onTap: onTap,
+            child: Flex(
+              direction: Axis.horizontal,
+              children: [
+                AppIcon(iconUrl: iconUrl),
+                const SizedBox(width: kCardSpacing, height: kCardSpacing),
+                Expanded(
+                  child: _AppCardBody(
+                    title: title,
+                    summary: '',
+                    footer: footer,
                   ),
                 ),
-              ),
-            ],
-          )
-        : YaruBanner(
-            padding: const EdgeInsets.all(kCardSpacing),
-            onTap: onTap,
-            color: Theme.of(context).cardColor,
-            child: Flex(
-              direction: compact ? Axis.vertical : Axis.horizontal,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: appContent,
+              ],
             ),
-          );
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/packages/app_center/lib/widgets/category_snap_list.dart
+++ b/packages/app_center/lib/widgets/category_snap_list.dart
@@ -1,10 +1,13 @@
 import 'package:app_center/explore/explore_page.dart';
+import 'package:app_center/ratings/ratings_service.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/store/store.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:snapd/snapd.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 
 class CategorySnapList extends ConsumerWidget {
   const CategorySnapList({
@@ -60,5 +63,59 @@ class CategorySnapList extends ConsumerWidget {
             snaps: snaps,
             onTap: (snap) => StoreNavigator.pushSnap(context, name: snap.name),
           );
+  }
+}
+
+class RatedCategorySnapList extends ConsumerStatefulWidget {
+  const RatedCategorySnapList(
+      {required this.categories, this.numberOfSnaps = 6, super.key});
+
+  final Set<SnapCategoryEnum> categories;
+  final int numberOfSnaps;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _RatedCategorySnapList();
+}
+
+class _RatedCategorySnapList extends ConsumerState<RatedCategorySnapList> {
+  _RatedCategorySnapList();
+
+  List<Snap> snaps = [];
+
+  Future<void> fetchItems() async {
+    final ratings = getService<RatingsService>();
+    final snapd = getService<SnapdService>();
+
+    for (final category in widget.categories) {
+      final chart = await ratings.getChart(category);
+      var i = 0;
+      while (snaps.length < widget.numberOfSnaps && i < chart.length) {
+        final snap = await snapd.findById(chart[i].rating.snapId);
+        if (snap != null && snap.screenshotUrls.isNotEmpty) {
+          setState(() {
+            snaps.add(snap);
+          });
+        }
+        i++;
+      }
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    fetchItems();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppCardGrid.fromRatedSnaps(
+      snaps: snaps,
+      onTap: (snap) => StoreNavigator.pushSnap(
+        context,
+        name: snap.name,
+      ),
+    );
   }
 }

--- a/packages/app_center/lib/widgets/category_snap_list.dart
+++ b/packages/app_center/lib/widgets/category_snap_list.dart
@@ -88,9 +88,8 @@ class RatedCategorySnapList extends ConsumerWidget {
           name: snap.name,
         ),
       ),
-      error: (error, stackTrace) => SliverToBoxAdapter(
-        child: Text(error.toString()),
-      ),
+      error: (error, stackTrace) =>
+          CategorySnapList(category: categories.first),
       loading: () => const SliverToBoxAdapter(
         child: Center(child: YaruCircularProgressIndicator()),
       ),

--- a/packages/app_center/lib/widgets/category_snap_list.dart
+++ b/packages/app_center/lib/widgets/category_snap_list.dart
@@ -1,13 +1,12 @@
 import 'package:app_center/explore/explore_page.dart';
-import 'package:app_center/ratings/ratings_service.dart';
+import 'package:app_center/ratings/rated_category_model.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/store/store.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:snapd/snapd.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:yaru/yaru.dart';
 
 class CategorySnapList extends ConsumerWidget {
   const CategorySnapList({
@@ -66,55 +65,34 @@ class CategorySnapList extends ConsumerWidget {
   }
 }
 
-class RatedCategorySnapList extends ConsumerStatefulWidget {
-  const RatedCategorySnapList(
-      {required this.categories, this.numberOfSnaps = 6, super.key});
+class RatedCategorySnapList extends ConsumerWidget {
+  const RatedCategorySnapList({
+    required this.categories,
+    this.numberOfSnaps = 10,
+    super.key,
+  });
 
-  final Set<SnapCategoryEnum> categories;
+  final List<SnapCategoryEnum> categories;
   final int numberOfSnaps;
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      _RatedCategorySnapList();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ratedCategoryModel =
+        ref.watch(ratedCategoryModelProvider(categories, numberOfSnaps));
 
-class _RatedCategorySnapList extends ConsumerState<RatedCategorySnapList> {
-  _RatedCategorySnapList();
-
-  List<Snap> snaps = [];
-
-  Future<void> fetchItems() async {
-    final ratings = getService<RatingsService>();
-    final snapd = getService<SnapdService>();
-
-    for (final category in widget.categories) {
-      final chart = await ratings.getChart(category);
-      var i = 0;
-      while (snaps.length < widget.numberOfSnaps && i < chart.length) {
-        final snap = await snapd.findById(chart[i].rating.snapId);
-        if (snap != null && snap.screenshotUrls.isNotEmpty) {
-          setState(() {
-            snaps.add(snap);
-          });
-        }
-        i++;
-      }
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    fetchItems();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AppCardGrid.fromRatedSnaps(
-      snaps: snaps,
-      onTap: (snap) => StoreNavigator.pushSnap(
-        context,
-        name: snap.name,
+    return ratedCategoryModel.when(
+      data: (snaps) => AppCardGrid.fromRatedSnaps(
+        snaps: snaps,
+        onTap: (snap) => StoreNavigator.pushSnap(
+          context,
+          name: snap.name,
+        ),
+      ),
+      error: (error, stackTrace) => SliverToBoxAdapter(
+        child: Text(error.toString()),
+      ),
+      loading: () => const SliverToBoxAdapter(
+        child: Center(child: YaruCircularProgressIndicator()),
       ),
     );
   }

--- a/packages/app_center/lib/widgets/category_snap_list.dart
+++ b/packages/app_center/lib/widgets/category_snap_list.dart
@@ -81,7 +81,7 @@ class RatedCategorySnapList extends ConsumerWidget {
         ref.watch(ratedCategoryModelProvider(categories, numberOfSnaps));
 
     return ratedCategoryModel.when(
-      data: (snaps) => AppCardGrid.fromRatedSnaps(
+      data: (snaps) => RankedAppCardGrid.fromRankedSnaps(
         snaps: snaps,
         onTap: (snap) => StoreNavigator.pushSnap(
           context,

--- a/packages/app_center/lib/widgets/small_banner.dart
+++ b/packages/app_center/lib/widgets/small_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 
+/// Slimmer version (no border or description) of the [YaruBanner].
 class SmallBanner extends StatelessWidget {
   const SmallBanner({required this.child, super.key, this.onTap});
 
@@ -11,18 +12,16 @@ class SmallBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final borderRadius = BorderRadius.circular(kYaruBannerRadius);
-
     final light = theme.brightness == Brightness.light;
-
     final defaultSurfaceTintColor =
         light ? theme.cardColor : const Color.fromARGB(255, 126, 126, 126);
+
     return Material(
       color: Colors.transparent,
       borderRadius: borderRadius,
       child: InkWell(
         onTap: onTap,
-        borderRadius: borderRadius,
-        hoverColor: theme.colorScheme.onSurface.withOpacity(0.1),
+        hoverColor: Colors.transparent,
         child: Card(
           color: theme.cardColor,
           shadowColor: Colors.transparent,

--- a/packages/app_center/lib/widgets/small_banner.dart
+++ b/packages/app_center/lib/widgets/small_banner.dart
@@ -12,9 +12,6 @@ class SmallBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final borderRadius = BorderRadius.circular(kYaruBannerRadius);
-    final light = theme.brightness == Brightness.light;
-    final defaultSurfaceTintColor =
-        light ? theme.cardColor : const Color.fromARGB(255, 126, 126, 126);
 
     return Material(
       color: Colors.transparent,
@@ -25,7 +22,6 @@ class SmallBanner extends StatelessWidget {
         child: Card(
           color: theme.cardColor,
           shadowColor: Colors.transparent,
-          surfaceTintColor: defaultSurfaceTintColor,
           elevation: 1,
           shape: RoundedRectangleBorder(
             borderRadius: borderRadius.inner(const EdgeInsets.all(4.0)),

--- a/packages/app_center/lib/widgets/small_banner.dart
+++ b/packages/app_center/lib/widgets/small_banner.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+class SmallBanner extends StatelessWidget {
+  const SmallBanner({required this.child, super.key, this.onTap});
+
+  final VoidCallback? onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderRadius = BorderRadius.circular(kYaruBannerRadius);
+
+    final light = theme.brightness == Brightness.light;
+
+    final defaultSurfaceTintColor =
+        light ? theme.cardColor : const Color.fromARGB(255, 126, 126, 126);
+    return Material(
+      color: Colors.transparent,
+      borderRadius: borderRadius,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: borderRadius,
+        hoverColor: theme.colorScheme.onSurface.withOpacity(0.1),
+        child: Card(
+          color: theme.cardColor,
+          shadowColor: Colors.transparent,
+          surfaceTintColor: defaultSurfaceTintColor,
+          elevation: 1,
+          shape: RoundedRectangleBorder(
+            borderRadius: borderRadius.inner(const EdgeInsets.all(4.0)),
+          ),
+          child: Container(
+            padding: const EdgeInsets.all(8.0),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/app_center/lib/widgets/snap_grid.dart
+++ b/packages/app_center/lib/widgets/snap_grid.dart
@@ -8,6 +8,7 @@ import 'package:snapd/snapd.dart';
 class AppCardGrid extends StatelessWidget {
   const AppCardGrid({
     required this.appCards,
+    this.cardAspectRatio,
     super.key,
   });
 
@@ -36,6 +37,7 @@ class AppCardGrid extends StatelessWidget {
                 rating: entry.key + 1,
               ),
             ),
+        cardAspectRatio: 4.0,
       );
 
   factory AppCardGrid.fromDebs({
@@ -63,6 +65,7 @@ class AppCardGrid extends StatelessWidget {
       );
 
   final Iterable<AppCard> appCards;
+  final double? cardAspectRatio;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +73,7 @@ class AppCardGrid extends StatelessWidget {
     return SliverGrid.builder(
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: layout.cardColumnCount,
-        childAspectRatio: layout.cardSize.aspectRatio,
+        childAspectRatio: cardAspectRatio ?? layout.cardSize.aspectRatio,
         mainAxisSpacing: kCardSpacing - 2 * kCardMargin,
         crossAxisSpacing: kCardSpacing - 2 * kCardMargin,
       ),

--- a/packages/app_center/lib/widgets/snap_grid.dart
+++ b/packages/app_center/lib/widgets/snap_grid.dart
@@ -24,6 +24,20 @@ class AppCardGrid extends StatelessWidget {
         ),
       );
 
+  factory AppCardGrid.fromRatedSnaps({
+    required List<Snap> snaps,
+    required ValueChanged<Snap> onTap,
+  }) =>
+      AppCardGrid(
+        appCards: snaps.asMap().entries.map(
+              (entry) => AppCard.fromRatedSnap(
+                snap: entry.value,
+                onTap: () => onTap(entry.value),
+                rating: entry.key + 1,
+              ),
+            ),
+      );
+
   factory AppCardGrid.fromDebs({
     required List<AppstreamComponent> debs,
     required ValueChanged<AppstreamComponent> onTap,

--- a/packages/app_center/lib/widgets/snap_grid.dart
+++ b/packages/app_center/lib/widgets/snap_grid.dart
@@ -34,7 +34,7 @@ class AppCardGrid extends StatelessWidget {
               (entry) => AppCard.fromRatedSnap(
                 snap: entry.value,
                 onTap: () => onTap(entry.value),
-                rating: entry.key + 1,
+                rank: entry.key + 1,
               ),
             ),
         small: true,

--- a/packages/app_center/lib/widgets/snap_grid.dart
+++ b/packages/app_center/lib/widgets/snap_grid.dart
@@ -8,7 +8,7 @@ import 'package:snapd/snapd.dart';
 class AppCardGrid extends StatelessWidget {
   const AppCardGrid({
     required this.appCards,
-    this.cardAspectRatio,
+    this.small = false,
     super.key,
   });
 
@@ -37,7 +37,7 @@ class AppCardGrid extends StatelessWidget {
                 rating: entry.key + 1,
               ),
             ),
-        cardAspectRatio: 4.0,
+        small: true,
       );
 
   factory AppCardGrid.fromDebs({
@@ -65,15 +65,31 @@ class AppCardGrid extends StatelessWidget {
       );
 
   final Iterable<AppCard> appCards;
-  final double? cardAspectRatio;
+  final bool small;
 
   @override
   Widget build(BuildContext context) {
     final layout = ResponsiveLayout.of(context);
+    var columnCount = layout.cardColumnCount;
+    var cardAspectRatio = layout.cardSize.aspectRatio;
+    if (small) {
+      switch (layout.type) {
+        case ResponsiveLayoutType.small:
+          columnCount = 2;
+          cardAspectRatio = 2.5;
+        case ResponsiveLayoutType.medium:
+          columnCount = 3;
+          cardAspectRatio = 2.5;
+        case ResponsiveLayoutType.large:
+          columnCount = 4;
+          cardAspectRatio = 3.0;
+      }
+    }
+
     return SliverGrid.builder(
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: layout.cardColumnCount,
-        childAspectRatio: cardAspectRatio ?? layout.cardSize.aspectRatio,
+        crossAxisCount: columnCount,
+        childAspectRatio: cardAspectRatio,
         mainAxisSpacing: kCardSpacing - 2 * kCardMargin,
         crossAxisSpacing: kCardSpacing - 2 * kCardMargin,
       ),

--- a/packages/app_center/lib/widgets/snap_grid.dart
+++ b/packages/app_center/lib/widgets/snap_grid.dart
@@ -8,7 +8,6 @@ import 'package:snapd/snapd.dart';
 class AppCardGrid extends StatelessWidget {
   const AppCardGrid({
     required this.appCards,
-    this.small = false,
     super.key,
   });
 
@@ -23,21 +22,6 @@ class AppCardGrid extends StatelessWidget {
             onTap: () => onTap(snap),
           ),
         ),
-      );
-
-  factory AppCardGrid.fromRatedSnaps({
-    required List<Snap> snaps,
-    required ValueChanged<Snap> onTap,
-  }) =>
-      AppCardGrid(
-        appCards: snaps.asMap().entries.map(
-              (entry) => AppCard.fromRatedSnap(
-                snap: entry.value,
-                onTap: () => onTap(entry.value),
-                rank: entry.key + 1,
-              ),
-            ),
-        small: true,
       );
 
   factory AppCardGrid.fromDebs({
@@ -65,25 +49,62 @@ class AppCardGrid extends StatelessWidget {
       );
 
   final Iterable<AppCard> appCards;
-  final bool small;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = ResponsiveLayout.of(context);
+
+    return SliverGrid.builder(
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: layout.cardColumnCount,
+        childAspectRatio: layout.cardSize.aspectRatio,
+        mainAxisSpacing: kCardSpacing - 2 * kCardMargin,
+        crossAxisSpacing: kCardSpacing - 2 * kCardMargin,
+      ),
+      itemCount: appCards.length,
+      itemBuilder: (context, index) => appCards.elementAt(index),
+    );
+  }
+}
+
+class RankedAppCardGrid extends StatelessWidget {
+  const RankedAppCardGrid({
+    required this.appCards,
+    super.key,
+  });
+
+  factory RankedAppCardGrid.fromRankedSnaps({
+    required List<Snap> snaps,
+    required ValueChanged<Snap> onTap,
+  }) =>
+      RankedAppCardGrid(
+        appCards: snaps.asMap().entries.map(
+              (entry) => RankedAppCard.fromRankedSnap(
+                snap: entry.value,
+                onTap: () => onTap(entry.value),
+                rank: entry.key + 1,
+              ),
+            ),
+      );
+
+  final Iterable<RankedAppCard> appCards;
 
   @override
   Widget build(BuildContext context) {
     final layout = ResponsiveLayout.of(context);
     var columnCount = layout.cardColumnCount;
     var cardAspectRatio = layout.cardSize.aspectRatio;
-    if (small) {
-      switch (layout.type) {
-        case ResponsiveLayoutType.small:
-          columnCount = 2;
-          cardAspectRatio = 2.5;
-        case ResponsiveLayoutType.medium:
-          columnCount = 3;
-          cardAspectRatio = 2.5;
-        case ResponsiveLayoutType.large:
-          columnCount = 4;
-          cardAspectRatio = 3.0;
-      }
+
+    switch (layout.type) {
+      case ResponsiveLayoutType.small:
+        columnCount = 2;
+        cardAspectRatio = 2.5;
+      case ResponsiveLayoutType.medium:
+        columnCount = 3;
+        cardAspectRatio = 2.5;
+      case ResponsiveLayoutType.large:
+        columnCount = 4;
+        cardAspectRatio = 3.0;
     }
 
     return SliverGrid.builder(

--- a/packages/app_center/test/ratings_service_test.dart
+++ b/packages/app_center/test/ratings_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:app_center/ratings/ratings_service.dart';
+import 'package:app_center/snapd/snap_category_enum.dart';
 import 'package:app_center_ratings_client/app_center_ratings_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -28,6 +29,55 @@ void main() {
           ratingsBand: RatingsBand.veryGood,
         ),
       ),
+    );
+  });
+
+  test('get category', () async {
+    final mockClient = createMockRatingsClient(
+      token: 'jwt',
+      chartData: const [
+        ChartData(
+          rawRating: 117,
+          rating: Rating(
+            snapId: 'john',
+            totalVotes: 117,
+            ratingsBand: RatingsBand.veryGood,
+          ),
+        ),
+        ChartData(
+          rawRating: 104,
+          rating: Rating(
+            snapId: 'fred',
+            totalVotes: 104,
+            ratingsBand: RatingsBand.veryGood,
+          ),
+        ),
+      ],
+    );
+    final service = RatingsService(mockClient, id: 'myId');
+
+    final charts = await service.getChart(SnapCategoryEnum.games);
+    verify(mockClient.authenticate('myId')).called(1);
+    expect(
+      charts,
+      containsAll([
+        const ChartData(
+          rawRating: 117,
+          rating: Rating(
+            snapId: 'john',
+            totalVotes: 117,
+            ratingsBand: RatingsBand.veryGood,
+          ),
+        ),
+        const ChartData(
+          rawRating: 104,
+          rating: Rating(
+            snapId: 'fred',
+            totalVotes: 104,
+            ratingsBand: RatingsBand.veryGood,
+          ),
+        ),
+      ]),
     );
   });
 

--- a/packages/app_center/test/test_utils.dart
+++ b/packages/app_center/test/test_utils.dart
@@ -312,6 +312,7 @@ MockRatingsClient createMockRatingsClient({
   Rating? rating,
   List<Vote>? myVotes,
   List<Vote>? snapVotes,
+  List<ChartData>? chartData,
 }) {
   final client = MockRatingsClient();
   when(client.authenticate(any)).thenAnswer((_) async => token ?? '');
@@ -326,6 +327,7 @@ MockRatingsClient createMockRatingsClient({
   );
   when(client.listMyVotes(any, any)).thenAnswer((_) async => myVotes ?? []);
   when(client.getSnapVotes(any, any)).thenAnswer((_) async => snapVotes ?? []);
+  when(client.getChart(any, any, any)).thenAnswer((_) async => chartData ?? []);
   return client;
 }
 

--- a/packages/app_center_ratings_client/lib/app_center_ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/app_center_ratings_client.dart
@@ -1,3 +1,4 @@
+export 'src/chart.dart';
 export 'src/ratings.dart';
 export 'src/ratings_client.dart';
 export 'src/vote.dart';

--- a/packages/app_center_ratings_client/lib/app_center_ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/app_center_ratings_client.dart
@@ -1,4 +1,5 @@
 export 'src/chart.dart';
+export 'src/generated/ratings_features_chart.pbgrpc.dart' show Category;
 export 'src/ratings.dart';
 export 'src/ratings_client.dart';
 export 'src/vote.dart';

--- a/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pb.dart
+++ b/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pb.dart
@@ -21,72 +21,72 @@ export 'ratings_features_chart.pbenum.dart';
 class GetChartRequest extends $pb.GeneratedMessage {
   factory GetChartRequest({
     Timeframe? timeframe,
+    Category? category,
   }) {
     final $result = create();
     if (timeframe != null) {
       $result.timeframe = timeframe;
     }
+    if (category != null) {
+      $result.category = category;
+    }
     return $result;
   }
   GetChartRequest._() : super();
-  factory GetChartRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetChartRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetChartRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetChartRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetChartRequest',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'ratings.features.chart'),
-      createEmptyInstance: create)
-    ..e<Timeframe>(1, _omitFieldNames ? '' : 'timeframe', $pb.PbFieldType.OE,
-        defaultOrMaker: Timeframe.TIMEFRAME_UNSPECIFIED,
-        valueOf: Timeframe.valueOf,
-        enumValues: Timeframe.values)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetChartRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'ratings.features.chart'), createEmptyInstance: create)
+    ..e<Timeframe>(1, _omitFieldNames ? '' : 'timeframe', $pb.PbFieldType.OE, defaultOrMaker: Timeframe.TIMEFRAME_UNSPECIFIED, valueOf: Timeframe.valueOf, enumValues: Timeframe.values)
+    ..e<Category>(2, _omitFieldNames ? '' : 'category', $pb.PbFieldType.OE, defaultOrMaker: Category.ART_AND_DESIGN, valueOf: Category.valueOf, enumValues: Category.values)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetChartRequest clone() => GetChartRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetChartRequest copyWith(void Function(GetChartRequest) updates) =>
-      super.copyWith((message) => updates(message as GetChartRequest))
-          as GetChartRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetChartRequest copyWith(void Function(GetChartRequest) updates) => super.copyWith((message) => updates(message as GetChartRequest)) as GetChartRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetChartRequest create() => GetChartRequest._();
   GetChartRequest createEmptyInstance() => create();
-  static $pb.PbList<GetChartRequest> createRepeated() =>
-      $pb.PbList<GetChartRequest>();
+  static $pb.PbList<GetChartRequest> createRepeated() => $pb.PbList<GetChartRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetChartRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GetChartRequest>(create);
+  static GetChartRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetChartRequest>(create);
   static GetChartRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   Timeframe get timeframe => $_getN(0);
   @$pb.TagNumber(1)
-  set timeframe(Timeframe v) {
-    setField(1, v);
-  }
-
+  set timeframe(Timeframe v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasTimeframe() => $_has(0);
   @$pb.TagNumber(1)
   void clearTimeframe() => clearField(1);
+
+  @$pb.TagNumber(2)
+  Category get category => $_getN(1);
+  @$pb.TagNumber(2)
+  set category(Category v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCategory() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCategory() => clearField(2);
 }
 
 class GetChartResponse extends $pb.GeneratedMessage {
   factory GetChartResponse({
     Timeframe? timeframe,
     $core.Iterable<ChartData>? orderedChartData,
+    Category? category,
   }) {
     final $result = create();
     if (timeframe != null) {
@@ -95,60 +95,47 @@ class GetChartResponse extends $pb.GeneratedMessage {
     if (orderedChartData != null) {
       $result.orderedChartData.addAll(orderedChartData);
     }
+    if (category != null) {
+      $result.category = category;
+    }
     return $result;
   }
   GetChartResponse._() : super();
-  factory GetChartResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetChartResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GetChartResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetChartResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GetChartResponse',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'ratings.features.chart'),
-      createEmptyInstance: create)
-    ..e<Timeframe>(1, _omitFieldNames ? '' : 'timeframe', $pb.PbFieldType.OE,
-        defaultOrMaker: Timeframe.TIMEFRAME_UNSPECIFIED,
-        valueOf: Timeframe.valueOf,
-        enumValues: Timeframe.values)
-    ..pc<ChartData>(
-        2, _omitFieldNames ? '' : 'orderedChartData', $pb.PbFieldType.PM,
-        subBuilder: ChartData.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetChartResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'ratings.features.chart'), createEmptyInstance: create)
+    ..e<Timeframe>(1, _omitFieldNames ? '' : 'timeframe', $pb.PbFieldType.OE, defaultOrMaker: Timeframe.TIMEFRAME_UNSPECIFIED, valueOf: Timeframe.valueOf, enumValues: Timeframe.values)
+    ..pc<ChartData>(2, _omitFieldNames ? '' : 'orderedChartData', $pb.PbFieldType.PM, subBuilder: ChartData.create)
+    ..e<Category>(3, _omitFieldNames ? '' : 'category', $pb.PbFieldType.OE, defaultOrMaker: Category.ART_AND_DESIGN, valueOf: Category.valueOf, enumValues: Category.values)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GetChartResponse clone() => GetChartResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetChartResponse copyWith(void Function(GetChartResponse) updates) =>
-      super.copyWith((message) => updates(message as GetChartResponse))
-          as GetChartResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetChartResponse copyWith(void Function(GetChartResponse) updates) => super.copyWith((message) => updates(message as GetChartResponse)) as GetChartResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GetChartResponse create() => GetChartResponse._();
   GetChartResponse createEmptyInstance() => create();
-  static $pb.PbList<GetChartResponse> createRepeated() =>
-      $pb.PbList<GetChartResponse>();
+  static $pb.PbList<GetChartResponse> createRepeated() => $pb.PbList<GetChartResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetChartResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GetChartResponse>(create);
+  static GetChartResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetChartResponse>(create);
   static GetChartResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   Timeframe get timeframe => $_getN(0);
   @$pb.TagNumber(1)
-  set timeframe(Timeframe v) {
-    setField(1, v);
-  }
-
+  set timeframe(Timeframe v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasTimeframe() => $_has(0);
   @$pb.TagNumber(1)
@@ -156,6 +143,15 @@ class GetChartResponse extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(2)
   $core.List<ChartData> get orderedChartData => $_getList(1);
+
+  @$pb.TagNumber(3)
+  Category get category => $_getN(2);
+  @$pb.TagNumber(3)
+  set category(Category v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCategory() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCategory() => clearField(3);
 }
 
 class ChartData extends $pb.GeneratedMessage {
@@ -173,32 +169,25 @@ class ChartData extends $pb.GeneratedMessage {
     return $result;
   }
   ChartData._() : super();
-  factory ChartData.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChartData.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ChartData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChartData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'ChartData',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'ratings.features.chart'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ChartData', package: const $pb.PackageName(_omitMessageNames ? '' : 'ratings.features.chart'), createEmptyInstance: create)
     ..a<$core.double>(1, _omitFieldNames ? '' : 'rawRating', $pb.PbFieldType.OF)
-    ..aOM<$1.Rating>(2, _omitFieldNames ? '' : 'rating',
-        subBuilder: $1.Rating.create)
-    ..hasRequiredFields = false;
+    ..aOM<$1.Rating>(2, _omitFieldNames ? '' : 'rating', subBuilder: $1.Rating.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ChartData clone() => ChartData()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ChartData copyWith(void Function(ChartData) updates) =>
-      super.copyWith((message) => updates(message as ChartData)) as ChartData;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChartData copyWith(void Function(ChartData) updates) => super.copyWith((message) => updates(message as ChartData)) as ChartData;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -207,17 +196,13 @@ class ChartData extends $pb.GeneratedMessage {
   ChartData createEmptyInstance() => create();
   static $pb.PbList<ChartData> createRepeated() => $pb.PbList<ChartData>();
   @$core.pragma('dart2js:noInline')
-  static ChartData getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChartData>(create);
+  static ChartData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChartData>(create);
   static ChartData? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get rawRating => $_getN(0);
   @$pb.TagNumber(1)
-  set rawRating($core.double v) {
-    $_setFloat(0, v);
-  }
-
+  set rawRating($core.double v) { $_setFloat(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasRawRating() => $_has(0);
   @$pb.TagNumber(1)
@@ -226,10 +211,7 @@ class ChartData extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $1.Rating get rating => $_getN(1);
   @$pb.TagNumber(2)
-  set rating($1.Rating v) {
-    setField(2, v);
-  }
-
+  set rating($1.Rating v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasRating() => $_has(1);
   @$pb.TagNumber(2)
@@ -238,6 +220,6 @@ class ChartData extends $pb.GeneratedMessage {
   $1.Rating ensureRating() => $_ensure(1);
 }
 
+
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames =
-    $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pbenum.dart
+++ b/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pbenum.dart
@@ -14,24 +14,72 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Timeframe extends $pb.ProtobufEnum {
-  static const Timeframe TIMEFRAME_UNSPECIFIED =
-      Timeframe._(0, _omitEnumNames ? '' : 'TIMEFRAME_UNSPECIFIED');
-  static const Timeframe TIMEFRAME_WEEK =
-      Timeframe._(1, _omitEnumNames ? '' : 'TIMEFRAME_WEEK');
-  static const Timeframe TIMEFRAME_MONTH =
-      Timeframe._(2, _omitEnumNames ? '' : 'TIMEFRAME_MONTH');
+  static const Timeframe TIMEFRAME_UNSPECIFIED = Timeframe._(0, _omitEnumNames ? '' : 'TIMEFRAME_UNSPECIFIED');
+  static const Timeframe TIMEFRAME_WEEK = Timeframe._(1, _omitEnumNames ? '' : 'TIMEFRAME_WEEK');
+  static const Timeframe TIMEFRAME_MONTH = Timeframe._(2, _omitEnumNames ? '' : 'TIMEFRAME_MONTH');
 
-  static const $core.List<Timeframe> values = <Timeframe>[
+  static const $core.List<Timeframe> values = <Timeframe> [
     TIMEFRAME_UNSPECIFIED,
     TIMEFRAME_WEEK,
     TIMEFRAME_MONTH,
   ];
 
-  static final $core.Map<$core.int, Timeframe> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, Timeframe> _byValue = $pb.ProtobufEnum.initByValue(values);
   static Timeframe? valueOf($core.int value) => _byValue[value];
 
   const Timeframe._($core.int v, $core.String n) : super(v, n);
 }
+
+class Category extends $pb.ProtobufEnum {
+  static const Category ART_AND_DESIGN = Category._(0, _omitEnumNames ? '' : 'ART_AND_DESIGN');
+  static const Category BOOK_AND_REFERENCE = Category._(1, _omitEnumNames ? '' : 'BOOK_AND_REFERENCE');
+  static const Category DEVELOPMENT = Category._(2, _omitEnumNames ? '' : 'DEVELOPMENT');
+  static const Category DEVICES_AND_IOT = Category._(3, _omitEnumNames ? '' : 'DEVICES_AND_IOT');
+  static const Category EDUCATION = Category._(4, _omitEnumNames ? '' : 'EDUCATION');
+  static const Category ENTERTAINMENT = Category._(5, _omitEnumNames ? '' : 'ENTERTAINMENT');
+  static const Category FEATURED = Category._(6, _omitEnumNames ? '' : 'FEATURED');
+  static const Category FINANCE = Category._(7, _omitEnumNames ? '' : 'FINANCE');
+  static const Category GAMES = Category._(8, _omitEnumNames ? '' : 'GAMES');
+  static const Category HEALTH_AND_FITNESS = Category._(9, _omitEnumNames ? '' : 'HEALTH_AND_FITNESS');
+  static const Category MUSIC_AND_AUDIO = Category._(10, _omitEnumNames ? '' : 'MUSIC_AND_AUDIO');
+  static const Category NEWS_AND_WEATHER = Category._(11, _omitEnumNames ? '' : 'NEWS_AND_WEATHER');
+  static const Category PERSONALISATION = Category._(12, _omitEnumNames ? '' : 'PERSONALISATION');
+  static const Category PHOTO_AND_VIDEO = Category._(13, _omitEnumNames ? '' : 'PHOTO_AND_VIDEO');
+  static const Category PRODUCTIVITY = Category._(14, _omitEnumNames ? '' : 'PRODUCTIVITY');
+  static const Category SCIENCE = Category._(15, _omitEnumNames ? '' : 'SCIENCE');
+  static const Category SECURITY = Category._(16, _omitEnumNames ? '' : 'SECURITY');
+  static const Category SERVER_AND_CLOUD = Category._(17, _omitEnumNames ? '' : 'SERVER_AND_CLOUD');
+  static const Category SOCIAL = Category._(18, _omitEnumNames ? '' : 'SOCIAL');
+  static const Category UTILITIES = Category._(19, _omitEnumNames ? '' : 'UTILITIES');
+
+  static const $core.List<Category> values = <Category> [
+    ART_AND_DESIGN,
+    BOOK_AND_REFERENCE,
+    DEVELOPMENT,
+    DEVICES_AND_IOT,
+    EDUCATION,
+    ENTERTAINMENT,
+    FEATURED,
+    FINANCE,
+    GAMES,
+    HEALTH_AND_FITNESS,
+    MUSIC_AND_AUDIO,
+    NEWS_AND_WEATHER,
+    PERSONALISATION,
+    PHOTO_AND_VIDEO,
+    PRODUCTIVITY,
+    SCIENCE,
+    SECURITY,
+    SERVER_AND_CLOUD,
+    SOCIAL,
+    UTILITIES,
+  ];
+
+  static final $core.Map<$core.int, Category> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static Category? valueOf($core.int value) => _byValue[value];
+
+  const Category._($core.int v, $core.String n) : super(v, n);
+}
+
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pbgrpc.dart
+++ b/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pbgrpc.dart
@@ -12,49 +12,48 @@
 import 'dart:async' as $async;
 import 'dart:core' as $core;
 
-import 'package:app_center_ratings_client/src/generated/ratings_features_chart.pb.dart'
-    as $0;
 import 'package:grpc/service_api.dart' as $grpc;
 import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'ratings_features_chart.pb.dart' as $0;
 
 export 'ratings_features_chart.pb.dart';
 
 @$pb.GrpcServiceName('ratings.features.chart.Chart')
 class ChartClient extends $grpc.Client {
+  static final _$getChart = $grpc.ClientMethod<$0.GetChartRequest, $0.GetChartResponse>(
+      '/ratings.features.chart.Chart/GetChart',
+      ($0.GetChartRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetChartResponse.fromBuffer(value));
+
   ChartClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
       $core.Iterable<$grpc.ClientInterceptor>? interceptors})
-      : super(channel, options: options, interceptors: interceptors);
-  static final _$getChart =
-      $grpc.ClientMethod<$0.GetChartRequest, $0.GetChartResponse>(
-          '/ratings.features.chart.Chart/GetChart',
-          (value) => value.writeToBuffer(),
-          (value) => $0.GetChartResponse.fromBuffer(value));
+      : super(channel, options: options,
+        interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.GetChartResponse> getChart($0.GetChartRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.GetChartResponse> getChart($0.GetChartRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getChart, request, options: options);
   }
 }
 
 @$pb.GrpcServiceName('ratings.features.chart.Chart')
 abstract class ChartServiceBase extends $grpc.Service {
+  $core.String get $name => 'ratings.features.chart.Chart';
+
   ChartServiceBase() {
     $addMethod($grpc.ServiceMethod<$0.GetChartRequest, $0.GetChartResponse>(
         'GetChart',
         getChart_Pre,
         false,
         false,
-        (value) => $0.GetChartRequest.fromBuffer(value),
-        (value) => value.writeToBuffer()));
+        ($core.List<$core.int> value) => $0.GetChartRequest.fromBuffer(value),
+        ($0.GetChartResponse value) => value.writeToBuffer()));
   }
-  $core.String get $name => 'ratings.features.chart.Chart';
 
-  $async.Future<$0.GetChartResponse> getChart_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.GetChartRequest> request) async {
+  $async.Future<$0.GetChartResponse> getChart_Pre($grpc.ServiceCall call, $async.Future<$0.GetChartRequest> request) async {
     return getChart(call, await request);
   }
 
-  $async.Future<$0.GetChartResponse> getChart(
-      $grpc.ServiceCall call, $0.GetChartRequest request);
+  $async.Future<$0.GetChartResponse> getChart($grpc.ServiceCall call, $0.GetChartRequest request);
 }

--- a/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pbjson.dart
+++ b/packages/app_center_ratings_client/lib/src/generated/ratings_features_chart.pbjson.dart
@@ -28,46 +28,71 @@ final $typed_data.Uint8List timeframeDescriptor = $convert.base64Decode(
     'CglUaW1lZnJhbWUSGQoVVElNRUZSQU1FX1VOU1BFQ0lGSUVEEAASEgoOVElNRUZSQU1FX1dFRU'
     'sQARITCg9USU1FRlJBTUVfTU9OVEgQAg==');
 
+@$core.Deprecated('Use categoryDescriptor instead')
+const Category$json = {
+  '1': 'Category',
+  '2': [
+    {'1': 'ART_AND_DESIGN', '2': 0},
+    {'1': 'BOOK_AND_REFERENCE', '2': 1},
+    {'1': 'DEVELOPMENT', '2': 2},
+    {'1': 'DEVICES_AND_IOT', '2': 3},
+    {'1': 'EDUCATION', '2': 4},
+    {'1': 'ENTERTAINMENT', '2': 5},
+    {'1': 'FEATURED', '2': 6},
+    {'1': 'FINANCE', '2': 7},
+    {'1': 'GAMES', '2': 8},
+    {'1': 'HEALTH_AND_FITNESS', '2': 9},
+    {'1': 'MUSIC_AND_AUDIO', '2': 10},
+    {'1': 'NEWS_AND_WEATHER', '2': 11},
+    {'1': 'PERSONALISATION', '2': 12},
+    {'1': 'PHOTO_AND_VIDEO', '2': 13},
+    {'1': 'PRODUCTIVITY', '2': 14},
+    {'1': 'SCIENCE', '2': 15},
+    {'1': 'SECURITY', '2': 16},
+    {'1': 'SERVER_AND_CLOUD', '2': 17},
+    {'1': 'SOCIAL', '2': 18},
+    {'1': 'UTILITIES', '2': 19},
+  ],
+};
+
+/// Descriptor for `Category`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List categoryDescriptor = $convert.base64Decode(
+    'CghDYXRlZ29yeRISCg5BUlRfQU5EX0RFU0lHThAAEhYKEkJPT0tfQU5EX1JFRkVSRU5DRRABEg'
+    '8KC0RFVkVMT1BNRU5UEAISEwoPREVWSUNFU19BTkRfSU9UEAMSDQoJRURVQ0FUSU9OEAQSEQoN'
+    'RU5URVJUQUlOTUVOVBAFEgwKCEZFQVRVUkVEEAYSCwoHRklOQU5DRRAHEgkKBUdBTUVTEAgSFg'
+    'oSSEVBTFRIX0FORF9GSVRORVNTEAkSEwoPTVVTSUNfQU5EX0FVRElPEAoSFAoQTkVXU19BTkRf'
+    'V0VBVEhFUhALEhMKD1BFUlNPTkFMSVNBVElPThAMEhMKD1BIT1RPX0FORF9WSURFTxANEhAKDF'
+    'BST0RVQ1RJVklUWRAOEgsKB1NDSUVOQ0UQDxIMCghTRUNVUklUWRAQEhQKEFNFUlZFUl9BTkRf'
+    'Q0xPVUQQERIKCgZTT0NJQUwQEhINCglVVElMSVRJRVMQEw==');
+
 @$core.Deprecated('Use getChartRequestDescriptor instead')
 const GetChartRequest$json = {
   '1': 'GetChartRequest',
   '2': [
-    {
-      '1': 'timeframe',
-      '3': 1,
-      '4': 1,
-      '5': 14,
-      '6': '.ratings.features.chart.Timeframe',
-      '10': 'timeframe'
-    },
+    {'1': 'timeframe', '3': 1, '4': 1, '5': 14, '6': '.ratings.features.chart.Timeframe', '10': 'timeframe'},
+    {'1': 'category', '3': 2, '4': 1, '5': 14, '6': '.ratings.features.chart.Category', '9': 0, '10': 'category', '17': true},
+  ],
+  '8': [
+    {'1': '_category'},
   ],
 };
 
 /// Descriptor for `GetChartRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List getChartRequestDescriptor = $convert.base64Decode(
     'Cg9HZXRDaGFydFJlcXVlc3QSPwoJdGltZWZyYW1lGAEgASgOMiEucmF0aW5ncy5mZWF0dXJlcy'
-    '5jaGFydC5UaW1lZnJhbWVSCXRpbWVmcmFtZQ==');
+    '5jaGFydC5UaW1lZnJhbWVSCXRpbWVmcmFtZRJBCghjYXRlZ29yeRgCIAEoDjIgLnJhdGluZ3Mu'
+    'ZmVhdHVyZXMuY2hhcnQuQ2F0ZWdvcnlIAFIIY2F0ZWdvcnmIAQFCCwoJX2NhdGVnb3J5');
 
 @$core.Deprecated('Use getChartResponseDescriptor instead')
 const GetChartResponse$json = {
   '1': 'GetChartResponse',
   '2': [
-    {
-      '1': 'timeframe',
-      '3': 1,
-      '4': 1,
-      '5': 14,
-      '6': '.ratings.features.chart.Timeframe',
-      '10': 'timeframe'
-    },
-    {
-      '1': 'ordered_chart_data',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.ratings.features.chart.ChartData',
-      '10': 'orderedChartData'
-    },
+    {'1': 'timeframe', '3': 1, '4': 1, '5': 14, '6': '.ratings.features.chart.Timeframe', '10': 'timeframe'},
+    {'1': 'ordered_chart_data', '3': 2, '4': 3, '5': 11, '6': '.ratings.features.chart.ChartData', '10': 'orderedChartData'},
+    {'1': 'category', '3': 3, '4': 1, '5': 14, '6': '.ratings.features.chart.Category', '9': 0, '10': 'category', '17': true},
+  ],
+  '8': [
+    {'1': '_category'},
   ],
 };
 
@@ -75,21 +100,16 @@ const GetChartResponse$json = {
 final $typed_data.Uint8List getChartResponseDescriptor = $convert.base64Decode(
     'ChBHZXRDaGFydFJlc3BvbnNlEj8KCXRpbWVmcmFtZRgBIAEoDjIhLnJhdGluZ3MuZmVhdHVyZX'
     'MuY2hhcnQuVGltZWZyYW1lUgl0aW1lZnJhbWUSTwoSb3JkZXJlZF9jaGFydF9kYXRhGAIgAygL'
-    'MiEucmF0aW5ncy5mZWF0dXJlcy5jaGFydC5DaGFydERhdGFSEG9yZGVyZWRDaGFydERhdGE=');
+    'MiEucmF0aW5ncy5mZWF0dXJlcy5jaGFydC5DaGFydERhdGFSEG9yZGVyZWRDaGFydERhdGESQQ'
+    'oIY2F0ZWdvcnkYAyABKA4yIC5yYXRpbmdzLmZlYXR1cmVzLmNoYXJ0LkNhdGVnb3J5SABSCGNh'
+    'dGVnb3J5iAEBQgsKCV9jYXRlZ29yeQ==');
 
 @$core.Deprecated('Use chartDataDescriptor instead')
 const ChartData$json = {
   '1': 'ChartData',
   '2': [
     {'1': 'raw_rating', '3': 1, '4': 1, '5': 2, '10': 'rawRating'},
-    {
-      '1': 'rating',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.ratings.features.common.Rating',
-      '10': 'rating'
-    },
+    {'1': 'rating', '3': 2, '4': 1, '5': 11, '6': '.ratings.features.common.Rating', '10': 'rating'},
   ],
 };
 
@@ -97,3 +117,4 @@ const ChartData$json = {
 final $typed_data.Uint8List chartDataDescriptor = $convert.base64Decode(
     'CglDaGFydERhdGESHQoKcmF3X3JhdGluZxgBIAEoAlIJcmF3UmF0aW5nEjcKBnJhdGluZxgCIA'
     'EoCzIfLnJhdGluZ3MuZmVhdHVyZXMuY29tbW9uLlJhdGluZ1IGcmF0aW5n');
+

--- a/packages/app_center_ratings_client/lib/src/ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/src/ratings_client.dart
@@ -53,12 +53,15 @@ class RatingsClient {
     await _userClient.delete(request, options: callOptions);
   }
 
-  Future<List<ChartData>> getChart(Timeframe timeframe, String token,
-      [int? category]) async {
+  Future<List<ChartData>> getChart(
+    Timeframe timeframe,
+    String token, [
+    int? category,
+  ]) async {
     final request = chart_pb.GetChartRequest(
-        timeframe: timeframe.toDTO(),
-        category:
-            category != null ? chart_pb.Category.valueOf(category) : null);
+      timeframe: timeframe.toDTO(),
+      category: category != null ? chart_pb.Category.valueOf(category) : null,
+    );
     final callOptions =
         CallOptions(metadata: {'authorization': 'Bearer $token'});
     final grpcResponse =

--- a/packages/app_center_ratings_client/lib/src/ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/src/ratings_client.dart
@@ -56,11 +56,11 @@ class RatingsClient {
   Future<List<ChartData>> getChart(
     Timeframe timeframe,
     String token, [
-    int? category,
+    chart_pb.Category? category,
   ]) async {
     final request = chart_pb.GetChartRequest(
       timeframe: timeframe.toDTO(),
-      category: category != null ? chart_pb.Category.valueOf(category) : null,
+      category: category,
     );
     final callOptions =
         CallOptions(metadata: {'authorization': 'Bearer $token'});

--- a/packages/app_center_ratings_client/lib/src/ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/src/ratings_client.dart
@@ -53,8 +53,10 @@ class RatingsClient {
     await _userClient.delete(request, options: callOptions);
   }
 
-  Future<List<ChartData>> getChart(Timeframe timeframe, String token) async {
-    final request = chart_pb.GetChartRequest(timeframe: timeframe.toDTO());
+  Future<List<ChartData>> getChart(Timeframe timeframe, String token,
+      [chart_pb.Category? category]) async {
+    final request = chart_pb.GetChartRequest(
+        timeframe: timeframe.toDTO(), category: category);
     final callOptions =
         CallOptions(metadata: {'authorization': 'Bearer $token'});
     final grpcResponse =

--- a/packages/app_center_ratings_client/lib/src/ratings_client.dart
+++ b/packages/app_center_ratings_client/lib/src/ratings_client.dart
@@ -54,9 +54,11 @@ class RatingsClient {
   }
 
   Future<List<ChartData>> getChart(Timeframe timeframe, String token,
-      [chart_pb.Category? category]) async {
+      [int? category]) async {
     final request = chart_pb.GetChartRequest(
-        timeframe: timeframe.toDTO(), category: category);
+        timeframe: timeframe.toDTO(),
+        category:
+            category != null ? chart_pb.Category.valueOf(category) : null);
     final callOptions =
         CallOptions(metadata: {'authorization': 'Bearer $token'});
     final grpcResponse =

--- a/packages/app_center_ratings_client/protos/ratings_features_chart.proto
+++ b/packages/app_center_ratings_client/protos/ratings_features_chart.proto
@@ -10,11 +10,13 @@ service Chart {
 
 message GetChartRequest {
   Timeframe timeframe = 1;
+  optional Category category = 2;
 }
 
 message GetChartResponse {
   Timeframe timeframe = 1;
   repeated ChartData ordered_chart_data = 2;
+  optional Category category = 3;
 }
 
 message ChartData {
@@ -26,4 +28,27 @@ enum Timeframe {
   TIMEFRAME_UNSPECIFIED = 0;
   TIMEFRAME_WEEK = 1;
   TIMEFRAME_MONTH = 2;
+}
+
+enum Category {
+  ART_AND_DESIGN = 0;
+  BOOK_AND_REFERENCE = 1;
+  DEVELOPMENT = 2;
+  DEVICES_AND_IOT = 3;
+  EDUCATION = 4;
+  ENTERTAINMENT = 5;
+  FEATURED = 6;
+  FINANCE = 7;
+  GAMES = 8;
+  HEALTH_AND_FITNESS = 9;
+  MUSIC_AND_AUDIO = 10;
+  NEWS_AND_WEATHER = 11;
+  PERSONALISATION = 12;
+  PHOTO_AND_VIDEO = 13;
+  PRODUCTIVITY = 14;
+  SCIENCE = 15;
+  SECURITY = 16;
+  SERVER_AND_CLOUD = 17;
+  SOCIAL = 18;
+  UTILITIES = 19;
 }

--- a/packages/app_center_ratings_client/test/ratings_client_test.dart
+++ b/packages/app_center_ratings_client/test/ratings_client_test.dart
@@ -66,8 +66,8 @@ void main() {
       options: anyNamed('options'),
     )).thenAnswer(
         (_) => MockResponseFuture<pb_chart.GetChartResponse>(mockResponse));
-    final response =
-        await ratingsClient.getChart(timeframe, token, pb_chart.Category.GAMES);
+    final response = await ratingsClient.getChart(
+        timeframe, token, pb_chart.Category.GAMES.value);
     expect(
       response,
       equals(expectedResponse),

--- a/packages/app_center_ratings_client/test/ratings_client_test.dart
+++ b/packages/app_center_ratings_client/test/ratings_client_test.dart
@@ -73,7 +73,7 @@ void main() {
     final response = await ratingsClient.getChart(
       timeframe,
       token,
-      pb_chart.Category.GAMES.value,
+      pb_chart.Category.GAMES,
     );
     expect(
       response,

--- a/packages/app_center_ratings_client/test/ratings_client_test.dart
+++ b/packages/app_center_ratings_client/test/ratings_client_test.dart
@@ -7,7 +7,8 @@ import 'package:app_center_ratings_client/src/generated/google/protobuf/empty.pb
 import 'package:app_center_ratings_client/src/generated/google/protobuf/timestamp.pb.dart';
 import 'package:app_center_ratings_client/src/generated/ratings_features_app.pbgrpc.dart'
     as pb;
-import 'package:app_center_ratings_client/src/generated/ratings_features_chart.pbgrpc.dart';
+import 'package:app_center_ratings_client/src/generated/ratings_features_chart.pbgrpc.dart'
+    as pb_chart;
 import 'package:app_center_ratings_client/src/generated/ratings_features_common.pb.dart';
 import 'package:app_center_ratings_client/src/generated/ratings_features_user.pbgrpc.dart';
 import 'package:app_center_ratings_client/src/ratings.dart' as ratings;
@@ -20,7 +21,7 @@ import 'package:test/test.dart';
 
 import 'ratings_client_test.mocks.dart';
 
-@GenerateMocks([pb.AppClient, UserClient, ChartClient])
+@GenerateMocks([pb.AppClient, UserClient, pb_chart.ChartClient])
 void main() {
   final mockAppClient = MockAppClient();
   final mockUserClient = MockUserClient();
@@ -33,14 +34,13 @@ void main() {
     const token = 'bar';
     const timeframe = chart.Timeframe.month;
     final pbChartList = [
-      ChartData(
-        rawRating: 3,
-        rating: Rating(
-          snapId: snapId,
-          totalVotes: Int64(105),
-          ratingsBand: RatingsBand.NEUTRAL,
-        ),
-      ),
+      pb_chart.ChartData(
+          rawRating: 3,
+          rating: Rating(
+            snapId: snapId,
+            totalVotes: Int64(105),
+            ratingsBand: RatingsBand.NEUTRAL,
+          ))
     ];
 
     final expectedResponse = [
@@ -53,18 +53,21 @@ void main() {
         ),
       ),
     ];
-    final mockResponse = GetChartResponse(
-      timeframe: Timeframe.TIMEFRAME_MONTH,
+    final mockResponse = pb_chart.GetChartResponse(
+      timeframe: pb_chart.Timeframe.TIMEFRAME_MONTH,
       orderedChartData: pbChartList,
     );
-    final request = GetChartRequest(timeframe: Timeframe.TIMEFRAME_MONTH);
-    when(
-      mockChartClient.getChart(
-        request,
-        options: anyNamed('options'),
-      ),
-    ).thenAnswer((_) => MockResponseFuture<GetChartResponse>(mockResponse));
-    final response = await ratingsClient.getChart(timeframe, token);
+    final request = pb_chart.GetChartRequest(
+      timeframe: pb_chart.Timeframe.TIMEFRAME_MONTH,
+      category: pb_chart.Category.GAMES,
+    );
+    when(mockChartClient.getChart(
+      request,
+      options: anyNamed('options'),
+    )).thenAnswer(
+        (_) => MockResponseFuture<pb_chart.GetChartResponse>(mockResponse));
+    final response =
+        await ratingsClient.getChart(timeframe, token, pb_chart.Category.GAMES);
     expect(
       response,
       equals(expectedResponse),

--- a/packages/app_center_ratings_client/test/ratings_client_test.dart
+++ b/packages/app_center_ratings_client/test/ratings_client_test.dart
@@ -35,12 +35,13 @@ void main() {
     const timeframe = chart.Timeframe.month;
     final pbChartList = [
       pb_chart.ChartData(
-          rawRating: 3,
-          rating: Rating(
-            snapId: snapId,
-            totalVotes: Int64(105),
-            ratingsBand: RatingsBand.NEUTRAL,
-          ))
+        rawRating: 3,
+        rating: Rating(
+          snapId: snapId,
+          totalVotes: Int64(105),
+          ratingsBand: RatingsBand.NEUTRAL,
+        ),
+      ),
     ];
 
     final expectedResponse = [
@@ -61,13 +62,19 @@ void main() {
       timeframe: pb_chart.Timeframe.TIMEFRAME_MONTH,
       category: pb_chart.Category.GAMES,
     );
-    when(mockChartClient.getChart(
-      request,
-      options: anyNamed('options'),
-    )).thenAnswer(
-        (_) => MockResponseFuture<pb_chart.GetChartResponse>(mockResponse));
+    when(
+      mockChartClient.getChart(
+        request,
+        options: anyNamed('options'),
+      ),
+    ).thenAnswer(
+      (_) => MockResponseFuture<pb_chart.GetChartResponse>(mockResponse),
+    );
     final response = await ratingsClient.getChart(
-        timeframe, token, pb_chart.Category.GAMES.value);
+      timeframe,
+      token,
+      pb_chart.Category.GAMES.value,
+    );
     expect(
       response,
       equals(expectedResponse),

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
       fvm dart pub global run melos clean
       fvm dart pub global run melos bootstrap
       set -e
-
+      
       fvm dart pub global run melos exec -c 1 --fail-fast --depends-on=build_runner -- \
       fvm dart run build_runner build --delete-conflicting-outputs
 
@@ -55,9 +55,9 @@ apps:
   snap-store:
     command: bin/snap-store
     environment: &store_env
-      RATINGS_SERVICE_URL: '91.189.95.24'
+      RATINGS_SERVICE_URL: 'ratings.ubuntu.com'
       RATINGS_SERVICE_PORT: '443'
-      RATINGS_SERVICE_USE_TLS: 'false'
+      RATINGS_SERVICE_USE_TLS: 'true'
     desktop: bin/data/flutter_assets/assets/app-center.desktop
     extensions: [gnome]
     plugs: &store_plugs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
       fvm dart pub global run melos clean
       fvm dart pub global run melos bootstrap
       set -e
-      
+
       fvm dart pub global run melos exec -c 1 --fail-fast --depends-on=build_runner -- \
       fvm dart run build_runner build --delete-conflicting-outputs
 
@@ -55,9 +55,9 @@ apps:
   snap-store:
     command: bin/snap-store
     environment: &store_env
-      RATINGS_SERVICE_URL: 'ratings.ubuntu.com'
+      RATINGS_SERVICE_URL: '91.189.95.24'
       RATINGS_SERVICE_PORT: '443'
-      RATINGS_SERVICE_USE_TLS: 'true'
+      RATINGS_SERVICE_USE_TLS: 'false'
     desktop: bin/data/flutter_assets/assets/app-center.desktop
     extensions: [gnome]
     plugs: &store_plugs


### PR DESCRIPTION
This PR adds an ordered list of snaps based on their rating to the Games tab. Doing this required adding support for the top charts endpoints from the ratings service to the ratings client.

I've added this as a new variation of the `CategorySnapList`, so hopefully if we intend to incorporate top charts into other areas of the app, we can easily reuse the `RatedCategorySnapList`. A spinner is displayed while the list is loading; it does take a moment since we have to fetch the snap details for each snap ID.

This is more or less what it looks like, though the actual snaps displayed will not be the same:
![image](https://github.com/user-attachments/assets/01ae6053-f4b9-4efb-a644-c44b43c56bed)

UDENG-3351