### PR TITLE
feat: ignore outdated ratings cache

### DIFF
--- a/packages/app_center/lib/snapd/cache_file.dart
+++ b/packages/app_center/lib/snapd/cache_file.dart
@@ -8,11 +8,14 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:snapd/snapd.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
 
 @visibleForTesting
 final cachePath =
     '${xdg.cacheHome.path}/${p.basename(Platform.resolvedExecutable)}/snapd';
+
+final _log = Logger('cache_file');
 
 class CacheFile {
   CacheFile(
@@ -109,7 +112,14 @@ class CacheFile {
 
   Future<RatingsData?> readRatingsData() async {
     final data = await read() as Map?;
-    return data != null ? RatingsData.fromJson(data.cast()) : null;
+    if (data == null) return null;
+
+    try {
+      return RatingsData.fromJson(data.cast());
+    } on Error catch (e) {
+      _log.debug('Caught error while reading ratings cache data: $e');
+      return null;
+    }
   }
 
   void writeRatingsDataSync(RatingsData ratingsData) {


### PR DESCRIPTION
Old cache data for the ratings will be missing the snap_name field. If that's the case we should ignore the error and throw away the cache data.

UDENG-5771