### PR TITLE
ci(tics): update tics project url

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,6 @@ jobs:
         with:
           mode: qserver
           project: app-center
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true


### PR DESCRIPTION
Another quick fix: tiobe has migrated the project so that we can run the latest version of Coverity - this PR updates the url in the github action accordingly. I did a successful test run [here](https://github.com/ubuntu/app-center/actions/runs/15781034752/job/44486744417).