### PR TITLE
a11y: Featured snaps icons should have identifying labels

### DIFF
--- a/packages/app_center/lib/widgets/banner.dart
+++ b/packages/app_center/lib/widgets/banner.dart
@@ -220,9 +220,13 @@ class _BannerIconState extends State<_BannerIcon> {
                     ),
                   ],
                 ),
-                child: AppIcon(
-                  iconUrl: widget.snap.iconUrl,
-                  size: widget.iconSize.height * scale,
+                child: Semantics(
+                  label: widget.snap.titleOrName,
+                  button: true,
+                  child: AppIcon(
+                    iconUrl: widget.snap.iconUrl,
+                    size: widget.iconSize.height * scale,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Screen readers only say "Image" when we tab over the icons in the featured snaps banner. Users that depend on screen readers cannot really know which apps are those.

With the snap name or title as labels those images become immediately more understandable.