### PR TITLE
fix: reduce CPU usage on Manage page (#1998)

### DIFF
--- a/packages/app_center/lib/manage/manage_app_actions.dart
+++ b/packages/app_center/lib/manage/manage_app_actions.dart
@@ -52,10 +52,9 @@ class ManageAppActions extends ConsumerWidget {
     );
   }
 
-  /// Builds snap action buttons using the per-snap [SnapModel]. Shows a loading
-  /// indicator while the snap model loads, an active change status when a snapd
-  /// operation is in progress, or the appropriate action buttons (update, open,
-  /// remove) otherwise.
+  /// Builds snap action buttons. Uses data from [snap] directly for display
+  /// decisions to avoid creating per-snap [SnapModel] instances on each tile.
+  /// Only creates a [SnapModel] when an action is actually performed.
   Widget _buildSnapActions(
     BuildContext context,
     WidgetRef ref,
@@ -63,37 +62,23 @@ class ManageAppActions extends ConsumerWidget {
     Snap snap,
     String? updateVersion,
   ) {
-    final snapModel = ref.watch(snapModelProvider(snap.name));
-    if (!snapModel.hasValue) {
-      return const Center(
-        child: SizedBox.square(
-          dimension: kLoaderMediumHeight,
-          child: YaruCircularProgressIndicator(),
-        ),
-      );
-    }
-    final snapData = snapModel.value!;
-    final shouldQuitToUpdate = snapData.localSnap?.refreshInhibit != null;
-    final snapViewModel = ref.watch(snapModelProvider(snap.name).notifier);
-    final snapLauncher = snapData.localSnap == null
-        ? null
-        : ref.watch(launchProvider(snapData.localSnap!));
-    final canOpen = snapLauncher?.isLaunchable ?? false;
-    final hasActiveChange = snapData.activeChangeId != null;
+    final currentlyInstalling = ref.watch(currentlyInstallingModelProvider);
+    final activeChangeData = currentlyInstalling[snap.name];
+    final hasActiveChange = activeChangeData?.activeChangeId != null;
+
     if (hasActiveChange) {
+      final activeChange = ref.watch(activeChangeProvider(activeChangeData!.activeChangeId));
       return ActiveChangeStatus(
-        actionLabel: ref
-            .watch(activeChangeProvider(snapData.activeChangeId))
-            ?.localize(l10n),
-        progress:
-            ref
-                .watch(activeChangeProvider(snapData.activeChangeId))
-                ?.progress ??
-            0,
+        actionLabel: activeChange?.localize(l10n),
+        progress: activeChange?.progress ?? 0,
         onCancelPressed: () =>
             ref.read(snapModelProvider(snap.name).notifier).cancel(),
       );
     }
+
+    final shouldQuitToUpdate = snap.refreshInhibit != null;
+    final canOpen = snap.apps.isNotEmpty;
+    final hasUpdate = updateVersion != null;
 
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -104,34 +89,24 @@ class ManageAppActions extends ConsumerWidget {
         ],
         if (showOnlyUpdate)
           OutlinedButton(
-            onPressed: SnapAction.update.callback(
-              snapData,
-              snapViewModel,
-              snapLauncher,
-              context,
-            ),
+            onPressed: () =>
+                ref.read(snapModelProvider(snap.name).notifier).refresh(),
             child: Text(SnapAction.update.label(l10n)),
           ),
-        if (!showOnlyUpdate && snapData.isInstalled) ...[
+        if (!showOnlyUpdate) ...[
           if (canOpen) ...[
             OutlinedButton(
-              onPressed: SnapAction.open.callback(
-                snapData,
-                snapViewModel,
-                snapLauncher,
-                context,
-              ),
+              onPressed: () {
+                final launcher = ref.read(launchProvider(snap));
+                if (launcher.isLaunchable) launcher.open();
+              },
               child: Text(SnapAction.open.label(l10n)),
             ),
             const SizedBox(width: kSpacing),
           ],
           OutlinedButton(
-            onPressed: SnapAction.remove.callback(
-              snapData,
-              snapViewModel,
-              snapLauncher,
-              context,
-            ),
+            onPressed: () =>
+                ref.read(snapModelProvider(snap.name).notifier).remove(),
             child: Text(SnapAction.remove.label(l10n)),
           ),
         ],

--- a/packages/app_center/test/manage_app_actions_test.dart
+++ b/packages/app_center/test/manage_app_actions_test.dart
@@ -1,0 +1,85 @@
+import 'package:app_center/manage/manage_app_actions.dart';
+import 'package:app_center/snapd/snap_launcher.dart';
+import 'package:app_center/snapd/snap_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:snapd/snapd.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+import 'test_utils.dart';
+import 'test_utils.mocks.dart';
+
+void main() {
+  late MockSnapdService snapd;
+
+  setUp(() {
+    snapd = registerMockSnapdService();
+    registerMockRatingsService();
+  });
+
+  tearDown(resetAllServices);
+
+  testWidgets('renders open and remove buttons for installed snap with apps', (
+    tester,
+  ) async {
+    final snap = createSnap(
+      name: 'testsnap',
+      title: 'Test Snap',
+      apps: [const SnapApp(name: 'testsnap')],
+    );
+
+    final mockLauncher = createMockSnapLauncher(isLaunchable: true);
+
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          launchProvider(snap).overrideWithValue(mockLauncher),
+        ],
+        child: ManageAppActions(snap: snap),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text(tester.l10n.snapActionOpenLabel), findsOneWidget);
+    expect(find.text(tester.l10n.snapActionRemoveLabel), findsOneWidget);
+
+    // Tap open
+    await tester.tap(find.text(tester.l10n.snapActionOpenLabel));
+    await tester.pump();
+    verify(mockLauncher.open()).called(1);
+
+    // Tap remove
+    await tester.tap(find.text(tester.l10n.snapActionRemoveLabel));
+    await tester.pump();
+    verify(snapd.remove('testsnap')).called(1);
+  });
+
+  testWidgets('renders update button when showOnlyUpdate is true', (
+    tester,
+  ) async {
+    final snap = createSnap(
+      name: 'testsnap',
+      title: 'Test Snap',
+      version: '1.0',
+    );
+
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        child: ManageAppActions(
+          snap: snap,
+          updateVersion: '2.0',
+          showOnlyUpdate: true,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text(tester.l10n.snapActionUpdateLabel), findsOneWidget);
+    expect(find.text(tester.l10n.snapActionOpenLabel), findsNothing);
+
+    await tester.tap(find.text(tester.l10n.snapActionUpdateLabel));
+    await tester.pump();
+    verify(snapd.refresh('testsnap', channel: anyNamed('channel'), classic: anyNamed('classic'))).called(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Fixes high CPU usage (10%+) on the Manage screen when many snaps are installed
- Fixes #1998

## Root Cause

The `ManageAppActions` widget called `ref.watch(snapModelProvider(snap.name))` for every snap tile, creating a full `SnapModel` for each installed snap. With 100+ snaps, this caused significant overhead as each `SnapModel` independently fetches data from snapd.

## Fix

Refactored `_buildSnapActions` to avoid creating per-snap `SnapModel` instances on each tile:

1. **Display decisions use `Snap` data directly** - `refreshInhibit`, `apps.isNotEmpty`, `updateVersion` are available from `ManageSnapData.snap` without needing a full `SnapModel`

2. **Active changes tracked at manage page level** - Uses `currentlyInstallingModelProvider` instead of per-snap `SnapModel.activeChangeId`

3. **Lazy SnapModel creation** - Only creates/reads `snapModelProvider` when an action button (update, open, remove) is actually pressed

4. **Simplified launchability check** - Uses `snap.apps.isNotEmpty` instead of `LaunchProvider`

## Testing

Verify that:
- Manage page loads quickly with 100+ installed snaps
- Update, Open, and Remove buttons still work correctly
- Active change status still shows when a snap operation is in progress