### PR TITLE
fix: hide contributors section on network error (#2020)

### DIFF
--- a/packages/app_center/lib/about/about_page.dart
+++ b/packages/app_center/lib/about/about_page.dart
@@ -122,7 +122,7 @@ class _ContributorView extends ConsumerWidget {
         const SizedBox(height: 8),
         state.when(
           data: _ContributorWrap.new,
-          error: (error, stackTrace) => Text(error.toString()),
+          error: (_, __) => const SizedBox.shrink(),
           loading: () => Shimmer.fromColors(
             baseColor: light ? kShimmerBaseLight : kShimmerBaseDark,
             highlightColor: light

--- a/packages/app_center/test/about_page_test.dart
+++ b/packages/app_center/test/about_page_test.dart
@@ -1,0 +1,55 @@
+import 'package:app_center/about/about_providers.dart';
+import 'package:app_center/about/about_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github/github.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:yaru/yaru.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  testWidgets('about page shows contributors when loaded', (tester) async {
+    final contributors = [
+      Contributor(login: 'user1', htmlUrl: 'https://github.com/user1'),
+      Contributor(login: 'user2', htmlUrl: 'https://github.com/user2'),
+    ];
+
+    await tester.pumpApp(
+      (context) => ProviderScope(
+        overrides: [
+          contributorsProvider('ubuntu/app-center')
+              .overrideWith((_) async => contributors),
+          versionProvider.overrideWith((_) async => '1.0.0'),
+        ],
+        child: const AboutPage(),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('App Center'), findsOneWidget);
+    expect(find.text('Version 1.0.0'), findsOneWidget);
+  });
+
+  testWidgets('about page gracefully handles contributor error', (tester) async {
+    await tester.pumpApp(
+      (context) => ProviderScope(
+        overrides: [
+          contributorsProvider('ubuntu/app-center')
+              .overrideWith((_) => throw Exception('Network error')),
+          versionProvider.overrideWith((_) async => '1.0.0'),
+        ],
+        child: const AboutPage(),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('App Center'), findsOneWidget);
+    expect(find.text('Version 1.0.0'), findsOneWidget);
+    expect(find.textContaining('Exception'), findsNothing);
+    expect(find.textContaining('Network error'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- Hides the contributors section gracefully when GitHub API is unreachable
- Shows `SizedBox.shrink()` instead of raw exception text when contributors fail to load
- Fixes #2020

## Changes

- Modified `packages/app_center/lib/about/about_page.dart` to return an empty widget on error instead of displaying `error.toString()`
- Added unit test to verify error handling in `packages/app_center/test/about_page_test.dart`

## Testing

The test verifies that when the contributors provider throws an error, the About page still renders correctly without showing the raw error message to the user.