### PR TITLE
fix(a11y): Autofocus page headers for screen reader announcements

### DIFF
--- a/packages/app_center/lib/about/about_page.dart
+++ b/packages/app_center/lib/about/about_page.dart
@@ -69,9 +69,16 @@ class _AboutHeader extends ConsumerWidget {
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              kAppName,
-              style: Theme.of(context).textTheme.headlineSmall,
+            MergeSemantics(
+              child: Semantics(
+                header: true,
+                focused: true,
+                label: l10n.aboutPageLabel,
+                child: Text(
+                  kAppName,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+              ),
             ),
             const SizedBox(height: 8),
             ref.watch(versionProvider).maybeWhen(

--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -247,7 +247,13 @@ class _Header extends ConsumerWidget {
           children: [
             AppIcon(iconUrl: debModel.component.icon, size: 96),
             const SizedBox(width: 16),
-            Expanded(child: AppTitle.fromDeb(debModel.component)),
+            Expanded(
+              child: Semantics(
+                header: true,
+                focused: true,
+                child: AppTitle.fromDeb(debModel.component),
+              ),
+            ),
             if (debModel.component.website != null)
               YaruIconButton(
                 icon: Icon(

--- a/packages/app_center/lib/explore/explore_page.dart
+++ b/packages/app_center/lib/explore/explore_page.dart
@@ -24,10 +24,14 @@ class ExplorePage extends ConsumerWidget {
     return ResponsiveLayoutScrollView(
       slivers: [
         SliverList.list(
-          children: const [
-            SizedBox(height: 56),
-            CategoryBanner(category: SnapCategoryEnum.featured),
-            SizedBox(height: kPagePadding),
+          children: [
+            const SizedBox(height: 56),
+            Semantics(
+              focused: true,
+              header: true,
+              child: const CategoryBanner(category: SnapCategoryEnum.featured),
+            ),
+            const SizedBox(height: kPagePadding),
           ],
         ),
         const CategorySnapList(

--- a/packages/app_center/lib/games/games_page.dart
+++ b/packages/app_center/lib/games/games_page.dart
@@ -193,7 +193,11 @@ class _Title extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(text, style: Theme.of(context).textTheme.headlineSmall);
+    return Semantics(
+      header: true,
+      focused: true,
+      child: Text(text, style: Theme.of(context).textTheme.headlineSmall),
+    );
   }
 }
 

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -50,9 +50,13 @@ class ManagePage extends ConsumerWidget {
         slivers: [
           SliverList.list(
             children: [
-              Text(
-                l10n.managePageTitle,
-                style: textTheme.headlineSmall,
+              Semantics(
+                header: true,
+                focused: true,
+                child: Text(
+                  l10n.managePageTitle,
+                  style: textTheme.headlineSmall,
+                ),
               ),
               const SizedBox(height: kMargin),
               Text(

--- a/packages/app_center/lib/search/search_page.dart
+++ b/packages/app_center/lib/search/search_page.dart
@@ -36,14 +36,22 @@ class SearchPage extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (query != null)
-                  Text(
-                    l10n.searchPageTitle(query!),
-                    style: Theme.of(context).textTheme.headlineSmall,
+                  Semantics(
+                    focused: true,
+                    header: true,
+                    child: Text(
+                      l10n.searchPageTitle(query!),
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
                   ),
                 if (initialCategory != null)
-                  Text(
-                    initialCategory.localize(l10n),
-                    style: Theme.of(context).textTheme.headlineSmall,
+                  Semantics(
+                    focused: true,
+                    header: true,
+                    child: Text(
+                      initialCategory.localize(l10n),
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
                   ),
                 const SizedBox(height: 8),
                 Row(

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -160,7 +160,14 @@ class _SnapView extends StatelessWidget {
                         AppIcon(iconUrl: snapData.snap.iconUrl, size: 96),
                         const SizedBox(width: 16),
                         Expanded(
-                          child: AppTitle.fromSnap(snapData.snap, large: true),
+                          child: Semantics(
+                            header: true,
+                            focused: true,
+                            child: AppTitle.fromSnap(
+                              snapData.snap,
+                              large: true,
+                            ),
+                          ),
                         ),
                         _IconRow(snapData: snapData),
                       ],

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -138,7 +138,7 @@
     "productivityPageLabel": "Productivity",
     "developmentPageLabel": "Development",
     "gamesPageLabel": "Games",
-    "gamesPageTitle": "What's Hot",
+    "gamesPageTitle": "Games",
     "gamesPageTop": "Top Rated",
     "gamesPageFeatured": "Featured Titles",
     "gamesPageBundles": "App Bundles",


### PR DESCRIPTION
Currently, when a new page is navigated to, there is no information about the new page read aloud by the screen reader. This change autofocuses the header of each page so that the header is read aloud. For example, when the user clicks the Productivity page, it will say "Productivity header". This shouldn't mess with tab-orders or introduce any new focus nodes based on my testing.

I'm aware of `SemanticsService.announce` and live regions, but both don't seem to work. I think a service announcement would fit better here in theory, but I haven't gotten it to actually announce anything. I'm not sure if it's an issue with Flutter, Orca, or my setup, so it would be good to do some additional testing but in the meantime I believe this is a fine solution.

---

Audit 1859244
UDEAA-48