### PR TITLE
Fix share button url

### DIFF
--- a/packages/app_center/lib/constants.dart
+++ b/packages/app_center/lib/constants.dart
@@ -30,3 +30,4 @@ const localDebInfoUrl =
     'https://ubuntu.com/server/docs/third-party-repository-usage';
 const debManageDocsUrl =
     'https://documentation.ubuntu.com/server/tutorial/managing-software/#installing-deb-packages';
+const snapStoreBaseUrl = 'https://snapcraft.io';

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -423,13 +423,14 @@ class _IconRow extends ConsumerWidget {
             ),
             onPressed: () {
               final navigationKey = ref.watch(materialAppNavigatorKeyProvider);
+              final snapStoreUrl = '$snapStoreBaseUrl/${snapData.name}';
 
               ScaffoldMessenger.of(navigationKey.currentContext!).showSnackBar(
                 SnackBar(
                   content: Text(l10n.snapPageShareLinkCopiedMessage),
                 ),
               );
-              Clipboard.setData(ClipboardData(text: snap.website!));
+                Clipboard.setData(ClipboardData(text: snapStoreUrl));
             },
           ),
         YaruIconButton(


### PR DESCRIPTION
Bug Description
The share button in the app page links to the app developer page. It should link to the snap store page: there's a different location for developer links further down.

For instance, the button on the top right copies the link to https://brave.com/ instead of to https://snapcraft.io/brave

Changes Made
Added snapStoreBaseUrl constant in packages/app_center/lib/constants.dart
Updated share button in packages/app_center/lib/snapd/snap_page.dart to copy Snap Store URL
Share button now provides correct https://snapcraft.io/{snapName} links instead of developer website
Testing
Share button now copies the correct Snap Store page URL
Maintains existing UI behavior (only shows when website exists)
Fixes the exact issue described in the bug report