### PR TITLE
fix(appstream): bound the metadata load with a timeout

### DIFF
--- a/packages/app_center/lib/appstream/appstream_service.dart
+++ b/packages/app_center/lib/appstream/appstream_service.dart
@@ -137,19 +137,42 @@ class _ScoredComponent {
 
 class AppstreamService {
   // TODO: cache AppstreamPool
-  AppstreamService({@visibleForTesting AppstreamPool? pool})
-    : _pool = pool ?? AppstreamPool(),
-      _l10n = _loadL10n() {
+  AppstreamService({
+    @visibleForTesting AppstreamPool? pool,
+    @visibleForTesting this._loadTimeout = _defaultLoadTimeout,
+  }) : _pool = pool ?? AppstreamPool(),
+       _l10n = _loadL10n() {
     PlatformDispatcher.instance.onLocaleChanged = () async {
       await _loader;
       _populateCache();
     };
   }
+
+  /// A catalog load that never returns must not be able to wedge the app.
+  /// Parsing happens in isolates the pool spawns, so a parse that neither
+  /// completes nor throws leaves `load()` pending and everything waiting on
+  /// the metadata waits with it — the manage page sits on a spinner with
+  /// nothing in the log to explain it.
+  ///
+  /// canonical/appstream.dart#44 fixed the case that caused this in practice,
+  /// a catalog entry the parser rejects. The cap stays as a backstop so that
+  /// any other way the load gets stuck fails visibly instead of silently.
+  static const _defaultLoadTimeout = Duration(seconds: 60);
+
   final AppstreamPool _pool;
-  late final Future<void> _loader = _pool.load().then((_) {
+  final Duration _loadTimeout;
+  late final Future<void> _loader = _load();
+
+  Future<void> _load() async {
+    try {
+      await _pool.load().timeout(_loadTimeout);
+    } on Object catch (error, stackTrace) {
+      log.error('Failed to load AppStream metadata', error, stackTrace);
+      rethrow;
+    }
     _populateCache();
     _initialized = true;
-  });
+  }
 
   bool get initialized => _initialized;
   bool _initialized = false;

--- a/packages/app_center/lib/main.dart
+++ b/packages/app_center/lib/main.dart
@@ -61,8 +61,10 @@ Future<void> main(List<String> args) async {
 
   final appstream = AppstreamService();
   // Explicitly ignore the future to continue while appstream is reading the
-  // metadata from the disk.
-  unawaited(appstream.init());
+  // metadata from the disk. A failure is already logged by the service and
+  // resurfaces on whichever page actually needs the metadata, so swallow it
+  // here rather than let this fire-and-forget call report it as unhandled.
+  unawaited(appstream.init().catchError((_) {}));
   registerServiceInstance(appstream);
 
   registerService(PackageKitClient.new);

--- a/packages/app_center/test/appstream_service_test.dart
+++ b/packages/app_center/test/appstream_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_center/appstream/appstream.dart';
 import 'package:appstream/appstream.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,6 +73,19 @@ void main() {
     components.add(component1);
     await service.init();
     expect(service.cacheSize, 1);
+  });
+
+  test('load that never completes times out', () async {
+    // A catalog entry the parser can't handle kills the isolate the pool
+    // spawned, and `load()` is then left pending forever.
+    when(pool.load()).thenAnswer((_) => Completer<void>().future);
+    service = AppstreamService(
+      pool: pool,
+      loadTimeout: const Duration(milliseconds: 50),
+    );
+
+    await expectLater(service.init(), throwsA(isA<TimeoutException>()));
+    expect(service.initialized, isFalse);
   });
 
   test('search', () async {


### PR DESCRIPTION
Related to #2139 and #2142, but deliberately not "Fixes" either of them.

Metadata parsing happens in isolates the pool spawns, so a parse that neither completes nor throws leaves `load()` pending forever. Everything waiting on the metadata waits with it: `componentsByPackage` → `localDebs` → `installedApps`/`appUpdates` all stay in loading, and the manage page sits on a spinner with nothing in the log to explain it. Traced on 26.04: PackageKit logs `get-packages` succeeding, and then no further call is ever made, because the chain stalls at the AppStream step.

This caps the load at 60 s and logs the failure, so pages that need the metadata surface an error with a retry instead of hanging. 60 s is deliberately generous — a real catalog here loads in 3.4 s.

### Scope: what this is and isn't

The catalog entry causing this in practice is a `snapshot` release type the `appstream` package didn't know about. That is fixed at the root in canonical/appstream.dart#44, and #2156 already ships it by pinning the dependency to that commit — released 7 August as revision 1390 on `2/stable`. So #2139 and #2142 are fixed in practice today; what remains there is swapping the git ref for a normal constraint once 0.2.11 reaches pub.dev.

#2153 covers the other axis: per-file resilience, so a single unparseable catalog costs one component instead of all the metadata. That is a better outcome than this PR gives on its own, and the two don't conflict.

What this adds that neither of those does is a bound on the failure mode itself. Both of them work by turning a bad parse into an error — which only helps when the parse actually fails. A parse that hangs without throwing, or an isolate that dies outside the handler, still leaves `load()` pending forever. The cap is the only thing that makes that visible.

Happy to close this if you would rather carry the other two alone.
