### PR TITLE
docs(AGENTS.md): Update AGENTS.md to run tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,13 @@ In the snap, these are set to `ratings.ubuntu.com:443` with TLS on. See @snap/sn
 # Linting
 
 Uses `ubuntu_lints` — do not add a custom `analysis_options.yaml`.
+
+# Contribution Checklist
+
+Before finishing any code contribution, run the following and ensure all pass:
+
+```bash
+melos test
+melos analyze --fatal-infos
+melos format:exclude
+```


### PR DESCRIPTION
I find that agents often don't run tests to confirm changes, or they run "raw" `fvm flutter test` commands instead of the desired `melos` commands. I added a section to the AGENTS.md to confirm that `melos test`, `melos analyze`, and `melos format` pass when contributing code.