### PR TITLE
fix: handle autocomplete error gracefully in search field (#1950)

### DIFF
--- a/packages/app_center/lib/search/search_field.dart
+++ b/packages/app_center/lib/search/search_field.dart
@@ -60,7 +60,12 @@ class _SearchFieldState extends ConsumerState<SearchField> {
     return RawAutocomplete<AutoCompleteOption>(
       optionsBuilder: (query) async {
         ref.read(queryProvider.notifier).state = query.text;
-        final options = await ref.watch(autoCompleteProvider.future);
+        final AutoCompleteOptions options;
+        try {
+          options = await ref.watch(autoCompleteProvider.future);
+        } on Exception {
+          return <AutoCompleteOption>[];
+        }
         if (options.snaps.isEmpty && options.debs.isEmpty) return [];
         _optionsAvailable = true;
         final snapOptions = options.snaps

--- a/packages/app_center/test/search_field_test.dart
+++ b/packages/app_center/test/search_field_test.dart
@@ -230,4 +230,33 @@ void main() {
       verifyNever(mockSelectedCallback(any));
     });
   });
+
+  group('error handling', () {
+    testWidgets('gracefully handles autocomplete error', (tester) async {
+      await tester.pumpApp(
+        (_) => ProviderScope(
+          overrides: [
+            snapSearchProvider.overrideWith(
+              (ref, searchParameters) =>
+                  Stream.error(Exception('Network error')),
+            ),
+            appstreamSearchProvider
+                .overrideWith((ref, query) => Stream.value([])),
+          ],
+          child: SearchField(
+            onSearch: (_) {},
+            onSnapSelected: (_) {},
+            onDebSelected: (_) {},
+            searchFocus: FocusNode(),
+          ),
+        ),
+      );
+
+      final textField = find.byType(TextField);
+      await tester.enterText(textField, 'test');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Wraps the `autoCompleteProvider` call in `optionsBuilder` with try-catch
- Returns empty options list when autocomplete fails instead of propagating the exception
- Fixes #1950

## Problem

When the autocomplete provider throws an error (e.g., `SnapDataNotFoundException` or network error), the exception propagates uncaught from `optionsBuilder` to `RawAutocomplete`, causing the app to freeze and crash.

## Changes

- Modified `packages/app_center/lib/search/search_field.dart` to catch exceptions in `optionsBuilder`
- Added test to verify graceful error handling in `packages/app_center/test/search_field_test.dart`