### PR TITLE
Fixed issue #1955: Reduced excessive vertical padding in Manage page

### DIFF
--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -44,7 +44,7 @@ class ManagePage extends ConsumerWidget {
     final hasInternet = updatesModel.valueOrNull?.hasInternet ?? true;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: kPagePadding),
+      padding: const EdgeInsets.symmetric(vertical: 2), // padding changed from kPagePadding to 2 as it somewhat makes the padding below searchbar consistent with the explore page.
       child: ResponsiveLayoutScrollView(
         slivers: [
           SliverList.list(


### PR DESCRIPTION
An issue was filed that the explore page had an appropriate amount of space below the search bar while the manage page had too much space below the search bar. I reduced the vertical padding to reduce this space and thus make it consistent with explore page.