### PR TITLE
chore: Add melos start command

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -78,6 +78,11 @@ scripts:
   # run pub upgrade in all packages
   upgrade: melos pub upgrade
 
+  # run the app in dev mode
+  start: >
+    melos exec -c 1 --flutter --scope=app_center -- \
+      fvm flutter run "$@"
+
   # generate protobuf files in app_center_ratings_client
   protoc:
     run: |


### PR DESCRIPTION
Adds a `melos start` command to more easily bring up the dev UI without needing to `cd` around or know what commands you need to run.

Would probably be nice to add this in more places, if approved.