### PR TITLE
fix: document path resolution

### DIFF
--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -43,7 +43,7 @@ class PackageKitService {
   final XdgDocumentsPortal? _documentsPortal;
   final FileSystem _fs;
   final String? _runtimeDir;
-  XdgDesktopPortalClient? _portalClient;
+  XdgDesktopPortalClient? _desktopPortalClient;
   Future<io.Directory>? _mountPointFuture;
 
   bool get isAvailable => _isAvailable;
@@ -226,33 +226,34 @@ class PackageKitService {
       return snapArch;
     }
 
-    final result = await io.Process.run('/usr/bin/dpkg', ['--print-architecture']);
+    final result =
+        await io.Process.run('/usr/bin/dpkg', ['--print-architecture']);
     return (result.stdout as String).trim();
   }
 
   String _getAbsolutePath(String path) => _fs.file(path).absolute.path;
 
-  Future<XdgDocumentsPortal> _getPortal() async {
-    return _documentsPortal ?? (_portalClient ??= XdgDesktopPortalClient()).documents;
-  }
+  XdgDocumentsPortal get _portal =>
+      _documentsPortal ??
+      (_desktopPortalClient ??= XdgDesktopPortalClient()).documents;
 
   Future<io.Directory> _getMountPoint() {
-    return _mountPointFuture ??= _getPortal().then((p) async => p.getMountPoint());
+    return _mountPointFuture ??= _portal.getMountPoint();
   }
 
   Future<bool> _isPortalPath(String path) async {
     try {
       final mountPoint = await _getMountPoint();
       return isWithin(mountPoint.path, path);
-    } on Exception {
+    } on Exception catch (e) {
+      log.warning('Failed to check if $path is a portal path: $e');
       return false;
     }
   }
 
   Future<String?> _resolvePortalPath(String path) async {
-    final portal = await _getPortal();
+    final portal = _portal;
     final mountPoint = await _getMountPoint();
-    // Path is /<mountPoint>/<docId>/filename — extract docId as first segment after mount
     final relativePath = relative(path, from: mountPoint.path);
     final docId = split(relativePath).first;
     try {
@@ -263,13 +264,12 @@ class PackageKitService {
         'Documents portal returned no path for $docId. Falling back to original path.',
       );
       return null;
-    } on DBusUnknownMethodException {
-      rethrow;
     } on Exception catch (e) {
       log.warning(
-        'Failed to resolve portal path $path via Documents portal: $e. Falling back to original path.',
+        'Failed to resolve portal path $path via Documents portal '
+        '(${e.runtimeType}): $e — triggering copy fallback.',
       );
-      return null;
+      rethrow;
     }
   }
 
@@ -289,18 +289,14 @@ class PackageKitService {
         resolvedPath: resolved ?? _getAbsolutePath(path),
         tempCopy: null,
       );
