### PR TITLE
fix: use YaruListTile in ManageAppTile for correct vertical centering

### DIFF
--- a/packages/app_center/lib/manage/manage_app_tile.dart
+++ b/packages/app_center/lib/manage/manage_app_tile.dart
@@ -9,6 +9,7 @@ import 'package:app_center/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:snapd/snapd.dart';
+import 'package:yaru/yaru.dart';
 
 /// Position of a tile within a grouped list, used to apply the correct
 /// border radius (rounded top, bottom, both, or none).
@@ -89,7 +90,7 @@ class ManageAppTile extends ConsumerWidget {
           ManageTilePosition.single => Border.fromBorderSide(border),
         },
       ),
-      child: ListTile(
+      child: YaruListTile(
         key: ValueKey(app.id),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         leading: Clickable(

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -749,7 +749,7 @@ void main() {
 extension on CommonFinders {
   Finder snapTile(String title) => ancestor(
         of: text(title),
-        matching: byType(ListTile),
+        matching: byType(YaruListTile),
       );
   Finder buttonWithText(String text) => ancestor(
         of: this.text(text),


### PR DESCRIPTION
Swapping manage page onto YaruListTile with the fixes from Ashton

<img width="1863" height="1038" alt="image" src="https://github.com/user-attachments/assets/c0fb0c65-6519-4f7a-ba2d-15f21f4909f1" />