### PR TITLE
fix: add `branchname` to tics job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,3 +108,4 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
+          branchname: main


### PR DESCRIPTION
Somehow the tics job assumes "master" as the branch name (see [here](https://github.com/ubuntu/app-center/actions/runs/12884578321/job/35922462758)), although we're using "main". According to the [docs](https://github.com/marketplace/actions/tics-code-quality-analysis#advanced-parameters) we can provide a `branchname` (all lowercase) parameter - let's see if that helps.

UDENG-5819