### PR TITLE
fix: Avoid double loader for updates available section

### DIFF
--- a/packages/app_center/lib/layout.dart
+++ b/packages/app_center/lib/layout.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+const kMargin = 4.0;
 const kCardMargin = 4.0;
 const kPaneWidth = 204.0;
 const kPagePadding = 24.0;

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -24,6 +24,7 @@ class ManagePage extends ConsumerWidget {
     final localSnapsModel = ref.watch(filteredLocalSnapsProvider);
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
+    final isLoading = updatesModel.isLoading || localSnapsModel.isLoading;
 
     if (updatesModel.hasError || localSnapsModel.hasError) {
       return ErrorView(
@@ -35,6 +36,9 @@ class ManagePage extends ConsumerWidget {
       );
     }
 
+    final refreshableSnaps = updatesModel.valueOrNull?.snaps ?? [];
+    final hasInternet = updatesModel.valueOrNull?.hasInternet ?? true;
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: kPagePadding),
       child: ResponsiveLayoutScrollView(
@@ -45,63 +49,59 @@ class ManagePage extends ConsumerWidget {
                 l10n.managePageLabel,
                 style: textTheme.headlineSmall,
               ),
+              const SizedBox(height: kMargin),
               Text(
                 l10n.managePageDescription,
                 style: textTheme.titleMedium,
               ),
+              const SizedBox(height: kMargin),
               Text(
                 l10n.managePageDebUpdatesMessage,
                 style: textTheme.titleMedium,
               ),
               _SelfUpdateInfoBox(),
-              ...updatesModel.when(
-                data: (snapListState) {
-                  final refreshableSnaps = snapListState.snaps;
-                  return [
-                    Builder(
-                      builder: (context) {
-                        final compact = ResponsiveLayout.of(context).type ==
-                            ResponsiveLayoutType.small;
-                        return Flex(
-                          direction: compact ? Axis.vertical : Axis.horizontal,
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: compact
-                              ? CrossAxisAlignment.start
-                              : CrossAxisAlignment.center,
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              l10n.managePageUpdatesAvailable(
-                                refreshableSnaps.length,
-                              ),
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .titleMedium!
-                                  .copyWith(fontWeight: FontWeight.w500),
-                            ),
-                            if (compact) const SizedBox(height: 16),
-                            const Flexible(child: _ActionButtons()),
-                          ],
-                        );
-                      },
-                    ),
-                    const SizedBox(height: 24),
-                    if (!snapListState.hasInternet) ...[
+              Builder(
+                builder: (context) {
+                  final compact = ResponsiveLayout.of(context).type ==
+                      ResponsiveLayoutType.small;
+                  return Flex(
+                    direction: compact ? Axis.vertical : Axis.horizontal,
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: compact
+                        ? CrossAxisAlignment.start
+                        : CrossAxisAlignment.center,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
                       Text(
-                        l10n.managePageNoInternet,
-                        style: textTheme.titleMedium,
+                        l10n.managePageUpdatesAvailable(
+                          refreshableSnaps.length,
+                        ),
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium!
+                            .copyWith(fontWeight: FontWeight.w500),
                       ),
-                    ] else if (refreshableSnaps.isEmpty)
-                      Text(
-                        l10n.managePageNoUpdatesAvailableDescription,
-                        style: textTheme.titleMedium,
-                      ),
-                  ];
+                      if (compact) const SizedBox(height: 16),
+                      const Flexible(child: _ActionButtons()),
+                    ],
+                  );
                 },
-                error: (_, __) => [],
-                loading: () =>
-                    [const Center(child: YaruCircularProgressIndicator())],
               ),
+              const SizedBox(height: 24),
+              if (!hasInternet && !isLoading)
+                _MinHeightAsProgressIndicator(
+                  child: Text(
+                    l10n.managePageNoInternet,
+                    style: textTheme.titleMedium,
+                  ),
+                )
+              else if (refreshableSnaps.isEmpty && !isLoading)
+                _MinHeightAsProgressIndicator(
+                  child: Text(
+                    l10n.managePageNoUpdatesAvailableDescription,
+                    style: textTheme.titleMedium,
+                  ),
+                ),
             ],
           ),
           updatesModel.when(
@@ -242,6 +242,7 @@ class _ActionButtons extends ConsumerWidget {
     final updateChangeId = ref.watch(updateChangeIdProvider);
     final hasInternet = updatesModel.value?.hasInternet ?? true;
     final updatesInProgress = !updatesModel.isLoading && updateChangeId != null;
+    final isLoading = updatesModel.isLoading || localSnapsModel.isLoading;
 
     return Wrap(
       spacing: 10,
@@ -249,10 +250,7 @@ class _ActionButtons extends ConsumerWidget {
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
         PushButton.outlined(
-          onPressed: updatesInProgress ||
-                  updatesModel.hasError ||
-                  updatesModel.isLoading ||
-                  localSnapsModel.isLoading
+          onPressed: updatesInProgress || updatesModel.hasError || isLoading
               ? null
               : () => ref.refresh(updatesModelProvider),
           child: Row(
@@ -385,6 +383,28 @@ class _SelfUpdateInfoBox extends ConsumerWidget {
         yaruInfoType: YaruInfoType.information,
         isThreeLine: true,
       ),
+    );
+  }
+}
+
+class _MinHeightAsProgressIndicator extends StatelessWidget {
+  const _MinHeightAsProgressIndicator({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        const Visibility(
+          visible: false,
+          maintainSize: true,
+          maintainAnimation: true,
+          maintainState: true,
+          child: YaruCircularProgressIndicator(),
+        ),
+        child,
+      ],
     );
   }
 }

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -147,7 +147,7 @@ void main() {
         child: const ManagePage(),
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     final testTile = find.snapTile('Test Snap');
     final testTile2 = find.snapTile('Another Test Snap');


### PR DESCRIPTION
[Screencast from 2024-07-25 15-33-20.webm](https://github.com/user-attachments/assets/4407889d-1319-45b0-9206-1f363a3b1a72)

Also fixed so that the height doesn't change when the loaded switches to the text, which looked kind of janky.

Closes: #1752 