### PR TITLE
feat: Move About page as a nested page under new Settings page

### DIFF
--- a/packages/app_center/lib/settings/settings.dart
+++ b/packages/app_center/lib/settings/settings.dart
@@ -1,0 +1,1 @@
+export 'settings_page.dart';

--- a/packages/app_center/lib/settings/settings_page.dart
+++ b/packages/app_center/lib/settings/settings_page.dart
@@ -1,0 +1,37 @@
+import 'package:app_center/l10n.dart';
+import 'package:app_center/layout.dart';
+import 'package:app_center/store/store_navigator.dart';
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  static IconData icon(bool selected) =>
+      selected ? YaruIcons.settings_filled : YaruIcons.settings;
+  static String label(BuildContext context) =>
+      AppLocalizations.of(context).settingsPageLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return ResponsiveLayoutScrollView(
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.all(kPagePadding),
+          sliver: SliverToBoxAdapter(
+            child: YaruTileList(
+              children: [
+                YaruListTile.square(
+                  titleText: l10n.settingsPageAboutLabel,
+                  trailing: const Icon(YaruIcons.go_next),
+                  onTap: () => StoreNavigator.pushAbout(context),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -178,6 +178,8 @@
             }
         }
     },
+    "settingsPageLabel": "Settings",
+    "settingsPageAboutLabel": "About",
     "aboutPageLabel": "About",
     "aboutPageVersionLabel": "Version {version}",
     "@aboutPageVersionLabel": {

--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:app_center/about/about.dart';
 import 'package:app_center/deb/deb.dart';
 import 'package:app_center/error/error.dart';
 import 'package:app_center/games/games.dart';
@@ -170,6 +171,13 @@ class _StoreAppHome extends ConsumerWidget {
         ),
         breakpoint: 0, // always landscape
         onGenerateRoute: (settings) => switch (StoreRoutes.routeOf(settings)) {
+          StoreRoutes.about => MaterialPageRoute(
+            settings: settings,
+            builder: (_) => YaruDetailPage(
+              appBar: searchField,
+              body: const AboutPage(),
+            ),
+          ),
           StoreRoutes.deb => MaterialPageRoute(
             settings: settings,
             builder: (_) => YaruDetailPage(

--- a/packages/app_center/lib/store/store_navigator.dart
+++ b/packages/app_center/lib/store/store_navigator.dart
@@ -2,6 +2,10 @@ import 'package:app_center/store/store_routes.dart';
 import 'package:flutter/widgets.dart';
 
 class StoreNavigator {
+  static Future<void> pushAbout(BuildContext context) {
+    return Navigator.of(context).pushAbout();
+  }
+
   static Future<void> pushDeb(
     BuildContext context, {
     required String id,
@@ -50,6 +54,10 @@ class StoreNavigator {
 }
 
 extension StoreNavigatorState on NavigatorState {
+  Future<void> pushAbout() {
+    return pushNamed(StoreRoutes.about);
+  }
+
   Future<void> pushDeb({required String id}) {
     return pushNamed(StoreRoutes.namedDeb(id: id));
   }

--- a/packages/app_center/lib/store/store_pages.dart
+++ b/packages/app_center/lib/store/store_pages.dart
@@ -1,4 +1,3 @@
-import 'package:app_center/about/about.dart';
 import 'package:app_center/explore/explore.dart';
 import 'package:app_center/games/games.dart';
 import 'package:app_center/l10n.dart';
@@ -6,6 +5,7 @@ import 'package:app_center/manage/local_deb_updates_model.dart';
 import 'package:app_center/manage/manage.dart';
 import 'package:app_center/manage/snap_updates_model.dart';
 import 'package:app_center/search/search.dart';
+import 'package:app_center/settings/settings.dart';
 import 'package:app_center/snapd/snapd.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -129,12 +129,12 @@ final pages = <StorePage>[
   ),
   (
     tileBuilder: (context, selected) => _NavigationTile(
-      leading: Icon(AboutPage.icon(selected)),
-      title: Text(AboutPage.label(context)),
+      leading: Icon(SettingsPage.icon(selected)),
+      title: Text(SettingsPage.label(context)),
     ),
     pageBuilder: (_, title) => YaruDetailPage(
       appBar: title,
-      body: const AboutPage(),
+      body: const SettingsPage(),
     ),
   ),
 ];

--- a/packages/app_center/lib/store/store_routes.dart
+++ b/packages/app_center/lib/store/store_routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 
 abstract class StoreRoutes {
   static const explore = '/explore';
+  static const about = '/about';
   static const deb = '/deb';
   static const localDeb = '/local-deb';
   static const snap = '/snap';


### PR DESCRIPTION
This is to make way for future functionality that may live in the new Settings page. The About page isn't particularly important, so we move it to a subpage of the Settings page.

---

UDENG-10906