### PR TITLE
snap: update to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: snap-store
 summary: App Center
 description: App Center
 confinement: strict
-base: core22
+base: core24
 grade: stable
 version: git
 
@@ -18,6 +18,7 @@ parts:
       - clang
       - cmake
       - curl
+      - git
       - libgtk-3-dev
       - ninja-build
       - unzip


### PR DESCRIPTION
this pull request migrates the app center to core24
migration seems very straightforward only requiring the change in the base parameter and adding git as build parameter (how did it get it before by the way?)