### PR TITLE
fix(a11y): Fix empty publishers being announced

### DIFF
--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -80,7 +80,7 @@ class AppCard extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     final cardLabel = [
       '${title.title}.',
-      title.publisher != null
+      title.publisher != null && title.publisher != ''
           ? l10n.appCardPublisherSemanticLabel(title.publisher!)
           : null,
       '$summary.',
@@ -155,7 +155,7 @@ class RankedAppCard extends StatelessWidget {
     final cardLabel = [
       '$rank.',
       '${title.title}.',
-      title.publisher != null
+      title.publisher != null && title.publisher != ''
           ? l10n.appCardPublisherSemanticLabel(title.publisher!)
           : null,
     ].nonNulls.join(' ');


### PR DESCRIPTION
With the new labels added by https://github.com/ubuntu/app-center/pull/1936, some publishers are sometimes announced despite the publisher being empty. This is because some Debian packages have an empty string instead of a null publisher. This fixes that by removing the publisher announcement entirely when there is none.