### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,15 +2,12 @@ name: Bug report for the App Center
 description: Report an issue to help the development
 labels:
   - bug
-assignees:
-  - d-loose
-  - matthew-hagemann
 body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please check whether an issue already exists for this feature: https://github.com/canonical/app-center/issues.
+      Please check whether an issue already exists for this bug: https://github.com/canonical/app-center/issues.
     options:
     - label: I have searched the existing issues and found none matching what I'm reporting.
       required: true
@@ -39,25 +36,10 @@ body:
       A clear and concise description of what you expected to happen.
   validations:
     required: false
-- type: dropdown
+- type: input
   attributes:
     label: Ubuntu release
-    description: What version of our Ubuntu are you running?
-    options:
-      - '24.10'
-      - 24.04 LTS
-      - Other (specify in the last field)
-  validations:
-    required: false
-- type: dropdown
-  attributes:
-    label: What architecture are you using?
-    multiple: false
-    options:
-      - amd64
-      - arm64
-      - Other (specify in the last field)
-      - I don't know
+    description: What version of Ubuntu are you running? E.g. '26.04 LTS'. You can find it in Settings > About, or by running `lsb_release -d` in the terminal.
   validations:
     required: false
 - type: textarea
@@ -65,7 +47,7 @@ body:
     label: System info
     description: |
       Please run this command in your terminal:
-      ```uname -rv && snap info snap-store snapd```
+      ```uname -rvm && snap info snap-store snapd```
       and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,9 +2,6 @@ name: Feature request
 description: Suggest an idea for the App Center
 labels:
   - enhancement
-assignees:
-  - d-loose
-  - matthew-hagemann
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
- Remove auto-assignees from all templates
- Fix duplicate-check description: 'for this feature' → 'for this bug' in the bug report
- Replace the Ubuntu release dropdown with a free-text input field, updated with a helpful description and example
- Remove the architecture dropdown (covered by the System info command output)

UDENG-10151