### PR TITLE
fix: Remove card background color

### DIFF
--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -80,7 +80,6 @@ class AppCard extends StatelessWidget {
     return YaruBanner(
       padding: const EdgeInsets.all(kCardSpacing),
       onTap: onTap,
-      color: Theme.of(context).cardColor,
       child: Flex(
         direction: compact ? Axis.vertical : Axis.horizontal,
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
Removes the background color for app cards.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/21663416-9952-44db-a161-9e8ac9243d18) | ![image](https://github.com/user-attachments/assets/6a0c5515-bcd6-49f5-a098-4aa2cae81b56) |

Related to the issues described in https://github.com/ubuntu/app-center/pull/1818