### PR TITLE
chore: send snap id instead of title

### DIFF
--- a/packages/app_center/lib/snapd/snap_page.dart
+++ b/packages/app_center/lib/snapd/snap_page.dart
@@ -418,8 +418,10 @@ class _IconRow extends ConsumerWidget {
               context: context,
               builder: (context) {
                 return ResponsiveLayoutBuilder(
-                  builder: (context) =>
-                      SnapReport(name: snapData.snap.titleOrName),
+                  builder: (context) => SnapReport(
+                    name: snapData.snap.titleOrName,
+                    snapName: snapData.snap.name,
+                  ),
                 );
               },
             );

--- a/packages/app_center/lib/snapd/snap_report.dart
+++ b/packages/app_center/lib/snapd/snap_report.dart
@@ -7,9 +7,11 @@ import 'package:http/http.dart' as http;
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 class SnapReport extends StatefulWidget {
-  const SnapReport({required this.name, super.key});
+  const SnapReport({required this.name, required this.snapName, super.key});
 
   final String name;
+
+  final String snapName;
 
   @override
   State<SnapReport> createState() => _SnapReportState();
@@ -194,7 +196,7 @@ class _SnapReportState extends State<SnapReport> {
                         'Content-Type': 'application/x-www-form-urlencoded',
                       };
                       final requestBody = <String, String>{
-                        'entry.1703677219': widget.name.toLowerCase(),
+                        'entry.1703677219': widget.snapName,
                         'entry.1193754313': selectedReason!,
                         'entry.1170971435': _detailsController.text,
                         'entry.1424146082': _emailController.text,


### PR DESCRIPTION
Send the snap id instead of title, this will allow us to find the reported snap more easily in the reports sheet.