### PR TITLE
feat(a11y): Keyboard focusable hyperlinks

### DIFF
--- a/packages/app_center/lib/about/about_page.dart
+++ b/packages/app_center/lib/about/about_page.dart
@@ -2,6 +2,7 @@ import 'package:app_center/about/about_providers.dart';
 import 'package:app_center/constants.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
+import 'package:app_center/widgets/hyperlink_text.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -205,24 +206,14 @@ class _CommunityTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final markdownTheme = MarkdownStyleSheet.fromTheme(theme);
-
     return YaruTile(
       // TODO: icon
+      style: YaruTileStyle.banner,
       title: Text(
         title,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: MarkdownBody(
-        data: '[$subtitle]($href)',
-        onTapLink: (_, href, __) => launchUrlString(href!),
-        styleSheet: markdownTheme.copyWith(
-          a: markdownTheme.a?.copyWith(
-            decoration: TextDecoration.underline,
-          ),
-        ),
-      ),
+      subtitle: HyperlinkText(text: subtitle, link: href),
       padding: EdgeInsets.zero,
     );
   }

--- a/packages/app_center/lib/constants.dart
+++ b/packages/app_center/lib/constants.dart
@@ -11,6 +11,9 @@ const kShimmerBaseDark = Color.fromARGB(255, 51, 51, 51);
 const kShimmerHighLightLight = Color.fromARGB(200, 247, 247, 247);
 const kShimmerHighLightDark = Color.fromARGB(255, 57, 57, 57);
 
