### PR TITLE
fix(manage): stop rebuilding the installed apps list twice per keystroke

### DIFF
--- a/packages/app_center/lib/manage/app_providers.dart
+++ b/packages/app_center/lib/manage/app_providers.dart
@@ -95,7 +95,6 @@ class InstalledApps extends _$InstalledApps {
 
     void refreshFunction(_, __) => _applyFilters();
     ref.listen(localSnapFilterProvider, refreshFunction);
-    ref.listen(localDebFilterProvider, refreshFunction);
     ref.listen(showLocalSystemAppsProvider, refreshFunction);
     ref.listen(appSortOrderProvider, refreshFunction);
     ref.listen(packageTypeFilterProvider, refreshFunction);

--- a/packages/app_center/lib/manage/local_deb_providers.dart
+++ b/packages/app_center/lib/manage/local_deb_providers.dart
@@ -64,9 +64,6 @@ class LocalDebInfo with _$LocalDebInfo {
   }
 }
 
-final localDebFilterProvider = StateProvider.autoDispose<String>((_) => '');
-final showLocalSystemDebsProvider = StateProvider<bool>((_) => false);
-
 /// Returns all installed packages from PackageKit.
 @riverpod
 Future<List<PackageKitPackageEvent>> installedPackages(Ref ref) async {

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -5,7 +5,6 @@ import 'package:app_center/error/error.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/manage/app_providers.dart';
-import 'package:app_center/manage/local_deb_providers.dart';
 import 'package:app_center/manage/local_deb_updates_model.dart';
 import 'package:app_center/manage/local_snap_providers.dart';
 import 'package:app_center/manage/manage_app_data.dart';
@@ -576,7 +575,6 @@ class _DebouncedSearchFieldState extends ConsumerState<_DebouncedSearchField> {
     _debounce?.cancel();
     _debounce = Timer(const Duration(milliseconds: 200), () {
       ref.read(localSnapFilterProvider.notifier).state = value;
-      ref.read(localDebFilterProvider.notifier).state = value;
     });
   }
 


### PR DESCRIPTION
Closes #2069, though not as that issue describes it, see below.
`_onSearchChanged` writes the search text to both `localSnapFilterProvider` and `localDebFilterProvider`, and `InstalledApps.build` listens to both. But `_applyFilters` only ever reads the snap one:

```dart
final filter = ref.read(localSnapFilterProvider).toLowerCase();
final showSystemApps = ref.read(showLocalSystemAppsProvider);
final sortOrder = ref.read(appSortOrderProvider);
final packageType = ref.read(packageTypeFilterProvider);
```

So the second write re-runs the filter and pushes a fresh `AsyncData` holding a list identical to the one already in state. A full rebuild of the installed apps list, once per keystroke, for nothing.

`localDebFilterProvider` turns out to be written and listened to but never read anywhere in the tree, so removing it and its listener drops the redundant rebuild at the source rather than filtering it out afterwards. `showLocalSystemDebsProvider`, declared on the next line, is never referenced at all. I removed it in the same pass since it is the same leftover. Both look like remnants from when snaps and debs had separate lists.

No test accompanies this: what it removes is unreachable, and the analyzer passing with the declarations gone is the check that nothing used them.

### On the issue

#2069 describes this as a listener loop that can spin forever. That loop doesn't exist, `_applyFilters` only writes `InstalledApps`' own state, nothing writes back into the filter providers, and the search field already debounces at 200 ms. The real cost was the duplicate rebuild above. Happy to close #2069 as invalid instead if you would rather keep the two separate.

### One question

Was the deb filter meant to be read at some point, a separate search box for debs, say? Nothing in the tree suggests it, and today a single field writes the same value to both, so it is redundant either way. But you would know the intent better than I do; if it is a placeholder for planned work, say so and I will drop that part and only remove the listener.
