### PR TITLE
fix(a11y): Increase contrast on search field and rating icons

### DIFF
--- a/packages/app_center/lib/search/search_field.dart
+++ b/packages/app_center/lib/search/search_field.dart
@@ -186,7 +186,12 @@ class _SearchFieldState extends ConsumerState<SearchField> {
                     animation: controller,
                     builder: (context, child) {
                       return YaruIconButton(
-                        icon: const Icon(YaruIcons.edit_clear, size: 16),
+                        icon: Icon(
+                          YaruIcons.edit_clear,
+                          size: 16,
+                          color:
+                              Theme.of(context).inputDecorationTheme.iconColor,
+                        ),
                         onPressed: controller.text.isEmpty
                             ? null
                             : () {

--- a/packages/app_center/lib/widgets/app_title.dart
+++ b/packages/app_center/lib/widgets/app_title.dart
@@ -62,12 +62,18 @@ class AppTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = theme.textTheme;
     final titleTextStyle =
         large ? textTheme.headlineSmall! : textTheme.titleMedium!;
     final publisherTextStyle =
         large ? textTheme.bodyMedium! : textTheme.bodyMedium!;
+    final publisherIconColor = verifiedPublisher
+        ? theme.colorScheme.success
+        : theme.colorScheme.warning;
+    final isHighContrast = MediaQuery.highContrastOf(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -85,7 +91,7 @@ class AppTitle extends StatelessWidget {
                 child: Text(
                   publisher ?? l10n.unknownPublisher,
                   style: publisherTextStyle.copyWith(
-                    color: Theme.of(context).hintColor,
+                    color: theme.hintColor,
                   ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -97,9 +103,8 @@ class AppTitle extends StatelessWidget {
                   child: Icon(
                     verifiedPublisher ? Icons.verified : Icons.stars,
                     size: publisherTextStyle.fontSize,
-                    color: verifiedPublisher
-                        ? Theme.of(context).colorScheme.success
-                        : Theme.of(context).colorScheme.warning,
+                    color:
+                        isHighContrast ? theme.hintColor : publisherIconColor,
                   ),
                 ),
             ],


### PR DESCRIPTION
Makes the search field clear icon match the text color, and makes rating icon colors match text color on high contrast mode.

I believe all other icons previously noted (mostly collapse/expand chevrons) aren't an issue anymore since input fields no longer have a background color (https://github.com/ubuntu/app-center/pull/1910).

| | Default | High Contrast |
|-|---------|---------------|
| Light | <img width="1384" height="904" alt="image" src="https://github.com/user-attachments/assets/00afd43d-a30c-4396-91c8-90df0d84765a" /> | <img width="1384" height="904" alt="image" src="https://github.com/user-attachments/assets/9080211c-daf7-457c-98ce-c09cc17e0d38" /> |
| Dark | <img width="1384" height="904" alt="image" src="https://github.com/user-attachments/assets/79654c29-eb28-490f-8589-704e767188fb" /> | <img width="1384" height="904" alt="image" src="https://github.com/user-attachments/assets/c37c9b79-983a-4198-b619-3847cf4f3c0c" /> |