### PR TITLE
fix: Use `IntrinsicWidth` for rows with space

### DIFF
--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -126,7 +126,6 @@ class ManagePage extends ConsumerWidget {
                     length: snapListState.snaps.length,
                   ),
                   showUpdateButton: true,
-                  hasFixedSize: false,
                 ),
               );
             },
@@ -159,7 +158,6 @@ class ManagePage extends ConsumerWidget {
                   index: index,
                   length: currentlyInstalling.length,
                 ),
-                hasFixedSize: false,
               ),
             ),
           ],

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -126,6 +126,7 @@ class ManagePage extends ConsumerWidget {
                     length: snapListState.snaps.length,
                   ),
                   showUpdateButton: true,
+                  hasFixedSize: false,
                 ),
               );
             },
@@ -158,6 +159,7 @@ class ManagePage extends ConsumerWidget {
                   index: index,
                   length: currentlyInstalling.length,
                 ),
+                hasFixedSize: false,
               ),
             ),
           ],
@@ -276,6 +278,7 @@ class ManagePage extends ConsumerWidget {
                   index: index,
                   length: snapListState.snaps.length,
                 ),
+                hasFixedSize: true,
               ),
             ),
             error: (_, __) =>

--- a/packages/app_center/lib/manage/manage_snap_tile.dart
+++ b/packages/app_center/lib/manage/manage_snap_tile.dart
@@ -19,7 +19,7 @@ class ManageSnapTile extends StatelessWidget {
     required this.snap,
     this.position = ManageTilePosition.middle,
     this.showUpdateButton = false,
-    required this.hasFixedSize,
+    this.hasFixedSize = false,
     super.key,
   });
 

--- a/packages/app_center/lib/manage/manage_snap_tile.dart
+++ b/packages/app_center/lib/manage/manage_snap_tile.dart
@@ -19,12 +19,14 @@ class ManageSnapTile extends StatelessWidget {
     required this.snap,
     this.position = ManageTilePosition.middle,
     this.showUpdateButton = false,
+    required this.hasFixedSize,
     super.key,
   });
 
   final Snap snap;
   final ManageTilePosition position;
   final bool showUpdateButton;
+  final bool hasFixedSize;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +36,10 @@ class ManageSnapTile extends StatelessWidget {
         ? DateTime.now().difference(snap.installDate!)
         : null;
     const radius = Radius.circular(8);
+    final buttonBar = Align(
+      alignment: Alignment.centerRight,
+      child: _ButtonBar(snap, showUpdateButton),
+    );
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -162,13 +168,9 @@ class ManageSnapTile extends StatelessWidget {
               ),
           ],
         ),
-        trailing: SizedBox(
-          width: 260,
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: _ButtonBar(snap, showUpdateButton),
-          ),
-        ),
+        trailing: hasFixedSize
+            ? SizedBox(width: 180, child: buttonBar)
+            : IntrinsicWidth(child: buttonBar),
       ),
     );
   }


### PR DESCRIPTION
Fixed a bug reported on Discord where the length of the text makes the button bar overflow:
![image](https://github.com/user-attachments/assets/c76acfbb-aaff-4065-b91c-249f446096d3)
(Image of how the bug looks like, not how it looks like after the fix)