### PR TITLE
docs: Add instructions on how to report security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# How to report a security issue with app-center
+
+The easiest way to report a security issue is through [GitHub](https://github.com/ubuntu/app-center/security/advisories/new).
+See [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+contains more information about what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
Quoting SEC0026 - SSDLC

> SECURITY.md (V1.1)
> Any public repository must also include a SECURITY.md file in the root directory, which educates users/contributors on
> how to report a security concern.

The content of the file is based on the template referenced in the spec and what other Canonical repository are already using