### PR TITLE
fix: Don't reload lists after each update in `refreshAll`

### DIFF
--- a/packages/app_center/lib/manage/local_snap_providers.dart
+++ b/packages/app_center/lib/manage/local_snap_providers.dart
@@ -21,7 +21,7 @@ class FilteredLocalSnaps extends _$FilteredLocalSnaps {
     final snapListState = await connectionCheck(_snapd.getSnaps, ref);
     final snaps = snapListState.snaps;
     final refreshableSnaps =
-        (await ref.watch(updatesModelProvider.future)).snaps.map((s) => s.name);
+        (await ref.read(updatesModelProvider.future)).snaps.map((s) => s.name);
     final nonRefreshableSnaps =
         snaps.where((s) => !refreshableSnaps.contains(s.name));
     void refreshFunction(_, __) => _refreshWithFilters(nonRefreshableSnaps);

--- a/packages/app_center/lib/manage/updates_model.dart
+++ b/packages/app_center/lib/manage/updates_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:app_center/constants.dart';
 import 'package:app_center/error/error.dart';
+import 'package:app_center/manage/local_snap_providers.dart';
 import 'package:app_center/providers/error_stream_provider.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:collection/collection.dart';
@@ -135,7 +136,10 @@ class UpdatesModel extends _$UpdatesModel {
         final refreshFuture =
             ref.read(SnapModelProvider(snapName).notifier).refresh();
         try {
-          await refreshFuture;
+          final completedSuccessfully = await refreshFuture;
+          if (completedSuccessfully) {
+            ref.read(updatesModelProvider.notifier).removeFromList(snapName);
+          }
         } on Exception catch (e) {
           if (e is SnapdException && e.kind == 'auth-cancelled') {
             rethrow;
@@ -164,6 +168,7 @@ class UpdatesModel extends _$UpdatesModel {
             );
       }
       ref.invalidateSelf();
+      ref.invalidate(filteredLocalSnapsProvider);
     }
   }
 


### PR DESCRIPTION
Fixes #1813