### PR TITLE
fix: Remove secondary action icons

### DIFF
--- a/packages/app_center/lib/manage/manage_snap_tile.dart
+++ b/packages/app_center/lib/manage/manage_snap_tile.dart
@@ -234,7 +234,6 @@ class _ButtonBarForUpdate extends ConsumerWidget {
             ),
             MenuItemButton(
               onPressed: ref.read(snapModelProvider(snap.name).notifier).remove,
-              leadingIcon: Icon(SnapAction.remove.icon, color: removeColor),
               child: Text(
                 SnapAction.remove.label(l10n),
                 style: TextStyle(color: removeColor),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -358,8 +358,6 @@ class _SnapActionButtons extends ConsumerWidget {
           child: IntrinsicWidth(
             child: ListTile(
               mouseCursor: SystemMouseCursors.click,
-              leading:
-                  action.icon != null ? Icon(action.icon, color: color) : null,
               title: Text(
                 action.label(l10n),
                 style: TextStyle(color: color),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6de75a7b-c0ff-4791-815e-82831d7ce917)

![image](https://github.com/user-attachments/assets/07c1c5c8-857d-4cf7-9155-107075e06394)
