### PR TITLE
fix(a11y): Announce snackbar contents

### DIFF
--- a/packages/app_center/lib/deb/deb_page.dart
+++ b/packages/app_center/lib/deb/deb_page.dart
@@ -13,6 +13,7 @@ import 'package:app_center/providers/current_desktops_provider.dart';
 import 'package:app_center/store/store_app.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -90,6 +91,11 @@ class _DebView extends ConsumerWidget {
                     SnackBar(
                       content: Text(l10n.snapPageShareLinkCopiedMessage),
                     ),
+                  );
+                  SemanticsService.sendAnnouncement(
+                    View.of(navigationKey.currentContext!),
+                    l10n.snapPageShareLinkCopiedMessage,
+                    Directionality.of(navigationKey.currentContext!),
                   );
                   Clipboard.setData(
                     ClipboardData(text: debModel.component.website!),

--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -15,6 +15,7 @@ import 'package:app_center/snapd/snapd_cache.dart';
 import 'package:app_center/store/store_app.dart';
 import 'package:app_center/widgets/widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -398,6 +399,11 @@ class _IconRow extends ConsumerWidget {
                 SnackBar(
                   content: Text(l10n.snapPageShareLinkCopiedMessage),
                 ),
+              );
+              SemanticsService.sendAnnouncement(
+                View.of(navigationKey.currentContext!),
+                l10n.snapPageShareLinkCopiedMessage,
+                Directionality.of(navigationKey.currentContext!),
               );
               Clipboard.setData(ClipboardData(text: snapStoreUrl));
             },


### PR DESCRIPTION
Adds a `sendAnnouncement` on showing `SnackBar` widgets for screen reader users.

This might be something that Flutter should just do by default :thinking:.

---

UDENG-10299