### PR TITLE
fix: Reformat Manage page title to match other pages

### DIFF
--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -55,15 +55,12 @@ class ManagePage extends ConsumerWidget {
           padding: const EdgeInsets.only(top: kPagePadding),
           sliver: SliverList.list(
             children: [
-              Center(
-                child: Semantics(
-                  header: true,
-                  focused: true,
-                  child: Text(
-                    l10n.managePageLabel,
-                    style: textTheme.titleMedium!
-                        .copyWith(fontWeight: FontWeight.w500),
-                  ),
+              Semantics(
+                header: true,
+                focused: true,
+                child: Text(
+                  l10n.managePageLabel,
+                  style: textTheme.headlineSmall,
                 ),
               ),
               _SelfUpdateInfoBox(),


### PR DESCRIPTION
Reformats the Manage page title to match the other pages we have.

As discussed with @juanruitina 

| Before | After |
|--------|-------|
| <img width="1384" height="904" alt="image" src="https://github.com/user-attachments/assets/dcf9627e-2726-403a-a430-5996ba58acf0" /> | <img width="1384" height="904" alt="image" src="https://github.com/user-attachments/assets/1a1371d1-2a15-40fc-9220-aa1d37a5c3fc" /> |

---

UDENG-9814