### PR TITLE
fix: SearchBar autofocus when click on clear btn

### DIFF
--- a/packages/app_center/lib/search/search_field.dart
+++ b/packages/app_center/lib/search/search_field.dart
@@ -187,11 +187,12 @@ class _SearchFieldState extends ConsumerState<SearchField> {
                     builder: (context, child) {
                       return YaruIconButton(
                         icon: const Icon(YaruIcons.edit_clear, size: 16),
-                        onPressed:
-                            controller.text.isEmpty ? null : (){
-                              controller.clear();
-                              node.requestFocus();
-                        },
+                        onPressed: controller.text.isEmpty
+                            ? null
+                            : () {
+                                controller.clear();
+                                node.requestFocus();
+                              },
                       );
                     },
                   ),

--- a/packages/app_center/lib/search/search_field.dart
+++ b/packages/app_center/lib/search/search_field.dart
@@ -188,7 +188,10 @@ class _SearchFieldState extends ConsumerState<SearchField> {
                       return YaruIconButton(
                         icon: const Icon(YaruIcons.edit_clear, size: 16),
                         onPressed:
-                            controller.text.isEmpty ? null : controller.clear,
+                            controller.text.isEmpty ? null : (){
+                              controller.clear();
+                              node.requestFocus();
+                        },
                       );
                     },
                   ),


### PR DESCRIPTION
The search bar should automatically focused when 'clear search text' button is clicked. This is small tweak but usefull too. I do search, do some activities. Then search bar become unfocused. Then I click on clear search button and start typing my query, And then I see that Search bar is not focused. I have to manually click on the textfeild to focus it. This pull request will automatically focus search bar when someone click on clear search button. I made this changes from my experience.