### PR TITLE
fix(a11y): make sidebar tiles focusable with keyboard (#1592)

### DIFF
--- a/packages/app_center/lib/store/store_pages.dart
+++ b/packages/app_center/lib/store/store_pages.dart
@@ -33,25 +33,28 @@ class _NavigationTile extends StatelessWidget {
         ? listTileTheme.selectedTileColor
         : listTileTheme.tileColor;
 
-    return YaruMasterTile(
-      title: title,
-      decoration: BoxDecoration(
-        border: BoxBorder.all(color: Colors.transparent, width: 2),
-        borderRadius: const BorderRadius.all(
-          Radius.circular(kYaruButtonRadius),
+    return Semantics(
+      button: true,
+      child: YaruMasterTile(
+        title: title,
+        decoration: BoxDecoration(
+          border: BoxBorder.all(color: Colors.transparent, width: 2),
+          borderRadius: const BorderRadius.all(
+            Radius.circular(kYaruButtonRadius),
+          ),
+          color: backgroundColor,
         ),
-        color: backgroundColor,
-      ),
-      focusDecoration: BoxDecoration(
-        border: BoxBorder.all(color: theme.primaryColor, width: 2),
-        borderRadius: const BorderRadius.all(
-          Radius.circular(kYaruButtonRadius),
+        focusDecoration: BoxDecoration(
+          border: BoxBorder.all(color: theme.primaryColor, width: 2),
+          borderRadius: const BorderRadius.all(
+            Radius.circular(kYaruButtonRadius),
+          ),
+          color: backgroundColor ?? theme.cardColor,
         ),
-        color: backgroundColor ?? theme.cardColor,
+        leading: leading,
+        trailing: trailing,
+        selected: isSelected,
       ),
-      leading: leading,
-      trailing: trailing,
-      selected: isSelected,
     );
   }
 }

--- a/packages/app_center/test/store_app_test.dart
+++ b/packages/app_center/test/store_app_test.dart
@@ -74,6 +74,34 @@ void main() {
       expect(badge, findsOneWidget);
       expect((tester.widget<Badge>(badge).label! as Text).data, equals('2'));
     });
+
+    testWidgets('sidebar navigation tiles have button semantics', (
+      tester,
+    ) async {
+      registerMockService<GtkApplicationNotifier>(
+        createMockGtkApplicationNotifier(),
+      );
+      registerMockService<RatingsService>(registerMockRatingsService());
+      registerMockSnapdService();
+      await tester.pumpApp(
+        (_) => const ProviderScope(
+          child: StoreApp(),
+        ),
+      );
+      await tester.pump();
+
+      final manageTile = find.widgetWithText(
+        YaruMasterTile,
+        tester.l10n.managePageLabel,
+      );
+      final semantics = find.ancestor(
+        of: manageTile,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is Semantics && widget.properties.button == true,
+        ),
+      );
+      expect(semantics, findsOneWidget);
+    });
   });
 
   group('error handling', () {


### PR DESCRIPTION
## Summary

- Fixes #1592: Sidebar navigation tiles are now focusable with keyboard
- Screen readers can now announce sidebar items

## Problem

The sidebar navigation tiles (Explore, Featured, Productivity, etc.) were not keyboard focusable, making them inaccessible to keyboard-only users and screen readers.

## Fix

Wrapped `YaruMasterTile` with `Semantics(button: true)` to provide proper semantic information and make tiles focusable via keyboard navigation.