### PR TITLE
ci: reenable tics action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,18 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 
+      - name: Convert Flutter coverage files to cobertura XML
+        run: |
+          dart pub global activate cobertura
+          mkdir coverage
+          for package in app_center app_center_ratings_client; do
+            pushd packages/$package
+            cobertura convert
+            sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
+            mv coverage/cobertura.xml ../../coverage/$package.xml
+            popd
+          done
+
       - name: Run TICS analysis
         # if: github.event_name == 'push'
         uses: tiobe/tics-github-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,12 @@ jobs:
             popd
           done
 
+      - name: Cleanup
+        run: |
+          melos clean
+          melos exec -c 1 fvm flutter clean
+          rm -rf .fvm
+
       - name: Run TICS analysis
         # if: github.event_name == 'push'
         uses: tiobe/tics-github-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,17 +99,12 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 
-      - name: Convert Flutter coverage files to cobertura XML
+      - name: Process coverage output
         run: |
-          dart pub global activate cobertura
           mkdir coverage
           for package in app_center app_center_ratings_client; do
             pushd packages/$package
-            cobertura convert
-            sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
-            sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
             sed -i "s|lib/|$(pwd)/lib/|g" coverage/lcov.info
-            mv coverage/cobertura.xml ../../coverage/$package.xml
             mv coverage/lcov.info ../../coverage/$package.info
             popd
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           rm -rf .fvm
 
       - name: Run TICS analysis
-        # if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,7 @@ jobs:
             pushd packages/$package
             cobertura convert
             sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
+            sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
             mv coverage/cobertura.xml ../../coverage/$package.xml
             popd
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,9 @@ jobs:
             cobertura convert
             sed -i 's/branches-covered/decisions-covered/g' coverage/cobertura.xml
             sed -i "s|lib/|$(pwd)/lib/|g" coverage/cobertura.xml
+            sed -i "s|lib/|$(pwd)/lib/|g" coverage/lcov.info
             mv coverage/cobertura.xml ../../coverage/$package.xml
+            mv coverage/lcov.info ../../coverage/$package.info
             popd
           done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,15 +99,12 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 
-      # FIXME: uncomment once the configuration on the TiCS side is updated to use
-      #        the correct branch name
-      # - name: Run TICS analysis
-      #   if: github.event_name == 'push'
-      #   uses: tiobe/tics-github-action@v3
-      #   with:
-      #     mode: qserver
-      #     project: app-center
-      #     viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-      #     ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-      #     installTics: true
-      #     branchname: main
+      - name: Run TICS analysis
+        # if: github.event_name == 'push'
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: app-center
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/melos.yaml
+++ b/melos.yaml
@@ -34,6 +34,7 @@ scripts:
         '**/*.mocks.dart' \
         '**/l10n/*.dart' \
         '**/*.pb*.dart' \
+        --ignore-errors unused,unused \
         -o coverage/lcov.info
 
   # format all packages


### PR DESCRIPTION
This seems to work correctly now :)

The TiCS backend searches for coverage files in the `coverage` directory in the repository root. It seems like it actually only reads the lcov files, so the conversion to cobertura XML is unnecessary (for Dart code). Since the file paths in the coverage output are relative, they need to be adjusted when moving the output files around, so I'm just turning them into absolute paths.
I've also added a "cleanup" step, since symlinks in `.fvm` and `packages/*/linux/flutter/ephemeral` that point to directories outside of the repository, seem to cause problems with TiCS.

UDENG-5819