### PR TITLE
fix(a11y): Add corrected semantics to channel dropdown

### DIFF
--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -503,6 +503,7 @@ class _ChannelDropdown extends ConsumerWidget {
             ),
             child: Text(
               '${snapData.selectedChannel} ${snapData.availableChannels![snapData.selectedChannel]!.version}',
+              semanticsLabel: l10n.snapPageChannelLabel,
             ),
           ),
         ),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -520,6 +520,14 @@ class _ChannelDropdownEntry extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+
+    final channelInfo = {
+      l10n.snapPageChannelLabel: channelEntry.key,
+      l10n.snapPageVersionLabel: channelEntry.value.version,
+      l10n.snapPagePublishedLabel:
+          DateFormat.yMd().format(channelEntry.value.releasedAt),
+    };
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: DefaultTextStyle(
@@ -528,35 +536,36 @@ class _ChannelDropdownEntry extends StatelessWidget {
             ),
         child: SizedBox(
           width: _kChannelDropdownWidth - 24,
-          child: Row(
-            children: [
-              DefaultTextStyle.merge(
-                style: TextStyle(
-                  color: Theme.of(context).hintColor,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(l10n.snapPageChannelLabel),
-                    Text(l10n.snapPageVersionLabel),
-                    Text(l10n.snapPagePublishedLabel),
-                  ],
-                ),
+          child: Semantics(
+            button: true,
+            label:
+                channelInfo.entries.map((e) => '${e.key} ${e.value}').join(' '),
+            child: ExcludeSemantics(
+              child: Row(
+                children: [
+                  DefaultTextStyle.merge(
+                    style: TextStyle(
+                      color: Theme.of(context).hintColor,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisSize: MainAxisSize.min,
+                      children: channelInfo.keys.map(Text.new).toList(),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: channelInfo.values.nonNulls
+                          .map((e) => Text(e, maxLines: 1))
+                          .toList(),
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    channelEntry.key,
-                    channelEntry.value.version,
-                    DateFormat.yMd().format(channelEntry.value.releasedAt),
-                  ].nonNulls.map((e) => Text(e, maxLines: 1)).toList(),
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
The channel dropdown selector for snaps is read as the actual value of the dropdown, i.e. "latest/stable v1.5.517". This change makes it so the dropdown is read as "Channel push button".

Our audit suggests the behavior that is implemented by this PR, but I wonder if it would be useful for the version to still be read aloud. Or, perhaps just it being read when you click  it is sufficient (existing behavior of this PR).

This also fixes how the actual channel info is read in each dropdown entry. Before, it was read visual column by column, when it actually should be read by row.

Implementation wise, I had to manually define a `Semantics` label since screen readers will read the order of elements as they're defined. I don't think we have an option of reordering the widgets to fix the problem since we want the visual style of the Row(Column, Column) that you can't get with Column(Row, Row, Row).

---

Audit 1860570
Audit 1860662
UDENG-7149