### PR TITLE
fix(a11y): make links focusable with keyboard (#1591)

### DIFF
--- a/packages/app_center/lib/widgets/app_info_bar.dart
+++ b/packages/app_center/lib/widgets/app_info_bar.dart
@@ -251,7 +251,6 @@ class _AppInfoItem extends StatelessWidget {
         children: [
           label,
           SelectionArea(
-            focusNode: FocusNode(canRequestFocus: false),
             child: DefaultTextStyle.merge(
               style: const TextStyle(fontWeight: FontWeight.w500),
               child: value,

--- a/packages/app_center/test/app_info_bar_test.dart
+++ b/packages/app_center/test/app_info_bar_test.dart
@@ -1,0 +1,76 @@
+import 'package:app_center/deb/deb_model.dart';
+import 'package:app_center/ratings/ratings.dart';
+import 'package:app_center/snapd/snapd.dart';
+import 'package:app_center/widgets/app_info_bar.dart';
+import 'package:appstream/appstream.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  setUp(() {
+    registerMockRatingsService();
+    registerMockSnapdService();
+  });
+  tearDown(resetAllServices);
+
+  group('SnapInfoBar', () {
+    testWidgets('renders SelectionArea allowing keyboard focus', (tester) async {
+      final snap = createSnap(
+        name: 'testsnap',
+        version: '1.0.0',
+        website: 'https://example.com',
+      );
+      final snapData = SnapData(
+        name: 'testsnap',
+        storeSnap: snap,
+      );
+
+      await tester.pumpApp(
+        (_) => ProviderScope(
+          child: SnapInfoBar(snapData: snapData),
+        ),
+      );
+      await tester.pump();
+
+      final selectionAreas = find.byType(SelectionArea);
+      expect(selectionAreas, findsWidgets);
+
+      // Verify SelectionAreas do not have focus disabled
+      for (final element in tester.widgetList<SelectionArea>(selectionAreas)) {
+        expect(element.focusNode?.canRequestFocus, isNot(isFalse));
+      }
+    });
+  });
+
+  group('DebInfoBar', () {
+    testWidgets('renders SelectionArea allowing keyboard focus', (tester) async {
+      final debData = DebData(
+        component: AppstreamComponent(
+          id: 'test.deb',
+          name: 'Test Deb',
+          summary: 'Test Deb Summary',
+          pkgname: 'testdeb',
+          version: '1.0',
+        ),
+      );
+
+      await tester.pumpApp(
+        (_) => ProviderScope(
+          child: DebInfoBar(debData: debData),
+        ),
+      );
+      await tester.pump();
+
+      final selectionAreas = find.byType(SelectionArea);
+      expect(selectionAreas, findsWidgets);
+
+      for (final element in tester.widgetList<SelectionArea>(selectionAreas)) {
+        expect(element.focusNode?.canRequestFocus, isNot(isFalse));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Fixes #1591: Links on app detail pages are now focusable with keyboard
- Links (developer website, contact) can now be navigated to and activated with keyboard
- Screen readers can now properly announce link content

## Root Cause

The `SelectionArea` widget in `app_info_bar.dart` had `focusNode: FocusNode(canRequestFocus: false)`, which prevented child widgets (including hyperlinks) from receiving keyboard focus.

## Fix

Removed the `canRequestFocus: false` restriction from `SelectionArea` so that child hyperlinks can receive focus via keyboard navigation.