### PR TITLE
fix(a11y): improve app card accessibility for screen readers (#1586)

### DIFF
--- a/packages/app_center/lib/widgets/app_card.dart
+++ b/packages/app_center/lib/widgets/app_card.dart
@@ -88,28 +88,29 @@ class AppCard extends StatelessWidget {
       '$summary.',
     ].nonNulls.join(' ');
 
-    return MergeSemantics(
-      child: Semantics(
-        button: true,
-        label: cardLabel,
-        child: YaruBanner(
-          padding: const EdgeInsets.all(kCardSpacing),
-          onTap: onTap,
-          child: Flex(
-            direction: compact ? Axis.vertical : Axis.horizontal,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              iconWidget ?? AppIcon(iconUrl: iconUrl),
-              const SizedBox(width: kCardSpacing, height: kCardSpacing),
-              Expanded(
-                child: _AppCardBody(
-                  title: title,
-                  summary: summary,
-                  footer: footer,
-                ),
+    return Semantics(
+      label: cardLabel,
+      button: onTap != null,
+      onTap: onTap,
+      child: YaruBanner(
+        padding: const EdgeInsets.all(kCardSpacing),
+        onTap: onTap,
+        child: Flex(
+          direction: compact ? Axis.vertical : Axis.horizontal,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ExcludeSemantics(
+              child: iconWidget ?? AppIcon(iconUrl: iconUrl),
+            ),
+            const SizedBox(width: kCardSpacing, height: kCardSpacing),
+            Expanded(
+              child: _AppCardBody(
+                title: title,
+                summary: summary,
+                footer: footer,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/packages/app_center/test/app_card_test.dart
+++ b/packages/app_center/test/app_card_test.dart
@@ -44,4 +44,33 @@ void main() {
       findsOneWidget,
     );
   });
+
+  group('accessibility', () {
+    testWidgets('AppCard with onTap has button semantics', (tester) async {
+      await tester.pumpApp(
+        (_) => AppCard.fromSnap(
+          snap: snap,
+          onTap: () {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final semanticsFinder = find.byWidgetPredicate(
+        (widget) => widget is Semantics && widget.properties.button == true,
+      );
+      expect(semanticsFinder, findsOneWidget);
+    });
+
+    testWidgets('AppCard excludes icon from semantics', (tester) async {
+      await tester.pumpApp(
+        (_) => AppCard.fromSnap(
+          snap: snap,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final excludeSemanticsFinder = find.byType(ExcludeSemantics);
+      expect(excludeSemanticsFinder, findsWidgets);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Fixes #1586: App cards are now properly announced by screen readers
- Simplified semantics structure for better compatibility
- Added explicit button semantics with tap handler

## Changes

- Removed `MergeSemantics` wrapper which was causing issues with some screen readers
- Added explicit `onTap` to `Semantics` widget for proper button behavior
- Excluded icon from semantics to avoid duplicate "Image" announcement
- Set `button` property based on whether `onTap` is available