-    } on DBusUnknownMethodException {
-      log.info(
-        'GetHostPaths not supported, copying $path to runtime directory',
-      );
+    } on Exception catch (_) {
       final copyPath = await _copyToRuntime(path);
       return (resolvedPath: copyPath, tempCopy: copyPath);
     }
   }
 
   Future<String> _copyToRuntime(String path) async {
-    final dir =
-        _runtimeDir ??
+    final dir = _runtimeDir ??
         io.Platform.environment['SNAP_USER_COMMON'] ??
         io.Directory.systemTemp.path;
     final dest = join(dir, basename(path));
@@ -445,6 +441,6 @@ class PackageKitService {
     await _dbus.close();
     await _client.close();
     await _errorStreamController.close();
-    await _portalClient?.close();
+    await _desktopPortalClient?.close();
   }
 }

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -7,7 +7,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
-import 'package:path/path.dart';
+import 'package:path/path.dart' as p;
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 
@@ -128,7 +128,7 @@ class PackageKitService {
     try {
       await action?.call(transaction);
     } on Exception {
-      subscription.cancel();
+      await subscription.cancel();
       _transactions.remove(id);
       try {
         onDone?.call();
@@ -267,7 +267,7 @@ class PackageKitService {
   Future<bool> _isPortalPath(String path) async {
     try {
       final mountPoint = await _getMountPoint();
-      return isWithin(mountPoint.path, path);
+      return p.isWithin(mountPoint.path, path);
     } on Exception catch (e) {
       log.warning('Failed to check if $path is a portal path: $e');
       return false;
@@ -277,7 +277,7 @@ class PackageKitService {
   Future<String?> _resolvePortalPath(String path) async {
     final portal = _portal;
     await _getMountPoint();
-    final docId = basename(dirname(path));
+    final docId = p.basename(p.dirname(path));
     try {
       final hostPaths = await portal.getHostPaths([docId]);
       final file = hostPaths[docId];
@@ -324,14 +324,14 @@ class PackageKitService {
           io.Directory.systemTemp.path,
     );
     final tempDir = await baseDir.createTemp('packagekit-');
-    final dest = join(tempDir.path, basename(path));
+    final dest = p.join(tempDir.path, p.basename(path));
     await _fs.file(path).copy(dest);
     return dest;
   }
 
   Future<void> _deleteTempCopy(String path) async {
     try {
-      await _fs.directory(dirname(path)).delete(recursive: true);
+      await _fs.directory(p.dirname(path)).delete(recursive: true);
     } on Exception catch (e) {
       log.warning('Failed to delete temporary file $path: $e');
     }

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:app_center/packagekit/logger.dart';
 import 'package:dbus/dbus.dart';
@@ -41,6 +41,7 @@ class PackageKitService {
   final XdgDocumentsPortal? _documentsPortal;
   final FileSystem _fs;
   XdgDesktopPortalClient? _portalClient;
+  Future<io.Directory>? _mountPointFuture;
 
   bool get isAvailable => _isAvailable;
   bool _isAvailable = false;
@@ -180,7 +181,7 @@ class PackageKitService {
   /// Creates a transaction that installs the local package given by `path` and
   /// returns the transaction ID.
   Future<int> installLocal(String path) async {
-    final resolvedPath = _isPortalPath(path)
+    final resolvedPath = await _isPortalPath(path)
         ? await _resolvePortalPath(path)
         : _getAbsolutePath(path);
     return _createTransaction(
@@ -214,29 +215,40 @@ class PackageKitService {
       );
 
   static Future<String> _getNativeArchitecture() async {
-    final snapArch = Platform.environment['SNAP_ARCH'];
+    final snapArch = io.Platform.environment['SNAP_ARCH'];
     if (snapArch != null) {
       return snapArch;
     }
 
-    final result = await Process.run('/usr/bin/dpkg', ['--print-architecture']);
+    final result = await io.Process.run('/usr/bin/dpkg', ['--print-architecture']);
     return (result.stdout as String).trim();
   }
 
   String _getAbsolutePath(String path) => _fs.file(path).absolute.path;
 
-  static bool _isPortalPath(String path) {
-    // /run/user/<uid>/doc/<docId>/filename
-    final parts = split(path);
-    return parts.length > 5 &&
-        parts[1] == 'run' &&
-        parts[2] == 'user' &&
-        parts[4] == 'doc';
+  Future<XdgDocumentsPortal> _getPortal() async {
+    return _documentsPortal ?? (_portalClient ??= XdgDesktopPortalClient()).documents;
+  }
+
+  Future<io.Directory> _getMountPoint() {
+    return _mountPointFuture ??= _getPortal().then((p) async => p.getMountPoint());
+  }
+
+  Future<bool> _isPortalPath(String path) async {
+    try {
+      final mountPoint = await _getMountPoint();
+      return isWithin(mountPoint.path, path);
+    } on Exception {
+      return false;
+    }
   }
 
   Future<String> _resolvePortalPath(String path) async {
-    final docId = split(path)[5];
-    final portal = _documentsPortal ?? (_portalClient ??= XdgDesktopPortalClient()).documents;
+    final portal = await _getPortal();
+    final mountPoint = await _getMountPoint();
+    // Path is /<mountPoint>/<docId>/filename — extract docId as first segment after mount
+    final relativePath = relative(path, from: mountPoint.path);
+    final docId = split(relativePath).first;
     try {
       final hostPaths = await portal.getHostPaths([docId]);
       final file = hostPaths[docId];
@@ -319,7 +331,7 @@ class PackageKitService {
 
   Future<PackageKitPackageDetails?> getDetailsLocal(String path) async {
     PackageKitPackageDetails? details;
-    final resolvedPath = _isPortalPath(path)
+    final resolvedPath = await _isPortalPath(path)
         ? await _resolvePortalPath(path)
         : _getAbsolutePath(path);
     await _createTransaction(

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -182,7 +182,7 @@ class PackageKitService {
   /// returns the transaction ID.
   Future<int> installLocal(String path) async {
     final resolvedPath = await _isPortalPath(path)
-        ? await _resolvePortalPath(path)
+        ? await _resolvePortalPath(path) ?? _getAbsolutePath(path)
         : _getAbsolutePath(path);
     return _createTransaction(
       action: (transaction) => transaction.installFiles([resolvedPath]),
@@ -243,7 +243,7 @@ class PackageKitService {
     }
   }
 
-  Future<String> _resolvePortalPath(String path) async {
+  Future<String?> _resolvePortalPath(String path) async {
     final portal = await _getPortal();
     final mountPoint = await _getMountPoint();
     // Path is /<mountPoint>/<docId>/filename — extract docId as first segment after mount
@@ -256,12 +256,12 @@ class PackageKitService {
       log.warning(
         'Documents portal returned no path for $docId. Falling back to original path.',
       );
-      return path;
+      return null;
     } on Exception catch (e) {
       log.warning(
         'Failed to resolve portal path $path via Documents portal: $e. Falling back to original path.',
       );
-      return path;
+      return null;
     }
   }
 
@@ -332,7 +332,7 @@ class PackageKitService {
   Future<PackageKitPackageDetails?> getDetailsLocal(String path) async {
     PackageKitPackageDetails? details;
     final resolvedPath = await _isPortalPath(path)
-        ? await _resolvePortalPath(path)
+        ? await _resolvePortalPath(path) ?? _getAbsolutePath(path)
         : _getAbsolutePath(path);
     await _createTransaction(
       action: (transaction) => transaction.getDetailsLocal([resolvedPath]),

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -31,15 +31,18 @@ class PackageKitService {
     @visibleForTesting DBusClient? dbus,
     @visibleForTesting XdgDocumentsPortal? documentsPortal,
     @visibleForTesting FileSystem? fs,
+    @visibleForTesting String? runtimeDir,
   })  : _client = client ?? getService<PackageKitClient>(),
         _dbus = dbus ?? DBusClient.system(),
         _documentsPortal = documentsPortal,
-        _fs = fs ?? const LocalFileSystem();
+        _fs = fs ?? const LocalFileSystem(),
+        _runtimeDir = runtimeDir;
 
   final PackageKitClient _client;
   final DBusClient _dbus;
   final XdgDocumentsPortal? _documentsPortal;
   final FileSystem _fs;
+  final String? _runtimeDir;
   XdgDesktopPortalClient? _portalClient;
   Future<io.Directory>? _mountPointFuture;
 
@@ -92,11 +95,13 @@ class PackageKitService {
 
   /// Creates a new `PackageKitTransaction` and invokes `action` on it, if
   /// provided. If a `listener` is provided it will receive the `PackageKitEvent`s
-  /// from the transaction.
+  /// from the transaction. [onDone] is called once the transaction finishes or
+  /// is destroyed (useful for cleanup).
   /// Returns an internal transaction id.
   Future<int> _createTransaction({
     Future<void> Function(PackageKitTransaction transaction)? action,
     void Function(PackageKitEvent event)? listener,
+    void Function()? onDone,
   }) async {
     final transaction = await _client.createTransaction();
     final id = _nextId++;
@@ -108,6 +113,7 @@ class PackageKitService {
       if (event is PackageKitFinishedEvent || event is PackageKitDestroyEvent) {
         _transactions.remove(id);
         subscription.cancel();
+        onDone?.call();
       } else if (event is PackageKitErrorCodeEvent) {
         _errorStreamController.add(event);
         log.error(
@@ -181,11 +187,11 @@ class PackageKitService {
   /// Creates a transaction that installs the local package given by `path` and
   /// returns the transaction ID.
   Future<int> installLocal(String path) async {
-    final resolvedPath = await _isPortalPath(path)
-        ? await _resolvePortalPath(path) ?? _getAbsolutePath(path)
-        : _getAbsolutePath(path);
+    final (resolvedPath: resolvedPath, tempCopy: tempCopy) =
+        await _resolveLocalPath(path);
     return _createTransaction(
       action: (transaction) => transaction.installFiles([resolvedPath]),
+      onDone: tempCopy != null ? () => _deleteTempCopy(tempCopy) : null,
     );
   }
 
@@ -257,12 +263,56 @@ class PackageKitService {
         'Documents portal returned no path for $docId. Falling back to original path.',
       );
       return null;
+    } on DBusUnknownMethodException {
+      rethrow;
     } on Exception catch (e) {
       log.warning(
         'Failed to resolve portal path $path via Documents portal: $e. Falling back to original path.',
       );
       return null;
     }
+  }
+
+  /// Resolves a local file path for use with PackageKit. For portal FUSE paths,
+  /// attempts GetHostPaths first; falls back to copying the file to a
+  /// PackageKit-accessible location if the method is unavailable (old glib).
+  /// Returns the resolved path and, if a temp copy was made, its path for cleanup.
+  Future<({String resolvedPath, String? tempCopy})> _resolveLocalPath(
+    String path,
+  ) async {
+    if (!await _isPortalPath(path)) {
+      return (resolvedPath: _getAbsolutePath(path), tempCopy: null);
+    }
+    try {
+      final resolved = await _resolvePortalPath(path);
+      return (
+        resolvedPath: resolved ?? _getAbsolutePath(path),
+        tempCopy: null,
+      );
+    } on DBusUnknownMethodException {
+      log.info(
+        'GetHostPaths not supported, copying $path to runtime directory',
+      );
+      final copyPath = await _copyToRuntime(path);
+      return (resolvedPath: copyPath, tempCopy: copyPath);
+    }
+  }
+
+  Future<String> _copyToRuntime(String path) async {
+    final dir =
+        _runtimeDir ??
+        io.Platform.environment['SNAP_USER_COMMON'] ??
+        io.Directory.systemTemp.path;
+    final dest = join(dir, basename(path));
+    await _fs.file(path).copy(dest);
+    return dest;
+  }
+
+  void _deleteTempCopy(String path) {
+    _fs.file(path).delete().catchError((Object e) {
+      log.warning('Failed to delete temporary file $path: $e');
+      return _fs.file(path);
+    });
   }
 
   /// Resolves package names in a single transaction.
@@ -331,17 +381,20 @@ class PackageKitService {
 
   Future<PackageKitPackageDetails?> getDetailsLocal(String path) async {
     PackageKitPackageDetails? details;
-    final resolvedPath = await _isPortalPath(path)
-        ? await _resolvePortalPath(path) ?? _getAbsolutePath(path)
-        : _getAbsolutePath(path);
-    await _createTransaction(
-      action: (transaction) => transaction.getDetailsLocal([resolvedPath]),
-      listener: (event) {
-        if (event is PackageKitDetailsEvent) {
-          details = event;
-        }
-      },
-    ).then(waitTransaction);
+    final (resolvedPath: resolvedPath, tempCopy: tempCopy) =
+        await _resolveLocalPath(path);
+    try {
+      await _createTransaction(
+        action: (transaction) => transaction.getDetailsLocal([resolvedPath]),
+        listener: (event) {
+          if (event is PackageKitDetailsEvent) {
+            details = event;
+          }
+        },
+      ).then(waitTransaction);
+    } finally {
+      if (tempCopy != null) _deleteTempCopy(tempCopy);
+    }
     if (details == null) {
       log.error('Couldn\'t get details for local package $resolvedPath');
     }

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -113,7 +113,11 @@ class PackageKitService {
       if (event is PackageKitFinishedEvent || event is PackageKitDestroyEvent) {
         _transactions.remove(id);
         subscription.cancel();
-        onDone?.call();
+        try {
+          onDone?.call();
+        } on Exception catch (e) {
+          log.warning('onDone callback threw during transaction cleanup: $e');
+        }
       } else if (event is PackageKitErrorCodeEvent) {
         _errorStreamController.add(event);
         log.error(
@@ -121,7 +125,18 @@ class PackageKitService {
         );
       }
     });
-    await action?.call(transaction);
+    try {
+      await action?.call(transaction);
+    } on Exception {
+      subscription.cancel();
+      _transactions.remove(id);
+      try {
+        onDone?.call();
+      } on Exception catch (e) {
+        log.warning('onDone callback threw during transaction cleanup: $e');
+      }
+      rethrow;
+    }
     return id;
   }
 
@@ -189,10 +204,15 @@ class PackageKitService {
   Future<int> installLocal(String path) async {
     final (resolvedPath: resolvedPath, tempCopy: tempCopy) =
         await _resolveLocalPath(path);
-    return _createTransaction(
-      action: (transaction) => transaction.installFiles([resolvedPath]),
-      onDone: tempCopy != null ? () => _deleteTempCopy(tempCopy) : null,
-    );
+    try {
+      return await _createTransaction(
+        action: (transaction) => transaction.installFiles([resolvedPath]),
+        onDone: tempCopy != null ? () => _deleteTempCopy(tempCopy) : null,
+      );
+    } on Exception catch (_) {
+      if (tempCopy != null) await _deleteTempCopy(tempCopy);
+      rethrow;
+    }
   }
 
   /// Get the packages that provide the given id (usually a codec string).
@@ -238,7 +258,10 @@ class PackageKitService {
       (_desktopPortalClient ??= XdgDesktopPortalClient()).documents;
 
   Future<io.Directory> _getMountPoint() {
-    return _mountPointFuture ??= _portal.getMountPoint();
+    return _mountPointFuture ??= _portal.getMountPoint().catchError((Object e) {
+      _mountPointFuture = null;
+      throw e;
+    });
   }
 
   Future<bool> _isPortalPath(String path) async {
@@ -253,9 +276,8 @@ class PackageKitService {
 
   Future<String?> _resolvePortalPath(String path) async {
     final portal = _portal;
-    final mountPoint = await _getMountPoint();
-    final relativePath = relative(path, from: mountPoint.path);
-    final docId = split(relativePath).first;
+    await _getMountPoint();
+    final docId = basename(dirname(path));
     try {
       final hostPaths = await portal.getHostPaths([docId]);
       final file = hostPaths[docId];
@@ -264,7 +286,7 @@ class PackageKitService {
         'Documents portal returned no path for $docId. Falling back to original path.',
       );
       return null;
-    } on Exception catch (e) {
+    } on DBusUnknownMethodException catch (e) {
       log.warning(
         'Failed to resolve portal path $path via Documents portal '
         '(${e.runtimeType}): $e — triggering copy fallback.',
@@ -289,26 +311,30 @@ class PackageKitService {
         resolvedPath: resolved ?? _getAbsolutePath(path),
         tempCopy: null,
       );
-    } on Exception catch (_) {
+    } on DBusUnknownMethodException catch (_) {
       final copyPath = await _copyToRuntime(path);
       return (resolvedPath: copyPath, tempCopy: copyPath);
     }
   }
 
   Future<String> _copyToRuntime(String path) async {
-    final dir = _runtimeDir ??
-        io.Platform.environment['SNAP_USER_COMMON'] ??
-        io.Directory.systemTemp.path;
-    final dest = join(dir, basename(path));
+    final baseDir = _fs.directory(
+      _runtimeDir ??
+          io.Platform.environment['XDG_RUNTIME_DIR'] ??
+          io.Directory.systemTemp.path,
+    );
+    final tempDir = await baseDir.createTemp('packagekit-');
+    final dest = join(tempDir.path, basename(path));
     await _fs.file(path).copy(dest);
     return dest;
   }
 
-  void _deleteTempCopy(String path) {
-    _fs.file(path).delete().catchError((Object e) {
+  Future<void> _deleteTempCopy(String path) async {
+    try {
+      await _fs.directory(dirname(path)).delete(recursive: true);
+    } on Exception catch (e) {
       log.warning('Failed to delete temporary file $path: $e');
-      return _fs.file(path);
-    });
+    }
   }
 
   /// Resolves package names in a single transaction.
@@ -389,7 +415,7 @@ class PackageKitService {
         },
       ).then(waitTransaction);
     } finally {
-      if (tempCopy != null) _deleteTempCopy(tempCopy);
+      if (tempCopy != null) await _deleteTempCopy(tempCopy);
     }
     if (details == null) {
       log.error('Couldn\'t get details for local package $resolvedPath');

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -44,7 +44,7 @@ class PackageKitService {
   final FileSystem _fs;
   final String? _runtimeDir;
   XdgDesktopPortalClient? _desktopPortalClient;
-  Future<io.Directory>? _mountPointFuture;
+  io.Directory? _mountPoint;
 
   bool get isAvailable => _isAvailable;
   bool _isAvailable = false;
@@ -257,11 +257,8 @@ class PackageKitService {
       _documentsPortal ??
       (_desktopPortalClient ??= XdgDesktopPortalClient()).documents;
 
-  Future<io.Directory> _getMountPoint() {
-    return _mountPointFuture ??= _portal.getMountPoint().catchError((Object e) {
-      _mountPointFuture = null;
-      throw e;
-    });
+  Future<io.Directory> _getMountPoint() async {
+    return _mountPoint ??= await _portal.getMountPoint();
   }
 
   Future<bool> _isPortalPath(String path) async {
@@ -275,11 +272,10 @@ class PackageKitService {
   }
 
   Future<String?> _resolvePortalPath(String path) async {
-    final portal = _portal;
     await _getMountPoint();
     final docId = p.basename(p.dirname(path));
     try {
-      final hostPaths = await portal.getHostPaths([docId]);
+      final hostPaths = await _portal.getHostPaths([docId]);
       final file = hostPaths[docId];
       if (file != null) return file.path;
       log.warning(

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:path/path.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 
 export 'package:packagekit/packagekit.dart' show PackageKitTransaction;
 
@@ -28,17 +29,18 @@ class PackageKitService {
   PackageKitService({
     @visibleForTesting PackageKitClient? client,
     @visibleForTesting DBusClient? dbus,
-    @visibleForTesting DBusClient? sessionDbus,
+    @visibleForTesting XdgDocumentsPortal? documentsPortal,
     @visibleForTesting FileSystem? fs,
   })  : _client = client ?? getService<PackageKitClient>(),
         _dbus = dbus ?? DBusClient.system(),
-        _sessionDbus = sessionDbus,
+        _documentsPortal = documentsPortal,
         _fs = fs ?? const LocalFileSystem();
 
   final PackageKitClient _client;
   final DBusClient _dbus;
-  final DBusClient? _sessionDbus;
+  final XdgDocumentsPortal? _documentsPortal;
   final FileSystem _fs;
+  XdgDesktopPortalClient? _portalClient;
 
   bool get isAvailable => _isAvailable;
   bool _isAvailable = false;
@@ -234,27 +236,15 @@ class PackageKitService {
 
   Future<String> _resolvePortalPath(String path) async {
     final docId = split(path)[5];
-    final client = _sessionDbus ?? DBusClient.session();
+    final portal = _documentsPortal ?? (_portalClient ??= XdgDesktopPortalClient()).documents;
     try {
-      final object = DBusRemoteObject(
-        client,
-        name: 'org.freedesktop.portal.Documents',
-        path: DBusObjectPath('/org/freedesktop/portal/documents'),
+      final hostPaths = await portal.getHostPaths([docId]);
+      final file = hostPaths[docId];
+      if (file != null) return file.path;
+      log.warning(
+        'Documents portal returned no path for $docId. Falling back to original path.',
       );
-      final result = await object.callMethod(
-        'org.freedesktop.portal.Documents',
-        'GetHostPaths',
-        [
-          DBusArray.string([docId]),
-        ],
-      );
-      // Result is a{say}: doc_id -> null-terminated byte array path
-      final pathsDict = result.values[0] as DBusDict;
-      final pathBytes =
-          (pathsDict.children[DBusString(docId)] as DBusArray).children;
-      return String.fromCharCodes(
-        pathBytes.map((v) => (v as DBusByte).value).where((b) => b != 0),
-      );
+      return path;
     } on Exception catch (e) {
       log.warning(
         'Failed to resolve portal path $path via Documents portal: $e. Falling back to original path.',
@@ -390,5 +380,6 @@ class PackageKitService {
     await _dbus.close();
     await _client.close();
     await _errorStreamController.close();
+    await _portalClient?.close();
   }
 }

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -27,13 +27,16 @@ class PackageKitService {
   PackageKitService({
     @visibleForTesting PackageKitClient? client,
     @visibleForTesting DBusClient? dbus,
+    @visibleForTesting DBusClient? sessionDbus,
     @visibleForTesting FileSystem? fs,
   })  : _client = client ?? getService<PackageKitClient>(),
         _dbus = dbus ?? DBusClient.system(),
+        _sessionDbus = sessionDbus,
         _fs = fs ?? const LocalFileSystem();
 
   final PackageKitClient _client;
   final DBusClient _dbus;
+  final DBusClient? _sessionDbus;
   final FileSystem _fs;
 
   bool get isAvailable => _isAvailable;
@@ -173,10 +176,14 @@ class PackageKitService {
 
   /// Creates a transaction that installs the local package given by `path` and
   /// returns the transaction ID.
-  Future<int> installLocal(String path) async => _createTransaction(
-        action: (transaction) =>
-            transaction.installFiles([_getAbsolutePath(path)]),
-      );
+  Future<int> installLocal(String path) async {
+    final resolvedPath = _isPortalPath(path)
+        ? await _resolvePortalPath(path)
+        : _getAbsolutePath(path);
+    return _createTransaction(
+      action: (transaction) => transaction.installFiles([resolvedPath]),
+    );
+  }
 
   /// Get the packages that provide the given id (usually a codec string).
   Future<Iterable<PackageKitPackageInfo>> whatProvides(String id) async {
@@ -214,6 +221,46 @@ class PackageKitService {
   }
 
   String _getAbsolutePath(String path) => _fs.file(path).absolute.path;
+
+  static bool _isPortalPath(String path) {
+    final parts = path.split('/');
+    // /run/user/<uid>/doc/<docId>/filename
+    return parts.length > 5 &&
+        parts[1] == 'run' &&
+        parts[2] == 'user' &&
+        parts[4] == 'doc';
+  }
+
+  Future<String> _resolvePortalPath(String path) async {
+    final docId = path.split('/')[5];
+    final client = _sessionDbus ?? DBusClient.session();
+    try {
+      final object = DBusRemoteObject(
+        client,
+        name: 'org.freedesktop.portal.Documents',
+        path: DBusObjectPath('/org/freedesktop/portal/documents'),
+      );
+      final result = await object.callMethod(
+        'org.freedesktop.portal.Documents',
+        'GetHostPaths',
+        [
+          DBusArray.string([docId]),
+        ],
+      );
+      // Result is a{say}: doc_id -> null-terminated byte array path
+      final pathsDict = result.values[0] as DBusDict;
+      final pathBytes =
+          (pathsDict.children[DBusString(docId)] as DBusArray).children;
+      return String.fromCharCodes(
+        pathBytes.map((v) => (v as DBusByte).value).where((b) => b != 0),
+      );
+    } on Exception catch (e) {
+      log.warning(
+        'Failed to resolve portal path $path via Documents portal: $e. Falling back to original path.',
+      );
+      return path;
+    }
+  }
 
   /// Resolves package names in a single transaction.
   /// Returns a map of package name to package info.
@@ -281,9 +328,11 @@ class PackageKitService {
 
   Future<PackageKitPackageDetails?> getDetailsLocal(String path) async {
     PackageKitPackageDetails? details;
-    final absolutePath = _getAbsolutePath(path);
+    final resolvedPath = _isPortalPath(path)
+        ? await _resolvePortalPath(path)
+        : _getAbsolutePath(path);
     await _createTransaction(
-      action: (transaction) => transaction.getDetailsLocal([absolutePath]),
+      action: (transaction) => transaction.getDetailsLocal([resolvedPath]),
       listener: (event) {
         if (event is PackageKitDetailsEvent) {
           details = event;
@@ -291,7 +340,7 @@ class PackageKitService {
       },
     ).then(waitTransaction);
     if (details == null) {
-      log.error('Couldn\'t get details for local package $absolutePath');
+      log.error('Couldn\'t get details for local package $resolvedPath');
     }
     return details;
   }

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -7,6 +7,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
+import 'package:path/path.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 export 'package:packagekit/packagekit.dart' show PackageKitTransaction;
@@ -223,8 +224,8 @@ class PackageKitService {
   String _getAbsolutePath(String path) => _fs.file(path).absolute.path;
 
   static bool _isPortalPath(String path) {
-    final parts = path.split('/');
     // /run/user/<uid>/doc/<docId>/filename
+    final parts = split(path);
     return parts.length > 5 &&
         parts[1] == 'run' &&
         parts[2] == 'user' &&
@@ -232,7 +233,7 @@ class PackageKitService {
   }
 
   Future<String> _resolvePortalPath(String path) async {
-    final docId = path.split('/')[5];
+    final docId = split(path)[5];
     final client = _sessionDbus ?? DBusClient.session();
     try {
       final object = DBusRemoteObject(

--- a/packages/app_center/pubspec.lock
+++ b/packages/app_center/pubspec.lock
@@ -1504,6 +1504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  xdg_desktop_portal:
+    dependency: "direct main"
+    description:
+      name: xdg_desktop_portal
+      sha256: "4fae74b6ed63a449d4c796a74265cebdd912c390336dedc06d705142f3b939d7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.14"
   xdg_directories:
     dependency: "direct main"
     description:

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   ubuntu_test: ^0.2.3
   ubuntu_widgets: ^0.8.0
   url_launcher: ^6.3.0
+  xdg_desktop_portal: ^0.1.14
   xdg_directories: ^1.0.4
   yaru: ^10.1.0
   yaru_test: ^0.3.2

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:app_center/packagekit/packagekit_service.dart';
 import 'package:dbus/dbus.dart';
@@ -7,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:packagekit/packagekit.dart';
+import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 
 import 'packagekit_service_test.mocks.dart';
 import 'test_utils.dart';
@@ -15,8 +17,6 @@ const _dBusName = 'org.freedesktop.DBus';
 const _dBusInterface = 'org.freedesktop.DBus';
 const _dBusObjectPath = '/org/freedesktop/DBus';
 const _packageKitDBusName = 'org.freedesktop.PackageKit';
-const _documentsPortalName = 'org.freedesktop.portal.Documents';
-const _documentsPortalPath = '/org/freedesktop/portal/documents';
 
 void main() {
   group('activate service', () {
@@ -484,7 +484,7 @@ void main() {
           createMockPackageKitClient(transaction: mockTransaction);
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
-        sessionDbus: createMockSessionDbus(
+        documentsPortal: createMockDocumentsPortal(
           docId: '8cf4b075',
           realPath: realPath,
         ),
@@ -514,7 +514,7 @@ void main() {
           createMockPackageKitClient(transaction: mockTransaction);
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
-        sessionDbus: createMockSessionDbus(
+        documentsPortal: createMockDocumentsPortal(
           docId: '8cf4b075',
           realPath: realPath,
         ),
@@ -534,21 +534,9 @@ void main() {
       );
       final mockClient =
           createMockPackageKitClient(transaction: mockTransaction);
-      final failingSessionDbus = MockDBusClient();
-      when(
-        failingSessionDbus.callMethod(
-          path: DBusObjectPath(_documentsPortalPath),
-          destination: _documentsPortalName,
-          name: 'GetHostPaths',
-          interface: _documentsPortalName,
-          values: [
-            DBusArray.string(['8cf4b075']),
-          ],
-        ),
-      ).thenThrow(Exception('portal unavailable'));
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
-        sessionDbus: failingSessionDbus,
+        documentsPortal: createFailingDocumentsPortal(docId: '8cf4b075'),
         client: mockClient,
         fs: MemoryFileSystem.test(),
       );
@@ -592,7 +580,7 @@ void main() {
   });
 }
 
-@GenerateMocks([DBusClient])
+@GenerateMocks([DBusClient, XdgDocumentsPortal])
 MockDBusClient createMockDbusClient() {
   final dbus = MockDBusClient();
   when(
@@ -607,31 +595,21 @@ MockDBusClient createMockDbusClient() {
   return dbus;
 }
 
-MockDBusClient createMockSessionDbus({
+MockXdgDocumentsPortal createMockDocumentsPortal({
   required String docId,
   required String realPath,
 }) {
-  final dbus = MockDBusClient();
-  when(
-    dbus.callMethod(
-      path: DBusObjectPath(_documentsPortalPath),
-      destination: _documentsPortalName,
-      name: 'GetHostPaths',
-      interface: _documentsPortalName,
-      values: [
-        DBusArray.string([docId]),
-      ],
-    ),
-  ).thenAnswer(
-    (_) async => DBusMethodSuccessResponse([
-      DBusDict(
-        DBusSignature('s'),
-        DBusSignature('ay'),
-        {
-          DBusString(docId): DBusArray.byte([...realPath.codeUnits, 0]),
-        },
-      ),
-    ]),
+  final portal = MockXdgDocumentsPortal();
+  when(portal.getHostPaths([docId])).thenAnswer(
+    (_) async => {docId: File(realPath)},
   );
-  return dbus;
+  return portal;
+}
+
+MockXdgDocumentsPortal createFailingDocumentsPortal({
+  required String docId,
+}) {
+  final portal = MockXdgDocumentsPortal();
+  when(portal.getHostPaths([docId])).thenThrow(Exception('portal unavailable'));
+  return portal;
 }

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -546,6 +546,41 @@ void main() {
       completer.complete();
       await packageKit.waitTransaction(id);
     });
+
+    test('copies file to runtime dir when GetHostPaths is unavailable',
+        () async {
+      final completer = Completer();
+      final mockTransaction = createMockPackageKitTransaction(
+        start: completer.future,
+      );
+      final mockClient =
+          createMockPackageKitClient(transaction: mockTransaction);
+      final fs = MemoryFileSystem.test();
+      const portalPathForCopy =
+          '/run/user/1000/doc/8cf4b075/test-package_1.0_amd64.deb';
+      const snapUserCommon = '/snap/user/common';
+      const copyPath = '$snapUserCommon/test-package_1.0_amd64.deb';
+      await fs.file(portalPathForCopy).create(recursive: true);
+      await fs.directory(snapUserCommon).create(recursive: true);
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        documentsPortal: createUnknownMethodDocumentsPortal(
+          docId: '8cf4b075',
+        ),
+        client: mockClient,
+        fs: fs,
+        runtimeDir: snapUserCommon,
+      );
+      await packageKit.activateService();
+      final id = await packageKit.installLocal(portalPathForCopy);
+      verify(mockTransaction.installFiles([copyPath])).called(1);
+      expect(fs.file(copyPath).existsSync(), isTrue);
+      completer.complete();
+      await packageKit.waitTransaction(id);
+      // Give onDone callback a chance to run
+      await Future<void>.delayed(Duration.zero);
+      expect(fs.file(copyPath).existsSync(), isFalse);
+    });
   });
 
   test('getUpdates', () async {
@@ -619,5 +654,19 @@ MockXdgDocumentsPortal createFailingDocumentsPortal({
     (_) async => io.Directory(mountPoint),
   );
   when(portal.getHostPaths([docId])).thenThrow(Exception('portal unavailable'));
+  return portal;
+}
+
+MockXdgDocumentsPortal createUnknownMethodDocumentsPortal({
+  required String docId,
+  String mountPoint = '/run/user/1000/doc',
+}) {
+  final portal = MockXdgDocumentsPortal();
+  when(portal.getMountPoint()).thenAnswer(
+    (_) async => io.Directory(mountPoint),
+  );
+  when(portal.getHostPaths([docId])).thenThrow(
+    DBusUnknownMethodException(DBusMethodErrorResponse.unknownMethod()),
+  );
   return portal;
 }

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -472,8 +472,8 @@ void main() {
 
   group('portal path resolution', () {
     const portalPath =
-        '/run/user/1000/doc/8cf4b075/balena-etcher_2.1.0_amd64.deb';
-    const realPath = '/home/user/Downloads/balena-etcher_2.1.0_amd64.deb';
+        '/run/user/1000/doc/8cf4b075/test-package_1.0_amd64.deb';
+    const realPath = '/home/user/Downloads/test-package_1.0_amd64.deb';
 
     test('install local package via portal path', () async {
       final completer = Completer();
@@ -501,8 +501,8 @@ void main() {
     test('get details of local package via portal path', () async {
       final mockDetails = PackageKitPackageDetails(
         packageId: const PackageKitPackageId(
-          name: 'balena-etcher',
-          version: '2.1.0',
+          name: 'test-package',
+          version: '1.0',
           arch: 'amd64',
         ),
         summary: 'summary',

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:io' as io;
 
 import 'package:app_center/packagekit/packagekit_service.dart';
 import 'package:dbus/dbus.dart';
+import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -559,10 +560,9 @@ void main() {
       final fs = MemoryFileSystem.test();
       const portalPathForCopy =
           '/run/user/1000/doc/8cf4b075/test-package_1.0_amd64.deb';
-      const snapUserCommon = '/snap/user/common';
-      const copyPath = '$snapUserCommon/test-package_1.0_amd64.deb';
+      const runtimeDir = '/run/user/1000';
       await fs.file(portalPathForCopy).create(recursive: true);
-      await fs.directory(snapUserCommon).create(recursive: true);
+      await fs.directory(runtimeDir).create(recursive: true);
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
         documentsPortal: createUnknownMethodDocumentsPortal(
@@ -570,17 +570,33 @@ void main() {
         ),
         client: mockClient,
         fs: fs,
-        runtimeDir: snapUserCommon,
+        runtimeDir: runtimeDir,
       );
       await packageKit.activateService();
       final id = await packageKit.installLocal(portalPathForCopy);
-      verify(mockTransaction.installFiles([copyPath])).called(1);
-      expect(fs.file(copyPath).existsSync(), isTrue);
+      verify(
+        mockTransaction.installFiles(
+          argThat(
+            predicate<List<String>>(
+              (paths) =>
+                  paths.length == 1 &&
+                  paths.first.startsWith('$runtimeDir/packagekit-') &&
+                  paths.first.endsWith('test-package_1.0_amd64.deb'),
+            ),
+          ),
+        ),
+      ).called(1);
+      final tempDir = fs
+          .directory(runtimeDir)
+          .listSync()
+          .whereType<Directory>()
+          .firstWhere((d) => d.basename.startsWith('packagekit-'));
+      expect(tempDir.existsSync(), isTrue);
       completer.complete();
       await packageKit.waitTransaction(id);
       // Give onDone callback a chance to run
       await Future<void>.delayed(Duration.zero);
-      expect(fs.file(copyPath).existsSync(), isFalse);
+      expect(tempDir.existsSync(), isFalse);
     });
   });
 

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -15,6 +15,8 @@ const _dBusName = 'org.freedesktop.DBus';
 const _dBusInterface = 'org.freedesktop.DBus';
 const _dBusObjectPath = '/org/freedesktop/DBus';
 const _packageKitDBusName = 'org.freedesktop.PackageKit';
+const _documentsPortalName = 'org.freedesktop.portal.Documents';
+const _documentsPortalPath = '/org/freedesktop/portal/documents';
 
 void main() {
   group('activate service', () {
@@ -468,6 +470,96 @@ void main() {
     expect(packages.length, equals(2));
   });
 
+  group('portal path resolution', () {
+    const portalPath =
+        '/run/user/1000/doc/8cf4b075/balena-etcher_2.1.0_amd64.deb';
+    const realPath = '/home/user/Downloads/balena-etcher_2.1.0_amd64.deb';
+
+    test('install local package via portal path', () async {
+      final completer = Completer();
+      final mockTransaction = createMockPackageKitTransaction(
+        start: completer.future,
+      );
+      final mockClient =
+          createMockPackageKitClient(transaction: mockTransaction);
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        sessionDbus: createMockSessionDbus(
+          docId: '8cf4b075',
+          realPath: realPath,
+        ),
+        client: mockClient,
+        fs: MemoryFileSystem.test(),
+      );
+      await packageKit.activateService();
+      final id = await packageKit.installLocal(portalPath);
+      verify(mockTransaction.installFiles([realPath])).called(1);
+      completer.complete();
+      await packageKit.waitTransaction(id);
+    });
+
+    test('get details of local package via portal path', () async {
+      final mockDetails = PackageKitPackageDetails(
+        packageId: const PackageKitPackageId(
+          name: 'balena-etcher',
+          version: '2.1.0',
+          arch: 'amd64',
+        ),
+        summary: 'summary',
+      );
+      final mockTransaction = createMockPackageKitTransaction(
+        events: [mockDetails],
+      );
+      final mockClient =
+          createMockPackageKitClient(transaction: mockTransaction);
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        sessionDbus: createMockSessionDbus(
+          docId: '8cf4b075',
+          realPath: realPath,
+        ),
+        client: mockClient,
+        fs: MemoryFileSystem.test(),
+      );
+      await packageKit.activateService();
+      final details = await packageKit.getDetailsLocal(portalPath);
+      verify(mockTransaction.getDetailsLocal([realPath])).called(1);
+      expect(details, equals(mockDetails));
+    });
+
+    test('falls back to original path when portal call fails', () async {
+      final completer = Completer();
+      final mockTransaction = createMockPackageKitTransaction(
+        start: completer.future,
+      );
+      final mockClient =
+          createMockPackageKitClient(transaction: mockTransaction);
+      final failingSessionDbus = MockDBusClient();
+      when(
+        failingSessionDbus.callMethod(
+          path: DBusObjectPath(_documentsPortalPath),
+          destination: _documentsPortalName,
+          name: 'GetHostPaths',
+          interface: _documentsPortalName,
+          values: [
+            DBusArray.string(['8cf4b075']),
+          ],
+        ),
+      ).thenThrow(Exception('portal unavailable'));
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        sessionDbus: failingSessionDbus,
+        client: mockClient,
+        fs: MemoryFileSystem.test(),
+      );
+      await packageKit.activateService();
+      final id = await packageKit.installLocal(portalPath);
+      verify(mockTransaction.installFiles([portalPath])).called(1);
+      completer.complete();
+      await packageKit.waitTransaction(id);
+    });
+  });
+
   test('getUpdates', () async {
     const fooUpdate = PackageKitPackageEvent(
       info: PackageKitInfo.normal,
@@ -512,5 +604,34 @@ MockDBusClient createMockDbusClient() {
       values: const [DBusString(_packageKitDBusName), DBusUint32(0)],
     ),
   ).thenAnswer((_) async => DBusMethodSuccessResponse());
+  return dbus;
+}
+
+MockDBusClient createMockSessionDbus({
+  required String docId,
+  required String realPath,
+}) {
+  final dbus = MockDBusClient();
+  when(
+    dbus.callMethod(
+      path: DBusObjectPath(_documentsPortalPath),
+      destination: _documentsPortalName,
+      name: 'GetHostPaths',
+      interface: _documentsPortalName,
+      values: [
+        DBusArray.string([docId]),
+      ],
+    ),
+  ).thenAnswer(
+    (_) async => DBusMethodSuccessResponse([
+      DBusDict(
+        DBusSignature('s'),
+        DBusSignature('ay'),
+        {
+          DBusString(docId): DBusArray.byte([...realPath.codeUnits, 0]),
+        },
+      ),
+    ]),
+  );
   return dbus;
 }

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -471,8 +471,7 @@ void main() {
   });
 
   group('portal path resolution', () {
-    const portalPath =
-        '/run/user/1000/doc/8cf4b075/test-package_1.0_amd64.deb';
+    const portalPath = '/run/user/1000/doc/8cf4b075/test-package_1.0_amd64.deb';
     const realPath = '/home/user/Downloads/test-package_1.0_amd64.deb';
 
     test('install local package via portal path', () async {
@@ -527,7 +526,7 @@ void main() {
       expect(details, equals(mockDetails));
     });
 
-    test('falls back to original path when portal call fails', () async {
+    test('falls back to absolute path when portal is unavailable', () async {
       final completer = Completer();
       final mockTransaction = createMockPackageKitTransaction(
         start: completer.future,
@@ -536,12 +535,14 @@ void main() {
           createMockPackageKitClient(transaction: mockTransaction);
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
-        documentsPortal: createFailingDocumentsPortal(docId: '8cf4b075'),
+        documentsPortal: createUnavailableDocumentsPortal(),
         client: mockClient,
         fs: MemoryFileSystem.test(),
       );
       await packageKit.activateService();
       final id = await packageKit.installLocal(portalPath);
+      // _isPortalPath returns false when getMountPoint fails, so the raw path
+      // is passed through _getAbsolutePath (which equals portalPath on MemoryFS)
       verify(mockTransaction.installFiles([portalPath])).called(1);
       completer.complete();
       await packageKit.waitTransaction(id);
@@ -645,15 +646,9 @@ MockXdgDocumentsPortal createMockDocumentsPortal({
   return portal;
 }
 
-MockXdgDocumentsPortal createFailingDocumentsPortal({
-  required String docId,
-  String mountPoint = '/run/user/1000/doc',
-}) {
+MockXdgDocumentsPortal createUnavailableDocumentsPortal() {
   final portal = MockXdgDocumentsPortal();
-  when(portal.getMountPoint()).thenAnswer(
-    (_) async => io.Directory(mountPoint),
-  );
-  when(portal.getHostPaths([docId])).thenThrow(Exception('portal unavailable'));
+  when(portal.getMountPoint()).thenThrow(Exception('portal unavailable'));
   return portal;
 }
 

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -536,7 +536,7 @@ void main() {
           createMockPackageKitClient(transaction: mockTransaction);
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
-        documentsPortal: createUnavailableDocumentsPortal(),
+        documentsPortal: createMockDocumentsPortal(portalUnavailable: true),
         client: mockClient,
         fs: MemoryFileSystem.test(),
       );
@@ -565,8 +565,9 @@ void main() {
       await fs.directory(runtimeDir).create(recursive: true);
       final packageKit = PackageKitService(
         dbus: createMockDbusClient(),
-        documentsPortal: createUnknownMethodDocumentsPortal(
+        documentsPortal: createMockDocumentsPortal(
           docId: '8cf4b075',
+          getHostPathsUnknown: true,
         ),
         client: mockClient,
         fs: fs,
@@ -648,36 +649,28 @@ MockDBusClient createMockDbusClient() {
 }
 
 MockXdgDocumentsPortal createMockDocumentsPortal({
-  required String docId,
-  required String realPath,
+  String? docId,
+  String? realPath,
   String mountPoint = '/run/user/1000/doc',
+  bool portalUnavailable = false,
+  bool getHostPathsUnknown = false,
 }) {
   final portal = MockXdgDocumentsPortal();
-  when(portal.getMountPoint()).thenAnswer(
-    (_) async => io.Directory(mountPoint),
-  );
-  when(portal.getHostPaths([docId])).thenAnswer(
-    (_) async => {docId: io.File(realPath)},
-  );
-  return portal;
-}
-
-MockXdgDocumentsPortal createUnavailableDocumentsPortal() {
-  final portal = MockXdgDocumentsPortal();
-  when(portal.getMountPoint()).thenThrow(Exception('portal unavailable'));
-  return portal;
-}
-
-MockXdgDocumentsPortal createUnknownMethodDocumentsPortal({
-  required String docId,
-  String mountPoint = '/run/user/1000/doc',
-}) {
-  final portal = MockXdgDocumentsPortal();
-  when(portal.getMountPoint()).thenAnswer(
-    (_) async => io.Directory(mountPoint),
-  );
-  when(portal.getHostPaths([docId])).thenThrow(
-    DBusUnknownMethodException(DBusMethodErrorResponse.unknownMethod()),
-  );
+  if (portalUnavailable) {
+    when(portal.getMountPoint()).thenThrow(Exception('portal unavailable'));
+  } else {
+    when(portal.getMountPoint()).thenAnswer(
+      (_) async => io.Directory(mountPoint),
+    );
+    if (getHostPathsUnknown) {
+      when(portal.getHostPaths([docId!])).thenThrow(
+        DBusUnknownMethodException(DBusMethodErrorResponse.unknownMethod()),
+      );
+    } else {
+      when(portal.getHostPaths([docId!])).thenAnswer(
+        (_) async => {docId: io.File(realPath!)},
+      );
+    }
+  }
   return portal;
 }

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:app_center/packagekit/packagekit_service.dart';
 import 'package:dbus/dbus.dart';
@@ -598,18 +598,26 @@ MockDBusClient createMockDbusClient() {
 MockXdgDocumentsPortal createMockDocumentsPortal({
   required String docId,
   required String realPath,
+  String mountPoint = '/run/user/1000/doc',
 }) {
   final portal = MockXdgDocumentsPortal();
+  when(portal.getMountPoint()).thenAnswer(
+    (_) async => io.Directory(mountPoint),
+  );
   when(portal.getHostPaths([docId])).thenAnswer(
-    (_) async => {docId: File(realPath)},
+    (_) async => {docId: io.File(realPath)},
   );
   return portal;
 }
 
 MockXdgDocumentsPortal createFailingDocumentsPortal({
   required String docId,
+  String mountPoint = '/run/user/1000/doc',
 }) {
   final portal = MockXdgDocumentsPortal();
+  when(portal.getMountPoint()).thenAnswer(
+    (_) async => io.Directory(mountPoint),
+  );
   when(portal.getHostPaths([docId])).thenThrow(Exception('portal unavailable'));
   return portal;
 }


### PR DESCRIPTION
Adds document path resolution for FUSE paths using the `GetHostPaths` API on the `org.freedesktop.portal.Documents` session bus endpoint. Falls back to the provided path if that call fails.

I've manually tested opening a local deb and installing it via the app center on both 24.04.4 and 26.04