### PR TITLE
ci(tics): remove cleanup step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,12 +109,6 @@ jobs:
             popd
           done
 
-      - name: Cleanup
-        run: |
-          melos clean
-          melos exec -c 1 fvm flutter clean
-          rm -rf .fvm
-
       - name: Run TICS analysis
         if: github.event_name == 'push'
         uses: tiobe/tics-github-action@v3


### PR DESCRIPTION
This removes the 'cleanup' step for the tics action again. It was added previously to resolve issues related to the symlinks in `.fvm`. This directory has now been added to the ignored paths on the tiobe side. We need to keep the build artifacts around, so that Coverity can re-build the project and gather data from the compiler output.