### PR TITLE
chore: remove unused l10n string

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -28,14 +28,6 @@
     "managePageOwnUpdateAvailable": "App Center update available",
     "managePageQuitToUpdate": "Quit to update",
     "managePageOwnUpdateDescription": "When you quit the application it will automatically update.",
-    "managePageOwnUpdateDescriptionSoon": "The app center will automatically update in {time}.",
-    "@managePageOwnUpdateDescriptionSoon": {
-        "placeholders": {
-            "time": {
-                "type": "String"
-            }
-        }
-    },
     "managePageOwnUpdateQuitButton": "Quit to update",
     "managePageCheckForUpdates": "Check for updates",
     "managePageCheckingForUpdates": "Checking for updates",


### PR DESCRIPTION
Removes an unused l10n string introduced in #1751. Someone asked for more context when translating it on weblate, when I realized we're not actually using it anywhere.