### PR TITLE
feat: add purge option to snap uninstall dropdown (#2019)

### DIFF
--- a/packages/app_center/lib/manage/manage_app_actions.dart
+++ b/packages/app_center/lib/manage/manage_app_actions.dart
@@ -125,14 +125,34 @@ class ManageAppActions extends ConsumerWidget {
             ),
             const SizedBox(width: kSpacing),
           ],
-          OutlinedButton(
-            onPressed: SnapAction.remove.callback(
-              snapData,
-              snapViewModel,
-              snapLauncher,
-              context,
+          MenuAnchor(
+            menuChildren: [
+              MenuItemButton(
+                onPressed: SnapAction.remove.callback(
+                  snapData,
+                  snapViewModel,
+                  snapLauncher,
+                  context,
+                ),
+                child: Text(SnapAction.remove.label(l10n)),
+              ),
+              MenuItemButton(
+                onPressed: SnapAction.removePurge.callback(
+                  snapData,
+                  snapViewModel,
+                  snapLauncher,
+                  context,
+                ),
+                child: Text(SnapAction.removePurge.label(l10n)),
+              ),
+            ],
+            builder: (context, controller, child) => OutlinedButton.icon(
+              onPressed: () =>
+                  controller.isOpen ? controller.close() : controller.open(),
+              icon: const Icon(Icons.arrow_drop_down, size: 18),
+              iconAlignment: IconAlignment.end,
+              label: Text(SnapAction.remove.label(l10n)),
             ),
-            child: Text(SnapAction.remove.label(l10n)),
           ),
         ],
       ],

