### PR TITLE
fix(a11y): add semantic labels for back button and banner icons

### DIFF
--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -33,6 +33,7 @@
     "snapPageShareLinkCopiedMessage": "Link copied to clipboard",
     "snapPageShareSemanticLabel": "Copy link",
     "snapPageReportSemanticLabel": "Report",
+    "backButtonSemanticLabel": "Go back",
     "sectionExpandSemanticLabel": "Expand {section}",
     "@sectionExpandSemanticLabel": {
         "placeholders": {

--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -244,12 +244,17 @@ class _MaybeBackButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
     final routeName = ref.watch(routeNameProvider);
     final canPop = routeName != null && routeName != '/';
     return canPop
-        ? YaruBackButton(
-            style: YaruBackButtonStyle.rounded,
-            onPressed: navigatorKey.currentState?.pop,
+        ? Semantics(
+            label: l10n.backButtonSemanticLabel,
+            button: true,
+            child: YaruBackButton(
+              style: YaruBackButtonStyle.rounded,
+              onPressed: navigatorKey.currentState?.pop,
+            ),
           )
         : const SizedBox();
   }

--- a/packages/app_center/lib/widgets/banner.dart
+++ b/packages/app_center/lib/widgets/banner.dart
@@ -192,18 +192,21 @@ class _BannerIconState extends State<_BannerIcon> {
 
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      key: tooltipKey,
-      waitDuration: Duration.zero,
-      showDuration: Duration.zero,
-      verticalOffset: widget.maxSize.height / 2,
-      message: widget.snap.titleOrName,
-      triggerMode: TooltipTriggerMode.manual,
-      child: InkWell(
-        onTap: () => StoreNavigator.pushSnap(context, name: widget.snap.name),
-        onHover: _toggleFocus,
-        onFocusChange: _toggleFocus,
-        child: SizedBox(
+    return Semantics(
+      label: widget.snap.titleOrName,
+      button: true,
+      child: Tooltip(
+        key: tooltipKey,
+        waitDuration: Duration.zero,
+        showDuration: Duration.zero,
+        verticalOffset: widget.maxSize.height / 2,
+        message: widget.snap.titleOrName,
+        triggerMode: TooltipTriggerMode.manual,
+        child: InkWell(
+          onTap: () => StoreNavigator.pushSnap(context, name: widget.snap.name),
+          onHover: _toggleFocus,
+          onFocusChange: _toggleFocus,
+          child: SizedBox(
           height: widget.maxSize.height,
           width: widget.maxSize.width,
           child: Center(

--- a/packages/app_center/test/store_app_test.dart
+++ b/packages/app_center/test/store_app_test.dart
@@ -74,6 +74,35 @@ void main() {
       expect(badge, findsOneWidget);
       expect((tester.widget<Badge>(badge).label! as Text).data, equals('2'));
     });
+
+    testWidgets('back button has Go back semantic label', (tester) async {
+      registerMockService<GtkApplicationNotifier>(
+        createMockGtkApplicationNotifier(),
+      );
+      registerMockService<RatingsService>(registerMockRatingsService());
+      registerMockSnapdService();
+      await tester.pumpApp(
+        (_) => ProviderScope(
+          overrides: [
+            routeNameProvider.overrideWith((ref) => '/snap/testsnap'),
+          ],
+          child: const StoreApp(),
+        ),
+      );
+      await tester.pump();
+
+      final backButton = find.byType(YaruBackButton);
+      expect(backButton, findsOneWidget);
+      final semantics = find.ancestor(
+        of: backButton,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == tester.l10n.backButtonSemanticLabel,
+        ),
+      );
+      expect(semantics, findsOneWidget);
+    });
   });
 
   group('error handling', () {


### PR DESCRIPTION
## Summary

- Fixes #1588: Back button now has semantic label "Go back"
- Fixes #1594: Banner icons now have semantic labels with snap names

## Changes

### Back button (#1588)
- Wrapped `YaruBackButton` with `Semantics` widget
- Added l10n string `backButtonSemanticLabel` = "Go back"
- Screen readers will now announce "Go back" when focusing the back button

### Banner icons (#1594)
- Added semantic label to `_BannerIcon` widget
- Screen readers will now announce the snap name (e.g., "GIMP") instead of just "Image"
- Also made icons focusable with keyboard by adding `button: true` semantics