### PR TITLE
fix: Align extra snap menus

### DIFF
--- a/packages/app_center/lib/manage/manage_snap_tile.dart
+++ b/packages/app_center/lib/manage/manage_snap_tile.dart
@@ -4,6 +4,7 @@ import 'package:app_center/manage/manage_l10n.dart';
 import 'package:app_center/snapd/snap_action.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/store/store.dart';
+import 'package:app_center/widgets/snap_menu_item.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -220,24 +221,19 @@ class _ButtonBarForUpdate extends ConsumerWidget {
         MenuAnchor(
           menuChildren: [
             if (snapLauncher.isLaunchable)
-              MenuItemButton(
+              SnapMenuItem(
                 onPressed: snapLauncher.open,
-                child: Text(l10n.snapActionOpenLabel),
+                title: l10n.snapActionOpenLabel,
               ),
-            MenuItemButton(
+            SnapMenuItem(
               onPressed: () =>
                   StoreNavigator.pushSnap(context, name: snap.name),
-              child: Text(
-                l10n.managePageShowDetailsLabel,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
+              title: l10n.managePageShowDetailsLabel,
             ),
-            MenuItemButton(
+            SnapMenuItem(
               onPressed: ref.read(snapModelProvider(snap.name).notifier).remove,
-              child: Text(
-                SnapAction.remove.label(l10n),
-                style: TextStyle(color: removeColor),
-              ),
+              title: SnapAction.remove.label(l10n),
+              textStyle: TextStyle(color: removeColor),
             ),
           ],
           builder: (context, controller, child) => YaruOptionButton(
@@ -296,21 +292,15 @@ class _ButtonBarForOpen extends ConsumerWidget {
         const SizedBox(width: 16),
         MenuAnchor(
           menuChildren: [
-            MenuItemButton(
+            SnapMenuItem(
               onPressed: () =>
                   StoreNavigator.pushSnap(context, name: snap.name),
-              child: Text(
-                l10n.managePageShowDetailsLabel,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
+              title: l10n.managePageShowDetailsLabel,
             ),
-            MenuItemButton(
+            SnapMenuItem(
               onPressed: ref.read(snapModelProvider(snap.name).notifier).remove,
-              leadingIcon: Icon(SnapAction.remove.icon, color: removeColor),
-              child: Text(
-                SnapAction.remove.label(l10n),
-                style: TextStyle(color: removeColor),
-              ),
+              title: SnapAction.remove.label(l10n),
+              textStyle: TextStyle(color: removeColor),
             ),
           ],
           builder: (context, controller, child) => YaruOptionButton(

--- a/packages/app_center/lib/widgets/snap_menu_item.dart
+++ b/packages/app_center/lib/widgets/snap_menu_item.dart
@@ -1,9 +1,4 @@
-import 'package:app_center/games/games.dart';
-import 'package:app_center/layout.dart';
-import 'package:app_center/widgets/app_card.dart';
-import 'package:appstream/appstream.dart';
 import 'package:flutter/material.dart';
-import 'package:snapd/snapd.dart';
 
 class SnapMenuItem extends StatelessWidget {
   const SnapMenuItem({

--- a/packages/app_center/lib/widgets/snap_menu_item.dart
+++ b/packages/app_center/lib/widgets/snap_menu_item.dart
@@ -1,0 +1,35 @@
+import 'package:app_center/games/games.dart';
+import 'package:app_center/layout.dart';
+import 'package:app_center/widgets/app_card.dart';
+import 'package:appstream/appstream.dart';
+import 'package:flutter/material.dart';
+import 'package:snapd/snapd.dart';
+
+class SnapMenuItem extends StatelessWidget {
+  const SnapMenuItem({
+    required this.title,
+    required this.onPressed,
+    this.textStyle,
+    super.key,
+  });
+
+  final String title;
+  final void Function() onPressed;
+  final TextStyle? textStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuItemButton(
+      onPressed: onPressed,
+      child: IntrinsicWidth(
+        child: ListTile(
+          mouseCursor: SystemMouseCursors.click,
+          title: Text(
+            title,
+            style: textStyle,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3a8ddc83-2ce0-49fb-8de6-6b4f2689b281)

These `_ButtonBarForUpdate` and `_ButtonBarForOpen` should probably be generalized at some point, but I think that can be done later since it's only two of them now.

Closes: #1775 