### PR TITLE
Update CONTRIBUTING.md for smoother first-time setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,16 +70,17 @@ Translations are managed using [Weblate](https://hosted.weblate.org/projects/ubu
 
 ### Required dependencies
 
-[Install Flutter](https://flutter.dev/docs/get-started/install/linux) - the currently used version is specified in `.fvmrc`. If you're using [fvm](https://fvm.app) to manage your Flutter SDK, you can simply run `fvm install` to install the required version.
+[Install Flutter](https://flutter.dev/docs/get-started/install/linux) and the [Flutter Linux prerequisites](https://docs.flutter.dev/get-started/install/linux#linux-prerequisites).
 
-Install the [Flutter Linux prerequisites](https://docs.flutter.dev/get-started/install/linux#linux-prerequisites)
+This project uses [fvm](https://fvm.app) to manage Flutter SDK versions. Install fvm (you can also install it from the scripts directory in the repository):
 
-We provide a [Melos](https://docs.page/invertase/melos) configuration to make it straightforward to execute common tasks.
-
-Install fvm (you can also install it from the scripts directory in the repository):
 ```
 curl -fsSL https://fvm.app/install.sh | bash
 ```
+
+You can then run `fvm install` to install the required Flutter SDK version as specified in `.fvmrc`. This might seem redundant because installing Flutter was the first step above, but [the fvm documentation recommends installing one global Flutter SDK in addition to project-specific SDKs](https://fvm.app/documentation/getting-started/installation#recommendation).
+
+We provide a [Melos](https://docs.page/invertase/melos) configuration to make it straightforward to execute common tasks.
 
 Install Melos:
 ```
@@ -88,19 +89,24 @@ dart pub global activate melos
 
 Bootstrap the monorepo:
 ```
+# Bootstrap the monorepo (links local packages, runs pub get)
 melos bootstrap
+
+# Generate code (mocks, freezed, JSON serialization)
+melos generate
 ```
 
 `melos bootstrap` connects all the local packages/apps to each other with the help of `pubspec_overrides.yaml` files, and it also runs `pub get` in all packages/apps.
 
 ### Building and running the binaries
 
-You can run the application with
+You can run the application with:
 ```
+cd packages/app_center
 fvm flutter run
 ```
 
-and build a release version with
+Build a release version with:
 ```
 melos build
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,7 @@ dart pub global activate melos
 
 Bootstrap the monorepo:
 ```
-# Bootstrap the monorepo (links local packages, runs pub get)
 melos bootstrap
-
-# Generate code (mocks, freezed, JSON serialization)
 melos generate
 ```
 
@@ -100,13 +97,13 @@ melos generate
 
 ### Building and running the binaries
 
-You can run the application with:
+You can run the application with
 ```
 cd packages/app_center
 fvm flutter run
 ```
 
-Build a release version with:
+and build a release version with
 ```
 melos build
 ```


### PR DESCRIPTION
Hi there, I have previously developed Flutter apps on macOS and recently set up a laptop with Ubuntu 26.04 for tinkering. I wanted to send a quick patch to this repo but it took me longer than expected to run the app for the first time:

* The docs make it sound as if fvm was optional ("If you're using fvm...") but the Melos configuration relies on it. So, I uninstalled the Flutter snap and installed fvm.
* But then `part pub global activate melos` does not work without further prefixes...TIL that fvm recommends users to use fvm _in addition_ to a global Flutter installation. (It's my first time using fvm.)
* `melos generate` seems necessary (?) in addition to `melos bootstrap`.
* Running the project from the repo root is not possible, so I have added the `cd` command. 
* I saw that you @wathika-eng have appended `-d linux` in your commit https://github.com/wathika-eng/app-center/commit/00241695cd0cc1bb5f4421ddb82635f15fc28945#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055. That doesn't help but I took some inspiration from other parts of your commit.
* At this point I also ran into [/usr/local permission issues](https://github.com/flutter/flutter/issues/115376) that went away after a `flutter clean`. Not sure how to reproduce or prevent this.
* The tests still don't work but hey, GitHub can run them for me... :)

Maybe this will be useful for other drive-by contributors.