### PR TITLE
fix(a11y): Add semantic labels to gallery buttons

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -18,6 +18,14 @@
     "snapPageGalleryLabel": "Gallery",
     "snapPageGalleryNextSemanticLabel": "Next image",
     "snapPageGalleryPreviousSemanticLabel": "Previous image",
+    "snapPageGalleryImageSemanticLabel": "Image {n}",
+    "@snapPageGalleryImageSemanticLabel": {
+        "placeholders": {
+            "n": {
+                "type": "int"
+            }
+        }
+    },
     "snapPageLicenseLabel": "License",
     "snapPageLinksLabel": "Links",
     "snapPagePublisherLabel": "Publisher",

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -16,6 +16,8 @@
     "snapPageDownloadSizeLabel": "Download size",
     "snapPageSizeLabel": "Size",
     "snapPageGalleryLabel": "Gallery",
+    "snapPageGalleryNextSemanticLabel": "Next image",
+    "snapPageGalleryPreviousSemanticLabel": "Previous image",
     "snapPageLicenseLabel": "License",
     "snapPageLinksLabel": "Links",
     "snapPagePublisherLabel": "Publisher",

--- a/packages/app_center/lib/widgets/screenshot_gallery.dart
+++ b/packages/app_center/lib/widgets/screenshot_gallery.dart
@@ -37,6 +37,7 @@ class ScreenshotGallery extends StatelessWidget {
         for (int i = 0; i < urls.length; i++)
           MediaTile(
             url: urls[i],
+            semanticLabel: l10n.snapPageGalleryImageSemanticLabel(i + 1),
             onTap: () => showDialog(
               context: context,
               builder: (_) => _CarouselDialog(
@@ -55,11 +56,13 @@ class MediaTile extends StatelessWidget {
   const MediaTile({
     required this.url,
     required this.onTap,
+    required this.semanticLabel,
     super.key,
     this.fit = BoxFit.contain,
   });
 
   final String url;
+  final String semanticLabel;
   final BoxFit fit;
   final VoidCallback onTap;
 
@@ -71,16 +74,20 @@ class MediaTile extends StatelessWidget {
     return Center(
       child: Material(
         color: Colors.transparent,
-        child: InkWell(
-          borderRadius: borderRadius.outer(padding),
-          excludeFromSemantics: true,
-          onTap: onTap,
-          child: Padding(
-            padding: padding,
-            child: ClipRRect(
-              borderRadius: borderRadius,
-              child: SafeNetworkImage(
-                url: url,
+        child: Semantics(
+          button: true,
+          child: InkWell(
+            borderRadius: borderRadius.outer(padding),
+            excludeFromSemantics: true,
+            onTap: onTap,
+            child: Padding(
+              padding: padding,
+              child: ClipRRect(
+                borderRadius: borderRadius,
+                child: SafeNetworkImage(
+                  url: url,
+                  semanticLabel: semanticLabel,
+                ),
               ),
             ),
           ),
@@ -125,6 +132,8 @@ class _CarouselDialogState extends State<_CarouselDialog> {
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
+    final l10n = AppLocalizations.of(context);
+
     return KeyboardListener(
       focusNode: FocusNode(),
       onKeyEvent: (value) {
@@ -152,10 +161,12 @@ class _CarouselDialogState extends State<_CarouselDialog> {
               width: size.width,
               placeIndicatorMarginTop: 20.0,
               children: [
-                for (final url in widget.urls)
+                for (int i = 0; i < widget.urls.length; i++)
                   SafeNetworkImage(
-                    url: url,
+                    url: widget.urls[i],
                     fit: BoxFit.fitWidth,
+                    semanticLabel:
+                        l10n.snapPageGalleryImageSemanticLabel(i + 1),
                   ),
               ],
             ),
@@ -173,12 +184,14 @@ class SafeNetworkImage extends StatelessWidget {
     this.filterQuality = FilterQuality.medium,
     this.fit = BoxFit.fitHeight,
     this.fallBackIcon,
+    this.semanticLabel,
   });
 
   final String? url;
   final FilterQuality filterQuality;
   final BoxFit fit;
   final Widget? fallBackIcon;
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -198,6 +211,7 @@ class SafeNetworkImage extends StatelessWidget {
         image: imageProvider,
         filterQuality: filterQuality,
         fit: fit,
+        semanticLabel: semanticLabel,
       ),
       placeholder: (context, url) => fallBack,
       errorWidget: (context, url, error) => fallBack,

--- a/packages/app_center/lib/widgets/screenshot_gallery.dart
+++ b/packages/app_center/lib/widgets/screenshot_gallery.dart
@@ -1,3 +1,4 @@
+import 'package:app_center/l10n.dart';
 import 'package:app_center/xdg_cache_manager.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
@@ -18,11 +19,19 @@ class ScreenshotGallery extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return YaruCarousel(
       height: height ?? 500,
       width: double.infinity,
-      nextIcon: const Icon(YaruIcons.go_next),
-      previousIcon: const Icon(YaruIcons.go_previous),
+      nextIcon: Icon(
+        YaruIcons.go_next,
+        semanticLabel: l10n.snapPageGalleryNextSemanticLabel,
+      ),
+      previousIcon: Icon(
+        YaruIcons.go_previous,
+        semanticLabel: l10n.snapPageGalleryPreviousSemanticLabel,
+      ),
       navigationControls: urls.length > 1,
       children: [
         for (int i = 0; i < urls.length; i++)


### PR DESCRIPTION
Adds semantic labels "Next image" and "Previous image" to the next and previous buttons on the screenshot gallery.

This also adds some bare-bones screen reader labels to gallery images (i.e. "image 1", "image 2", etc.). From commit https://github.com/ubuntu/app-center/pull/1927/commits/e54b63a77452bc56fbb0b4239b84fb9ef274bd1e:
> Note that this is effectively image alt text, and this alt text is almost useless.
> 
> To get real alt text, snapcraft.io would need to support alt text for images and make that text also available via their API.

This is still an improvement over the previous behavior where images were not announced by the screen reader *at all*.

---

Audit 1859635
Audit 1860733
Audit 1860783
UDENG-7137