### PR TITLE
feat(a11y): Left Navigation focus ring

### DIFF
--- a/packages/app_center/lib/store/store_pages.dart
+++ b/packages/app_center/lib/store/store_pages.dart
@@ -10,6 +10,51 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru/yaru.dart';
 
+class _NavigationTile extends StatelessWidget {
+  const _NavigationTile({
+    required this.title,
+    this.leading,
+    this.trailing,
+  });
+
+  final bool? selected = false;
+  final Widget? leading;
+  final Widget? title;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final listTileTheme = theme.listTileTheme;
+    final scope = YaruMasterTileScope.maybeOf(context);
+    final isSelected = selected ?? scope?.selected ?? false;
+
+    final backgroundColor =
+        isSelected ? listTileTheme.selectedTileColor : listTileTheme.tileColor;
+
+    return YaruMasterTile(
+      title: title,
+      decoration: BoxDecoration(
+        border: BoxBorder.all(color: Colors.transparent, width: 2),
+        borderRadius: const BorderRadius.all(
+          Radius.circular(kYaruButtonRadius),
+        ),
+        color: backgroundColor,
+      ),
+      focusDecoration: BoxDecoration(
+        border: BoxBorder.all(color: theme.primaryColor, width: 2),
+        borderRadius: const BorderRadius.all(
+          Radius.circular(kYaruButtonRadius),
+        ),
+        color: backgroundColor ?? theme.cardColor,
+      ),
+      leading: leading,
+      trailing: trailing,
+      selected: isSelected,
+    );
+  }
+}
+
 final displayedCategories = [
   SnapCategoryEnum.featured,
   SnapCategoryEnum.productivity,
@@ -21,35 +66,26 @@ typedef StorePage = ({
   WidgetBuilder pageBuilder,
 });
 
-BoxDecoration yaruMasterTileFocusRing(BuildContext context) => BoxDecoration(
-      border: Border.all(color: Theme.of(context).primaryColor, width: 2),
-      borderRadius: const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
-      color: Theme.of(context).cardColor,
-    );
-
 final pages = <StorePage>[
   (
-    tileBuilder: (context, selected) => YaruMasterTile(
+    tileBuilder: (context, selected) => _NavigationTile(
           leading: Icon(ExplorePage.icon(selected)),
           title: Text(ExplorePage.label(context)),
-          focusDecoration: yaruMasterTileFocusRing(context),
         ),
     pageBuilder: (_) => const ExplorePage(),
   ),
   for (final category in displayedCategories)
     (
-      tileBuilder: (context, selected) => YaruMasterTile(
+      tileBuilder: (context, selected) => _NavigationTile(
             leading: Icon(category.icon(selected)),
             title: Text(category.localize(AppLocalizations.of(context))),
-            focusDecoration: yaruMasterTileFocusRing(context),
           ),
       pageBuilder: (_) => SearchPage(category: category.categoryName),
     ),
   (
-    tileBuilder: (context, selected) => YaruMasterTile(
+    tileBuilder: (context, selected) => _NavigationTile(
           leading: Icon(GamesPage.icon(selected)),
           title: Text(GamesPage.label(context)),
-          focusDecoration: yaruMasterTileFocusRing(context),
         ),
     pageBuilder: (_) => const GamesPage(),
   ),
@@ -62,10 +98,9 @@ final pages = <StorePage>[
     pageBuilder: (_) => const SizedBox.shrink(),
   ),
   (
-    tileBuilder: (context, selected) => YaruMasterTile(
+    tileBuilder: (context, selected) => _NavigationTile(
           leading: Icon(ManagePage.icon(selected)),
           title: Text(ManagePage.label(context)),
-          focusDecoration: yaruMasterTileFocusRing(context),
           trailing: Consumer(
             builder: (context, ref, child) {
               return ref.watch(updatesModelProvider).when(
@@ -81,10 +116,9 @@ final pages = <StorePage>[
     pageBuilder: (_) => const ManagePage(),
   ),
   (
-    tileBuilder: (context, selected) => YaruMasterTile(
+    tileBuilder: (context, selected) => _NavigationTile(
           leading: Icon(AboutPage.icon(selected)),
           title: Text(AboutPage.label(context)),
-          focusDecoration: yaruMasterTileFocusRing(context),
         ),
     pageBuilder: (_) => const AboutPage(),
   ),

--- a/packages/app_center/lib/store/store_pages.dart
+++ b/packages/app_center/lib/store/store_pages.dart
@@ -21,11 +21,18 @@ typedef StorePage = ({
   WidgetBuilder pageBuilder,
 });
 
+BoxDecoration yaruMasterTileFocusRing(BuildContext context) => BoxDecoration(
+      border: Border.all(color: Theme.of(context).primaryColor, width: 2),
+      borderRadius: const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+      color: Theme.of(context).cardColor,
+    );
+
 final pages = <StorePage>[
   (
     tileBuilder: (context, selected) => YaruMasterTile(
           leading: Icon(ExplorePage.icon(selected)),
           title: Text(ExplorePage.label(context)),
+          focusDecoration: yaruMasterTileFocusRing(context),
         ),
     pageBuilder: (_) => const ExplorePage(),
   ),
@@ -34,6 +41,7 @@ final pages = <StorePage>[
       tileBuilder: (context, selected) => YaruMasterTile(
             leading: Icon(category.icon(selected)),
             title: Text(category.localize(AppLocalizations.of(context))),
+            focusDecoration: yaruMasterTileFocusRing(context),
           ),
       pageBuilder: (_) => SearchPage(category: category.categoryName),
     ),
@@ -41,6 +49,7 @@ final pages = <StorePage>[
     tileBuilder: (context, selected) => YaruMasterTile(
           leading: Icon(GamesPage.icon(selected)),
           title: Text(GamesPage.label(context)),
+          focusDecoration: yaruMasterTileFocusRing(context),
         ),
     pageBuilder: (_) => const GamesPage(),
   ),
@@ -56,6 +65,7 @@ final pages = <StorePage>[
     tileBuilder: (context, selected) => YaruMasterTile(
           leading: Icon(ManagePage.icon(selected)),
           title: Text(ManagePage.label(context)),
+          focusDecoration: yaruMasterTileFocusRing(context),
           trailing: Consumer(
             builder: (context, ref, child) {
               return ref.watch(updatesModelProvider).when(
@@ -74,6 +84,7 @@ final pages = <StorePage>[
     tileBuilder: (context, selected) => YaruMasterTile(
           leading: Icon(AboutPage.icon(selected)),
           title: Text(AboutPage.label(context)),
+          focusDecoration: yaruMasterTileFocusRing(context),
         ),
     pageBuilder: (_) => const AboutPage(),
   ),


### PR DESCRIPTION
Adds a focus ring to the left navigation. This ring will change if you use your keyboard to tab-navigate through it.

![image](https://github.com/user-attachments/assets/af4cff5b-6590-4096-9c64-f774b86ef288)

I encountered some issues with tab navigation while implementing this, so I think there's further work to investigate in Yaru and would probably simplify this change in the future. 

---

Audit 1862144
UDENG-6907
UDEAA-96