### PR TITLE
Show download progress percentage in active change status

### DIFF
--- a/packages/app_center/lib/widgets/active_change_content.dart
+++ b/packages/app_center/lib/widgets/active_change_content.dart
@@ -43,6 +43,7 @@ class _ActiveChangeText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final percentage = (progress * 100).toStringAsFixed(0);
     return Row(
       children: [
         SizedBox.square(
@@ -54,11 +55,21 @@ class _ActiveChangeText extends StatelessWidget {
         ),
         if (label != null) ...[
           const SizedBox(width: kSpacingSmall),
-          Text(
-            label!,
-            style: Theme.of(context).textTheme.bodyMedium,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label!,
+                style: Theme.of(context).textTheme.bodyMedium,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              Text(
+                '$percentage%',
+                style: Theme.of(context).textTheme.bodySmall,
+                maxLines: 1,
+              ),
+            ],
           ),
         ],
       ],


### PR DESCRIPTION
Currently the active change status shows only the action label (e.g. "Installing", "Uninstalling") with no progress percentage.

This change displays the percentage below the label so users can see how far along the operation is.

Works for all action labels since `actionLabel` is passed dynamically - nothing is hardcoded.

Percentage is shown below the label using a `Column` rather than inline, because the parent Row has a constrained width. Appending the percentage inline (e.g. "Uninstalling 45%") causes a `RenderFlex` right overflow. Stacking them vertically with a `Column` fixes the overflow while keeping both pieces of information visible.

## Screenshots

**Before:**

<img width="284" height="84" alt="old" src="https://github.com/user-attachments/assets/af90a1ca-d6f0-468b-a43e-1587d6a01c7e" />

<img width="342" height="100" alt="old_uninstall" src="https://github.com/user-attachments/assets/0569e150-e329-4957-93be-808dcc513f82" />



**After:**

<img width="284" height="84" alt="new" src="https://github.com/user-attachments/assets/ef9e37f0-ab57-4d9f-8cc0-67f8f1678ad8" />

<img width="342" height="100" alt="new_uninstall" src="https://github.com/user-attachments/assets/d87a46a8-e4a8-4407-b91d-5ed541d5083a" />




