### PR TITLE
fix: Use `UpdateButton` on SnapPage

### DIFF
--- a/packages/app_center/lib/manage/manage_snap_tile.dart
+++ b/packages/app_center/lib/manage/manage_snap_tile.dart
@@ -1,6 +1,7 @@
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/manage/manage_l10n.dart';
+import 'package:app_center/manage/update_button.dart';
 import 'package:app_center/snapd/snap_action.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/store/store.dart';
@@ -260,7 +261,7 @@ class _ButtonBar extends ConsumerWidget {
         )
       else ...[
         if (showUpdateButton)
-          _UpdateButton(snapModel: snapModel, activeChangeId: activeChangeId),
+          UpdateButton(snapModel: snapModel, activeChangeId: activeChangeId),
         if (!showUpdateButton && canOpen)
           OutlinedButton(
             onPressed: snapLauncher.open,
@@ -273,71 +274,5 @@ class _ButtonBar extends ConsumerWidget {
           ),
       ],
     ];
-  }
-}
-
-class _UpdateButton extends ConsumerWidget {
-  const _UpdateButton({
-    required this.snapModel,
-    required this.activeChangeId,
-  });
-
-  final AsyncValue<SnapData> snapModel;
-  final String? activeChangeId;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context);
-    final shouldQuitToUpdate =
-        snapModel.valueOrNull?.localSnap?.refreshInhibit != null;
-    final snap =
-        snapModel.valueOrNull?.localSnap ?? snapModel.valueOrNull?.storeSnap;
-
-    if (shouldQuitToUpdate) {
-      return const QuitToUpdateNotice();
-    } else {
-      return OutlinedButton(
-        onPressed: activeChangeId != null || !snapModel.hasValue
-            ? null
-            : ref.read(snapModelProvider(snap!.name).notifier).refresh,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(YaruIcons.download),
-            const SizedBox(width: kSpacingSmall),
-            Text(
-              l10n.snapActionUpdateLabel,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
-        ),
-      );
-    }
-  }
-}
-
-@visibleForTesting
-class QuitToUpdateNotice extends StatelessWidget {
-  const QuitToUpdateNotice({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(YaruIcons.warning_filled, color: colorScheme.warning),
-        const SizedBox(width: 8),
-        Text(
-          l10n.managePageQuitToUpdate,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: Theme.of(context).textTheme.bodyMedium,
-        ),
-      ],
-    );
   }
 }

--- a/packages/app_center/lib/manage/update_button.dart
+++ b/packages/app_center/lib/manage/update_button.dart
@@ -1,0 +1,73 @@
+import 'package:app_center/l10n.dart';
+import 'package:app_center/layout.dart';
+import 'package:app_center/snapd/snapd.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yaru/yaru.dart';
+
+class UpdateButton extends ConsumerWidget {
+  const UpdateButton({
+    required this.snapModel,
+    required this.activeChangeId,
+    super.key,
+  });
+
+  final AsyncValue<SnapData> snapModel;
+  final String? activeChangeId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final shouldQuitToUpdate =
+        snapModel.valueOrNull?.localSnap?.refreshInhibit != null;
+    final snap =
+        snapModel.valueOrNull?.localSnap ?? snapModel.valueOrNull?.storeSnap;
+
+    if (shouldQuitToUpdate) {
+      return const QuitToUpdateNotice();
+    } else {
+      return OutlinedButton(
+        onPressed: activeChangeId != null || !snapModel.hasValue
+            ? null
+            : ref.read(snapModelProvider(snap!.name).notifier).refresh,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(YaruIcons.download),
+            const SizedBox(width: kSpacingSmall),
+            Text(
+              l10n.snapActionUpdateLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      );
+    }
+  }
+}
+
+@visibleForTesting
+class QuitToUpdateNotice extends StatelessWidget {
+  const QuitToUpdateNotice({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(YaruIcons.warning_filled, color: colorScheme.warning),
+        const SizedBox(width: 8),
+        Text(
+          l10n.managePageQuitToUpdate,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -5,6 +5,7 @@ import 'package:app_center/extensions/string_extensions.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/manage/local_snap_providers.dart';
+import 'package:app_center/manage/update_button.dart';
 import 'package:app_center/ratings/ratings.dart';
 import 'package:app_center/snapd/snap_action.dart';
 import 'package:app_center/snapd/snap_report.dart';
@@ -345,27 +346,43 @@ class _SnapActionButtons extends ConsumerWidget {
     );
 
     final secondaryActions = [
-      if (snapData.hasUpdate) SnapAction.update,
-      SnapAction.remove,
+      (
+        action: SnapAction.update,
+        widget: UpdateButton(
+          snapModel: ref.watch(snapModelProvider(snapData.name)),
+          activeChangeId: snapData.activeChangeId,
+        ),
+      ),
+      (action: SnapAction.remove, widget: null),
     ];
     final secondaryActionsButton = MenuAnchor(
-      menuChildren: secondaryActions.map((action) {
-        final color = action == SnapAction.remove
-            ? Theme.of(context).colorScheme.error
-            : null;
-        return MenuItemButton(
-          onPressed: action.callback(snapData, snapModel, snapLauncher),
-          child: IntrinsicWidth(
-            child: ListTile(
-              mouseCursor: SystemMouseCursors.click,
-              title: Text(
-                action.label(l10n),
-                style: TextStyle(color: color),
-              ),
-            ),
-          ),
-        );
-      }).toList(),
+      menuChildren: [
+        ...secondaryActions.map((entry) {
+          final (:action, :widget) = entry;
+          final color = action == SnapAction.remove
+              ? Theme.of(context).colorScheme.error
+              : null;
+          return widget == null
+              ? MenuItemButton(
+                  onPressed: action.callback(snapData, snapModel, snapLauncher),
+                  child: IntrinsicWidth(
+                    child: ListTile(
+                      mouseCursor: SystemMouseCursors.click,
+                      title: Text(
+                        action.label(l10n),
+                        style: TextStyle(color: color),
+                      ),
+                    ),
+                  ),
+                )
+              : IntrinsicWidth(
+                  child: ListTile(
+                    mouseCursor: SystemMouseCursors.click,
+                    title: widget,
+                  ),
+                );
+        }),
+      ],
       builder: (context, controller, child) => YaruOptionButton(
         onPressed: () {
           if (controller.isOpen) {

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -1,7 +1,7 @@
 import 'package:app_center/constants.dart';
 import 'package:app_center/manage/local_snap_providers.dart';
 import 'package:app_center/manage/manage.dart';
-import 'package:app_center/manage/manage_snap_tile.dart';
+import 'package:app_center/manage/update_button.dart';
 import 'package:app_center/manage/updates_model.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/widgets/widgets.dart';


### PR DESCRIPTION
Use the `UpdateButton` from the manage page on the snap page too so that we get info like "Quit to update"

Fixes: #1773