### PR TITLE
fix: filter held snaps from update available list (#1983)

### DIFF
--- a/packages/app_center/lib/manage/snap_updates_model.dart
+++ b/packages/app_center/lib/manage/snap_updates_model.dart
@@ -104,9 +104,11 @@ class SnapUpdatesModel extends _$SnapUpdatesModel {
 
   Future<SnapListState> fetchRefreshableSnaps() {
     return connectionCheck(
-      () => _snapd
-          .find(filter: SnapFindFilter.refresh)
-          .then((snaps) => snaps.where((s) => s.name != kSnapName)),
+      () => _snapd.find(filter: SnapFindFilter.refresh).then(
+            (snaps) => snaps.where(
+              (s) => s.name != kSnapName && (s.hold == null || s.hold!.isBefore(DateTime.now())),
+            ),
+          ),
       ref,
     );
   }

--- a/packages/app_center/test/snap_updates_model_test.dart
+++ b/packages/app_center/test/snap_updates_model_test.dart
@@ -48,6 +48,21 @@ void main() {
       final model = await container.read(snapUpdatesModelProvider.future);
       expect(model.single.name, equals('firefox'));
     });
+
+    test('filters out held snaps', () async {
+      final heldSnap = createSnap(
+        name: 'held-snap',
+        hold: DateTime.now().add(const Duration(days: 30)),
+      );
+      final activeSnap = createSnap(name: 'active-snap');
+      registerMockSnapdService(
+        refreshableSnaps: [heldSnap, activeSnap],
+      );
+      final container = createContainer();
+      final model = await container.read(snapUpdatesModelProvider.future);
+      expect(model.length, equals(1));
+      expect(model.single.name, equals('active-snap'));
+    });
   });
 
   test('update all', () async {


### PR DESCRIPTION
## Summary

- Snaps held via `snap refresh --hold` are now excluded from the updates available list
- Fixes #1983

## Problem

When a snap's updates are manually held (via `snap refresh snapName --hold`), the snap still appeared in the App Center's "Updates available" list. This is confusing because the user explicitly held the update.

## Fix

Added a filter in `fetchRefreshableSnaps()` to exclude snaps where `snap.hold` is set and in the future. The `hold` field on the `Snap` class indicates when updates are held until, so we check if `hold` is null or has passed.

## Testing

1. Run `snap refresh --hold <snap-name>`
2. Open App Center → Manage
3. The held snap should no longer appear in the updates list