--- a/packages/app_center/lib/snapd/snap_action.dart
+++ b/packages/app_center/lib/snapd/snap_action.dart
@@ -9,6 +9,7 @@ enum SnapAction {
   install,
   open,
   remove,
+  removePurge,
   revert,
   switchChannel,
   update;
@@ -18,6 +19,7 @@ enum SnapAction {
     install => l10n.snapActionInstallLabel,
     open => l10n.snapActionOpenLabel,
     remove => l10n.snapActionRemoveLabel,
+    removePurge => l10n.snapActionPurgeLabel,
     revert => l10n.snapActionRevertLabel,
     switchChannel => l10n.snapActionSwitchChannelLabel,
     update => l10n.snapActionUpdateLabel,
@@ -26,6 +28,7 @@ enum SnapAction {
   IconData? get icon => switch (this) {
     update => YaruIcons.refresh,
     remove => YaruIcons.trash,
+    removePurge => YaruIcons.trash,
     revert => YaruIcons.undo,
     _ => null,
   };
@@ -38,10 +41,12 @@ enum SnapAction {
   ]) {
     return switch (this) {
       SnapAction.cancel => model.cancel,
-      SnapAction.install => snapData?.storeSnap != null ? model.install : null,
+      SnapAction.install =>
+        snapData?.storeSnap != null ? model.install : null,
       SnapAction.open =>
         launcher?.isLaunchable ?? false ? launcher!.open : null,
       SnapAction.remove => model.remove,
+      SnapAction.removePurge => () => model.remove(purge: true),
       SnapAction.revert =>
         (snapData?.canRevert ?? false)
             ? () => confirmRevertAndRun(context!, snapData!, model)

--- a/packages/app_center/lib/snapd/snap_model.dart
+++ b/packages/app_center/lib/snapd/snap_model.dart
@@ -152,9 +152,11 @@ class SnapModel extends _$SnapModel {
   }
 
   /// Uninstalls the snap.
-  Future<void> remove() async {
+  ///
+  /// If [purge] is `true`, all user data associated with the snap is also removed.
+  Future<void> remove({bool purge = false}) async {
     assert(state.hasValue, 'The snap must be loaded before removing it');
-    final changeId = await _snapd.remove(snapName);
+    final changeId = await _snapd.remove(snapName, purge: purge);
     _updateChangeId(changeId);
     await _listenUntilDone(changeId, ref);
     ref.read(snapUpdatesModelProvider.notifier).removeFromList(snapName);

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -223,6 +223,8 @@
     "snapActionOpenLabel": "Open",
     "snapActionRemoveLabel": "Uninstall",
     "snapActionRemovingLabel": "Uninstalling",
+    "snapActionPurgeLabel": "Uninstall (remove data)",
+    "snapActionPurgeSemanticLabel": "Uninstall snap and remove all user data",
     "snapActionRevertLabel": "Revert update",
     "snapActionRevertingLabel": "Reverting update",
     "snapRevertConfirmTitle": "Revert to previous version?",

--- a/packages/app_center/test/snap_action_test.dart
+++ b/packages/app_center/test/snap_action_test.dart
@@ -15,12 +15,38 @@ void main() {
           SnapAction.revert.label(l10n),
           equals(l10n.snapActionRevertLabel),
         );
+        expect(
+          SnapAction.removePurge.label(l10n),
+          equals(l10n.snapActionPurgeLabel),
+        );
         return const SizedBox.shrink();
       });
     });
 
     test('revert action has correct icon', () {
       expect(SnapAction.revert.icon, equals(YaruIcons.undo));
+    });
+
+    test('removePurge action has correct icon', () {
+      expect(SnapAction.removePurge.icon, equals(YaruIcons.trash));
+    });
+
+    test('removePurge callback invokes remove with purge', () async {
+      final container = createContainer();
+      final service = registerMockSnapdService(
+        localSnap: createSnap(name: 'test'),
+      );
+      final model = container.read(snapModelProvider('test').notifier);
+      await container.read(snapModelProvider('test').future);
+      final snapData = SnapData(
+        name: 'test',
+        localSnap: createSnap(name: 'test'),
+      );
+
+      final callback = SnapAction.removePurge.callback(snapData, model);
+      expect(callback, isNotNull);
+      await callback!();
+      verify(service.remove('test', purge: true)).called(1);
     });
 
     test(

--- a/packages/app_center/test/snap_model_test.dart
+++ b/packages/app_center/test/snap_model_test.dart
@@ -220,6 +220,20 @@ void main() {
     verify(service.remove('testsnap')).called(1);
   });
 
+  test('remove with purge', () async {
+    final container = createContainer();
+    final service = registerMockSnapdService(
+      localSnap: localSnap,
+      storeSnap: storeSnap,
+    );
+    await container.read(snapModelProvider('testsnap').future);
+    await container
+        .read(snapModelProvider('testsnap').notifier)
+        .remove(purge: true);
+
+    verify(service.remove('testsnap', purge: true)).called(1);
+  });
+
   test('cancel active change', () async {
     final container = createContainer();
     final service = registerMockSnapdService(

--- a/packages/app_center/test/test_utils.dart
+++ b/packages/app_center/test/test_utils.dart
@@ -171,7 +171,7 @@ MockSnapdService registerMockSnapdService({
     ),
   ).thenAnswer((_) async => 'id');
   when(service.refreshMany(any)).thenAnswer((_) async => 'id');
-  when(service.remove(any)).thenAnswer((_) async => 'id');
+  when(service.remove(any, purge: anyNamed('purge'))).thenAnswer((_) async => 'id');
   when(service.revert(any)).thenAnswer((_) async => 'id');
   when(
     service.hasPreviousRevision(any),


### PR DESCRIPTION
## Summary

- Adds option to uninstall snaps with user data removal (--purge flag)
- Converts single Uninstall button to dropdown menu
- Fixes #2019

## Changes

- `snap_model.dart`: Added `removeWithPurge()` method that passes `purge: true` to snapd
- `snap_action.dart`: Added `removePurge` action variant
- `manage_app_actions.dart`: Converted Uninstall button to dropdown with two options:
  - "Uninstall" - removes snap, keeps user data
  - "Uninstall (remove data)" - removes snap and all user data via --purge
- `app_en.arb`: Added l10n strings for purge action

## Testing

The dropdown menu shows two options when clicking the Uninstall button on the manage page. The "Uninstall (remove data)" option uses the snapd API's existing `purge` parameter.