+const kHyperlinkDark = Color.fromRGBO(102, 153, 204, 1);
+const kHyperlinkLight = Color.fromRGBO(0, 102, 204, 1);
+
 const kLoaderHeight = 16.0;
 const kLoaderMediumHeight = 32.0;
 const kSearchFieldIconConstraints = BoxConstraints(

--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -9,6 +9,7 @@ import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/packagekit/packagekit.dart';
 import 'package:app_center/store/store_app.dart';
+import 'package:app_center/widgets/hyperlink_text.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:appstream/appstream.dart';
 import 'package:flutter/material.dart';
@@ -17,7 +18,6 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
 class DebPage extends ConsumerStatefulWidget {
@@ -88,6 +88,7 @@ class _DebView extends StatelessWidget {
         (
           label: Text(l10n.snapPageLinksLabel),
           value: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: debModel.component.urls
                 .where(
                   (url) => [
@@ -96,11 +97,9 @@ class _DebView extends StatelessWidget {
                   ].contains(url.type),
                 )
                 .map(
-                  (url) => Html(
-                    data: '<a href="${url.url}">${url.type.localize(l10n)}</a>',
-                    style: {'body': Style(margin: Margins.zero)},
-                    onLinkTap: (url, attributes, element) =>
-                        launchUrlString(url!),
+                  (url) => HyperlinkText(
+                    text: url.type.localize(l10n),
+                    link: url.url,
                   ),
                 )
                 .toList(),
@@ -276,12 +275,9 @@ class _Header extends ConsumerWidget {
           children: [
             _DebActionButtons(debModel: debModel),
             const SizedBox(width: 32),
-            Html(
-              shrinkWrap: true,
-              data:
-                  '<a href="$debManageDocsUrl">${l10n.debPageDocumentationLinkLabel} &gt;</a>',
-              style: {'body': Style(margin: Margins.zero)},
-              onLinkTap: (url, attributes, element) => launchUrlString(url!),
+            HyperlinkText(
+              text: '${l10n.debPageDocumentationLinkLabel} >',
+              link: debManageDocsUrl,
             ),
           ],
         ),

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -7,11 +7,10 @@ import 'package:app_center/manage/manage_snap_tile.dart';
 import 'package:app_center/manage/updates_model.dart';
 import 'package:app_center/snapd/currently_installing_model.dart';
 import 'package:app_center/snapd/snapd.dart';
+import 'package:app_center/widgets/hyperlink_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
 class ManagePage extends ConsumerWidget {
@@ -64,19 +63,15 @@ class ManagePage extends ConsumerWidget {
                 l10n.managePageDebUpdatesMessage,
                 style: textTheme.titleMedium,
               ),
-              Html(
-                shrinkWrap: true,
-                data:
-                    '<a href="$debManageDocsUrl">${l10n.managePageDocumentationLinkLabel}</a>',
-                style: {
-                  'body': Style(
-                    margin: Margins.zero,
-                    fontSize: FontSize(textTheme.titleMedium!.fontSize!),
-                    fontWeight: textTheme.titleMedium!.fontWeight,
-                    lineHeight: LineHeight(textTheme.titleMedium!.height),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: DefaultTextStyle(
+                  style: textTheme.titleMedium!,
+                  child: HyperlinkText(
+                    text: l10n.managePageDocumentationLinkLabel,
+                    link: debManageDocsUrl,
                   ),
-                },
-                onLinkTap: (url, attributes, element) => launchUrlString(url!),
+                ),
               ),
               _SelfUpdateInfoBox(),
               Builder(

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -10,19 +10,18 @@ import 'package:app_center/snapd/snap_report.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:app_center/snapd/snapd_cache.dart';
 import 'package:app_center/store/store_app.dart';
+import 'package:app_center/widgets/hyperlink_text.dart';
 import 'package:app_center/widgets/shimmer_placeholder.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:app_center_ratings_client/app_center_ratings_client.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
 const _kChannelDropdownWidth = 220.0;
@@ -120,22 +119,22 @@ class _SnapView extends StatelessWidget {
       (
         label: Text(l10n.snapPageLinksLabel),
         value: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             if (snapData.snap.website?.isNotEmpty ?? false)
-              '<a href="${snapData.snap.website}">${l10n.snapPageDeveloperWebsiteLabel}</a>',
+              HyperlinkText(
+                text: l10n.snapPageDeveloperWebsiteLabel,
+                link: snapData.snap.website ?? '',
+              ),
             if ((snapData.snap.contact.isNotEmpty) &&
                 snapData.snap.publisher != null)
-              '<a href="${snapData.snap.contact}">${l10n.snapPageContactPublisherLabel(snapData.snap.publisher!.displayName)}</a>',
-          ]
-              .map(
-                (link) => Html(
-                  data: link,
-                  style: {'body': Style(margin: Margins.zero)},
-                  onLinkTap: (url, attributes, element) =>
-                      launchUrlString(url!),
+              HyperlinkText(
+                text: l10n.snapPageContactPublisherLabel(
+                  snapData.snap.publisher!.displayName,
                 ),
-              )
-              .toList(),
+                link: snapData.snap.contact,
+              ),
+          ],
         ),
       ),
     ];

--- a/packages/app_center/lib/snapd/snap_report.dart
+++ b/packages/app_center/lib/snapd/snap_report.dart
@@ -1,11 +1,10 @@
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/snapd/logger.dart';
-import 'package:flutter/gestures.dart';
+import 'package:app_center/widgets/hyperlink_text.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
 class SnapReport extends StatefulWidget {
   const SnapReport({required this.name, super.key});
@@ -122,46 +121,20 @@ class _SnapReportState extends State<SnapReport> {
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: kPagePadding),
-                child: RichText(
-                  text: TextSpan(
-                    children: [
-                      TextSpan(
-                        text: l10n.snapReportPrivacyAgreementLabel,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                      TextSpan(
-                        text: l10n
-                            .snapReportPrivacyAgreementCanonicalPrivacyNotice,
-                        style: TextStyle(
-                          color: Theme.of(context).primaryColor,
-                          decoration: TextDecoration.underline,
-                        ),
-                        recognizer: TapGestureRecognizer()
-                          ..onTap = () async {
-                            await launchUrlString(
-                              'https://ubuntu.com/legal/data-privacy/contact',
-                            );
-                          },
-                      ),
-                      TextSpan(
-                        text: l10n.snapReportPrivacyAgreementAndLabel,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                      TextSpan(
-                        text: l10n.snapReportPrivacyAgreementPrivacyPolicy,
-                        style: TextStyle(
-                          color: Theme.of(context).primaryColor,
-                          decoration: TextDecoration.underline,
-                        ),
-                        recognizer: TapGestureRecognizer()
-                          ..onTap = () async {
-                            await launchUrlString(
-                              'https://ubuntu.com/legal/data-privacy',
-                            );
-                          },
-                      ),
-                    ],
-                  ),
+                child: Wrap(
+                  children: [
+                    Text(l10n.snapReportPrivacyAgreementLabel),
+                    HyperlinkText(
+                      text:
+                          l10n.snapReportPrivacyAgreementCanonicalPrivacyNotice,
+                      link: 'https://ubuntu.com/legal/data-privacy/contact',
+                    ),
+                    Text(l10n.snapReportPrivacyAgreementAndLabel),
+                    HyperlinkText(
+                      text: l10n.snapReportPrivacyAgreementPrivacyPolicy,
+                      link: 'https://ubuntu.com/legal/data-privacy',
+                    ),
+                  ],
                 ),
               ),
               Row(

--- a/packages/app_center/lib/widgets/hyperlink_text.dart
+++ b/packages/app_center/lib/widgets/hyperlink_text.dart
@@ -1,7 +1,6 @@
 import 'package:app_center/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
-import 'package:yaru/yaru.dart';
 
 /// A [Text] widget formatted as an accessible hyperlink.
 class HyperlinkText extends StatefulWidget {
@@ -28,11 +27,13 @@ class _HyperlinkTextState extends State<HyperlinkText> {
     return Semantics(
       link: true,
       child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
-          border: BoxBorder.all(
-            color: focused ? theme.primaryColor : Colors.transparent,
-            width: 2,
+        decoration: ShapeDecoration(
+          shape: RoundedRectangleBorder(
+            side: BorderSide(
+              color: focused ? theme.primaryColor : Colors.transparent,
+              width: 2,
+              strokeAlign: 2,
+            ),
           ),
         ),
         child: InkWell(

--- a/packages/app_center/lib/widgets/hyperlink_text.dart
+++ b/packages/app_center/lib/widgets/hyperlink_text.dart
@@ -1,0 +1,61 @@
+import 'package:app_center/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+import 'package:yaru/yaru.dart';
+
+/// A [Text] widget formatted as an accessible hyperlink.
+class HyperlinkText extends StatefulWidget {
+  const HyperlinkText({required this.text, required this.link, super.key});
+
+  /// The data of the [Text] underlying widget.
+  final String text;
+
+  /// URL to open on click.
+  final String link;
+
+  @override
+  State<HyperlinkText> createState() => _HyperlinkTextState();
+}
+
+class _HyperlinkTextState extends State<HyperlinkText> {
+  bool focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brightness = theme.brightness;
+
+    return Semantics(
+      link: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+          border: BoxBorder.all(
+            color: focused ? theme.primaryColor : Colors.transparent,
+            width: 2,
+          ),
+        ),
+        child: InkWell(
+          onTap: () async {
+            await launchUrlString(widget.link);
+          },
+          focusColor: Colors.transparent,
+          onFocusChange: (value) {
+            setState(() {
+              focused = value;
+            });
+          },
+          child: Text(
+            widget.text,
+            style: TextStyle(
+              decoration: TextDecoration.underline,
+              color: brightness == Brightness.dark
+                  ? kHyperlinkDark
+                  : kHyperlinkLight,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Makes all text hyperlinks able to be focused via the keyboard. Previously, hyperlinks were all styled slightly differently and were never able to be focused or activated by the keyboard alone. This PR changes that by adding a unified `HyperlinkText` widget for all instances of hyperlinks.

Design notes:
- All hyperlinks now use Vanilla's blue hyperlink color (theme dependent)
- Hyperlinks have focus rings with the same corner radius as Yaru buttons, with a width of 2

<details>
<summary>Screenshots</summary>

About page non-focused
![image](https://github.com/user-attachments/assets/4be699e3-c606-4528-bd72-c70111a0271e)
About page focused
![image](https://github.com/user-attachments/assets/559f5473-ae93-4153-a743-e98a159de01b)

---

Snap page non-focused
![image](https://github.com/user-attachments/assets/ccb55a3d-5730-42a7-ab63-f07fa629dd51)
Snap page focused
![image](https://github.com/user-attachments/assets/e39cbbe6-5bf3-4c05-b3d9-f0e077449751)


</details>

---

Audit 1860919
UDEAA-45