### PR TITLE
Added StartupWMClass=snap-store to the .desktop file.

### DIFF
--- a/packages/app_center/assets/app-center.desktop
+++ b/packages/app_center/assets/app-center.desktop
@@ -7,6 +7,7 @@ Terminal=false
 Categories=System;Utility;PackageManager;SoftwareManagement;Network;Settings;
 Keywords=Ubuntu;Applications;Apps;Store;Software;Snaps;
 MimeType=x-scheme-handler/snap;application/vnd.debian.binary-package;
+StartupWMClass=snap-store
 Name=App Center
 Name[ar]=مركز التطبيقات
 Name[be]=Цэнтр праграм


### PR DESCRIPTION
Currently, when pinning the Snap Store to the KDE panel and opening it, it is not considered the same app that is pinned and uses the yellow icon that symbolizes Wayland.
<img width="1600" height="900" alt="Captura de imagem_20260118_131719" src="https://github.com/user-attachments/assets/944c7516-a079-41a3-9b4b-1e45ddd4e9e6" />

By modifying the .desktop file to add StartupWMClass=snap-store, the problem was resolved:
<img width="1600" height="900" alt="Captura de imagem_20260118_142802" src="https://github.com/user-attachments/assets/00fe1810-85ff-4cca-b032-aa83314503eb" />
