### PR TITLE
fix: Accommodate long switch channel buttons texts

### DIFF
--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -27,7 +27,6 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
-const _kPrimaryButtonMaxWidth = 136.0;
 const _kChannelDropdownWidth = 220.0;
 
 typedef SnapInfo = ({Widget label, Widget value});

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -336,11 +336,13 @@ class _SnapActionButtons extends ConsumerWidget {
     }
 
     final hasActiveChange = snapData.activeChangeId != null;
-    final primaryActionButton = SizedBox(
-      width: _kPrimaryButtonMaxWidth,
+    final primaryActionButton = Flexible(
       child: PushButton.elevated(
         onPressed: primaryAction.callback(snapData, snapModel, snapLauncher),
-        child: Text(primaryAction.label(l10n)),
+        child: Text(
+          primaryAction.label(l10n),
+          overflow: TextOverflow.ellipsis,
+        ),
       ),
     );
 
@@ -383,8 +385,8 @@ class _SnapActionButtons extends ConsumerWidget {
             snapName: snapModel.snapName,
             activeChangeId: snapData.activeChangeId!,
           )
-        : OverflowBar(
-            overflowSpacing: 8,
+        : Row(
+            mainAxisSize: MainAxisSize.min,
             children: [
               primaryActionButton,
               if (snapData.isInstalled && snapData.activeChangeId == null)


### PR DESCRIPTION
![Screenshot from 2024-10-03 14-02-08](https://github.com/user-attachments/assets/d8ad0486-359b-4ef8-8901-f4b3ac26b0af)
![Screenshot from 2024-10-03 14-02-18](https://github.com/user-attachments/assets/daa0b66e-36d7-4626-ad5c-49ac0d7a94be)

Instead of putting using the overflow bar we'll make the switch button flexible so that it can shrink when it needs to (and be larger when the text is long).

Fixes: #1513