### PR TITLE
fix(a11y): Add labels to page actions and expandable sections

### DIFF
--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -8,6 +8,7 @@ import 'package:app_center/error/error.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/packagekit/packagekit.dart';
+import 'package:app_center/store/store_app.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:appstream/appstream.dart';
 import 'package:flutter/material.dart';
@@ -230,13 +231,13 @@ enum DebAction {
       };
 }
 
-class _Header extends StatelessWidget {
+class _Header extends ConsumerWidget {
   const _Header({required this.debModel});
 
   final DebModel debModel;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     return Column(
       children: [
@@ -254,6 +255,15 @@ class _Header extends StatelessWidget {
                   semanticLabel: l10n.debPageShareSemanticLabel,
                 ),
                 onPressed: () {
+                  final navigationKey =
+                      ref.watch(materialAppNavigatorKeyProvider);
+
+                  ScaffoldMessenger.of(navigationKey.currentContext!)
+                      .showSnackBar(
+                    SnackBar(
+                      content: Text(l10n.snapPageShareLinkCopiedMessage),
+                    ),
+                  );
                   Clipboard.setData(
                     ClipboardData(text: debModel.component.website!),
                   );

--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -126,7 +126,7 @@ class _DebView extends StatelessWidget {
                       AppInfoBar(appInfos: debInfos, layout: layout),
                       if (debModel.component.screenshotUrls.isNotEmpty)
                         AppPageSection(
-                          header: Text(l10n.snapPageGalleryLabel),
+                          header: l10n.snapPageGalleryLabel,
                           child: ScreenshotGallery(
                             title: debModel.component.getLocalizedName(),
                             urls: debModel.component.screenshotUrls,
@@ -134,7 +134,7 @@ class _DebView extends StatelessWidget {
                           ),
                         ),
                       AppPageSection(
-                        header: Text(l10n.snapPageDescriptionLabel),
+                        header: l10n.snapPageDescriptionLabel,
                         child: Html(
                           data: debModel.component.getLocalizedDescription(),
                         ),

--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -249,7 +249,10 @@ class _Header extends StatelessWidget {
             Expanded(child: AppTitle.fromDeb(debModel.component)),
             if (debModel.component.website != null)
               YaruIconButton(
-                icon: const Icon(YaruIcons.share),
+                icon: Icon(
+                  YaruIcons.share,
+                  semanticLabel: l10n.debPageShareSemanticLabel,
+                ),
                 onPressed: () {
                   Clipboard.setData(
                     ClipboardData(text: debModel.component.website!),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -423,7 +423,10 @@ class _IconRow extends ConsumerWidget {
       children: [
         if (snap.website != null)
           YaruIconButton(
-            icon: const Icon(YaruIcons.share),
+            icon: Icon(
+              YaruIcons.share,
+              semanticLabel: l10n.snapPageShareLabel,
+            ),
             onPressed: () {
               final navigationKey = ref.watch(materialAppNavigatorKeyProvider);
 
@@ -436,7 +439,10 @@ class _IconRow extends ConsumerWidget {
             },
           ),
         YaruIconButton(
-          icon: const Icon(YaruIcons.flag),
+          icon: Icon(
+            YaruIcons.flag,
+            semanticLabel: l10n.snapPageReportLabel,
+          ),
           onPressed: () {
             showDialog(
               context: context,

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -413,7 +413,7 @@ class _IconRow extends ConsumerWidget {
           YaruIconButton(
             icon: Icon(
               YaruIcons.share,
-              semanticLabel: l10n.snapPageShareLabel,
+              semanticLabel: l10n.snapPageShareSemanticLabel,
             ),
             onPressed: () {
               final navigationKey = ref.watch(materialAppNavigatorKeyProvider);
@@ -429,7 +429,7 @@ class _IconRow extends ConsumerWidget {
         YaruIconButton(
           icon: Icon(
             YaruIcons.flag,
-            semanticLabel: l10n.snapPageReportLabel,
+            semanticLabel: l10n.snapPageReportSemanticLabel,
           ),
           onPressed: () {
             showDialog(

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -199,13 +199,7 @@ class _SnapView extends StatelessWidget {
                     const SizedBox(height: kSectionSpacing),
                     if (snapData.hasGallery) ...[
                       AppPageSection(
-                        header: Text(
-                          l10n.snapPageGalleryLabel,
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
-                        ),
+                        header: l10n.snapPageGalleryLabel,
                         child: Padding(
                           padding: const EdgeInsets.only(
                             bottom: kSectionSpacing,
@@ -221,13 +215,7 @@ class _SnapView extends StatelessWidget {
                       const SizedBox(height: kSectionSpacing),
                     ],
                     AppPageSection(
-                      header: Text(
-                        l10n.snapPageDescriptionLabel,
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleMedium
-                            ?.copyWith(fontWeight: FontWeight.w500),
-                      ),
+                      header: l10n.snapPageDescriptionLabel,
                       child: SizedBox(
                         width: double.infinity,
                         child: Column(

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -23,6 +23,8 @@
     "snapPageSummaryLabel": "Summary",
     "snapPageVersionLabel": "Version",
     "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
+    "snapPageShareLabel": "Share this snap",
+    "snapPageReportLabel": "Report this snap",
     "explorePageLabel": "Explore",
     "explorePageCategoriesLabel": "Categories",
     "managePageOwnUpdateAvailable": "App Center update available",

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -25,8 +25,22 @@
     "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
     "snapPageShareLabel": "Share this snap",
     "snapPageReportLabel": "Report this snap",
-    "sectionExpandLabel": "Expand section",
-    "sectionCollapseLabel": "Collapse section",
+    "sectionExpandSemanticLabel": "Expand {section}",
+    "@sectionExpandSemanticLabel": {
+        "placeholders": {
+            "section": {
+                "type": "String"
+            }
+        }
+    },
+    "sectionCollapseSemanticLabel": "Collapse {section}",
+    "@sectionCollapseSemanticLabel": {
+        "placeholders": {
+            "section": {
+                "type": "String"
+            }
+        }
+    },
     "explorePageLabel": "Explore",
     "explorePageCategoriesLabel": "Categories",
     "managePageOwnUpdateAvailable": "App Center update available",

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -23,8 +23,8 @@
     "snapPageSummaryLabel": "Summary",
     "snapPageVersionLabel": "Version",
     "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
-    "snapPageShareSemanticLabel": "Share this snap",
-    "snapPageReportSemanticLabel": "Report this snap",
+    "snapPageShareSemanticLabel": "Copy link",
+    "snapPageReportSemanticLabel": "Report",
     "sectionExpandSemanticLabel": "Expand {section}",
     "@sectionExpandSemanticLabel": {
         "placeholders": {
@@ -296,7 +296,7 @@
     "debPageErrorNoPackageInfo": "No package information found",
     "debPageDocumentationLinkLabel": "Learn about managing Debian packages",
     "debPageShareLinkCopiedMessage": "Link copied to clipboard",
-    "debPageShareSemanticLabel": "Share this deb",
+    "debPageShareSemanticLabel": "Copy link",
     "externalResources": "Additional resources",
     "externalResourcesButtonLabel": "Discover more",
     "allGamesButtonLabel": "All games",

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -23,8 +23,8 @@
     "snapPageSummaryLabel": "Summary",
     "snapPageVersionLabel": "Version",
     "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
-    "snapPageShareLabel": "Share this snap",
-    "snapPageReportLabel": "Report this snap",
+    "snapPageShareSemanticLabel": "Share this snap",
+    "snapPageReportSemanticLabel": "Report this snap",
     "sectionExpandSemanticLabel": "Expand {section}",
     "@sectionExpandSemanticLabel": {
         "placeholders": {
@@ -295,6 +295,8 @@
     "snapReportPrivacyAgreementPrivacyPolicy": "Privacy Policy",
     "debPageErrorNoPackageInfo": "No package information found",
     "debPageDocumentationLinkLabel": "Learn about managing Debian packages",
+    "debPageShareLinkCopiedMessage": "Link copied to clipboard",
+    "debPageShareSemanticLabel": "Share this deb",
     "externalResources": "Additional resources",
     "externalResourcesButtonLabel": "Discover more",
     "allGamesButtonLabel": "All games",

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -25,6 +25,8 @@
     "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
     "snapPageShareLabel": "Share this snap",
     "snapPageReportLabel": "Report this snap",
+    "sectionExpandLabel": "Expand section",
+    "sectionCollapseLabel": "Collapse section",
     "explorePageLabel": "Explore",
     "explorePageCategoriesLabel": "Categories",
     "managePageOwnUpdateAvailable": "App Center update available",

--- a/packages/app_center/lib/widgets/app_page_section.dart
+++ b/packages/app_center/lib/widgets/app_page_section.dart
@@ -1,5 +1,5 @@
 import 'package:app_center/l10n.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 
 class AppPageSection extends StatefulWidget {
@@ -9,7 +9,7 @@ class AppPageSection extends StatefulWidget {
     super.key,
   });
 
-  final Widget header;
+  final String header;
   final Widget child;
 
   @override
@@ -27,11 +27,18 @@ class _AppPageSectionState extends State<AppPageSection> {
       expandButtonPosition: YaruExpandableButtonPosition.start,
       gapHeight: 24,
       isExpanded: expanded,
-      header: widget.header,
+      header: Text(
+        widget.header,
+        style: Theme.of(context)
+            .textTheme
+            .titleMedium
+            ?.copyWith(fontWeight: FontWeight.w500),
+      ),
       expandIcon: Icon(
         YaruIcons.pan_end,
-        semanticLabel:
-            expanded ? l10n.sectionCollapseLabel : l10n.sectionExpandLabel,
+        semanticLabel: expanded
+            ? l10n.sectionCollapseSemanticLabel(widget.header)
+            : l10n.sectionExpandSemanticLabel(widget.header),
       ),
       onChange: (expanded) => setState(() {
         this.expanded = expanded;

--- a/packages/app_center/lib/widgets/app_page_section.dart
+++ b/packages/app_center/lib/widgets/app_page_section.dart
@@ -1,10 +1,42 @@
+import 'package:app_center/l10n.dart';
+import 'package:flutter/widgets.dart';
 import 'package:yaru/yaru.dart';
 
-class AppPageSection extends YaruExpandable {
-  const AppPageSection({required super.header, required super.child, super.key})
-      : super(
-          expandButtonPosition: YaruExpandableButtonPosition.start,
-          isExpanded: true,
-          gapHeight: 24,
-        );
+class AppPageSection extends StatefulWidget {
+  const AppPageSection({
+    required this.header,
+    required this.child,
+    super.key,
+  });
+
+  final Widget header;
+  final Widget child;
+
+  @override
+  State<AppPageSection> createState() => _AppPageSectionState();
+}
+
+class _AppPageSectionState extends State<AppPageSection> {
+  bool expanded = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return YaruExpandable(
+      expandButtonPosition: YaruExpandableButtonPosition.start,
+      gapHeight: 24,
+      isExpanded: expanded,
+      header: widget.header,
+      expandIcon: Icon(
+        YaruIcons.pan_end,
+        semanticLabel:
+            expanded ? l10n.sectionCollapseLabel : l10n.sectionExpandLabel,
+      ),
+      onChange: (expanded) => setState(() {
+        this.expanded = expanded;
+      }),
+      child: widget.child,
+    );
+  }
 }


### PR DESCRIPTION
Adds accessible labels to the share and report buttons on snap pages, as well as the labels for expand/collapse sections. These are not visual labels, just text read by the screen reader. For example, it will read "Report this snap push button" when the report button receives focus.

This also adds the missing "Link copied" snack bar that appears when copying the share link from the snap page to the deb page. I think this fits in the PR since it addresses feedback of the button.

---

Audit 1859619
UDENG-7136