### PR TITLE
fix: prevent AppstreamPool.load() from hanging on malformed catalog files

### DIFF
--- a/packages/app_center/lib/appstream/appstream.dart
+++ b/packages/app_center/lib/appstream/appstream.dart
@@ -1,3 +1,4 @@
 export 'appstream_search.dart';
 export 'appstream_service.dart';
 export 'appstream_utils.dart';
+export 'resilient_appstream_pool.dart';

--- a/packages/app_center/lib/appstream/appstream_service.dart
+++ b/packages/app_center/lib/appstream/appstream_service.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:app_center/appstream/appstream_utils.dart';
 import 'package:app_center/appstream/logger.dart';
+import 'package:app_center/appstream/resilient_appstream_pool.dart';
 import 'package:app_center/l10n.dart';
 import 'package:appstream/appstream.dart';
 import 'package:collection/collection.dart';
@@ -138,7 +139,7 @@ class _ScoredComponent {
 class AppstreamService {
   // TODO: cache AppstreamPool
   AppstreamService({@visibleForTesting AppstreamPool? pool})
-    : _pool = pool ?? AppstreamPool(),
+    : _pool = pool ?? ResilientAppstreamPool(),
       _l10n = _loadL10n() {
     PlatformDispatcher.instance.onLocaleChanged = () async {
       await _loader;

--- a/packages/app_center/lib/appstream/resilient_appstream_pool.dart
+++ b/packages/app_center/lib/appstream/resilient_appstream_pool.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:app_center/appstream/logger.dart';
+import 'package:appstream/appstream.dart';
+
+/// The system directories that may contain AppStream catalog metadata, in
+/// the same order as used by [AppstreamPool].
+const _defaultCatalogDirPrefixes = ['/usr/share', '/var/lib', '/var/cache'];
+
+class _LoadArgs {
+  const _LoadArgs(this.port, this.path);
+  final SendPort port;
+  final String path;
+}
+
+/// An [AppstreamPool] that tolerates malformed catalog files.
+///
+/// [AppstreamPool.load] spawns one isolate per catalog file and waits for
+/// all of them via `Future.wait`. If a single file fails to parse (for
+/// example because it uses a release `type` that the `appstream` package
+/// doesn't recognize, such as `snapshot`), the isolate throws an unhandled
+/// exception and dies without ever responding on its `ReceivePort`. Since
+/// nothing ever arrives on that port, `Future.wait` never completes, which
+/// means the whole application silently loses all AppStream metadata:
+/// search, categories, and snap/deb detail pages hang forever waiting on
+/// [AppstreamPool.load] (see #2142).
+///
+/// This subclass re-implements the same directory scanning/parsing logic,
+/// but catches parsing errors on a per-file basis, so a single malformed
+/// catalog file is skipped (and logged) instead of blocking every other
+/// file from loading.
+class ResilientAppstreamPool extends AppstreamPool {
+  ResilientAppstreamPool({
+    this.catalogDirPrefixes = _defaultCatalogDirPrefixes,
+  });
+
+  final List<String> catalogDirPrefixes;
+
+  @override
+  Future<void> load() async {
+    final catalogDirs = <String>[];
+    for (final prefix in catalogDirPrefixes) {
+      final catalogPath = '$prefix/swcatalog';
+      final catalogLegacyPath = '$prefix/app-info';
+
+      // Only use the legacy path if it's not a symlink to the current path.
+      final legacyLink = Link(catalogLegacyPath);
+      final ignoreLegacyPath =
+          await legacyLink.exists() && await legacyLink.target() == catalogPath;
+
+      catalogDirs.add(catalogPath);
+      if (!ignoreLegacyPath) {
+        catalogDirs.add(catalogLegacyPath);
+      }
+    }
+
+    final collectionFutures = <Future<AppstreamCollection?>>[];
+    for (final dir in catalogDirs) {
+      for (final path in await _listFiles(dir)) {
+        collectionFutures.add(_loadCollection(_loadXmlInIsolate, path));
+      }
+      for (final path in await _listFiles('$dir/yaml')) {
+        collectionFutures.add(_loadCollection(_loadYamlInIsolate, path));
+      }
+    }
+
+    final collections = await Future.wait(collectionFutures);
+    for (final collection in collections) {
+      if (collection != null) {
+        components.addAll(collection.components);
+      }
+    }
+  }
+
+  static Future<List<String>> _listFiles(String path) async {
+    final dir = Directory(path);
+    try {
+      return await dir
+          .list()
+          .where((e) => e is File)
+          .map((e) => e.path)
+          .toList();
+    } on FileSystemException {
+      return [];
+    }
+  }
+
+  static Future<AppstreamCollection?> _loadCollection(
+    void Function(_LoadArgs args) entryPoint,
+    String path,
+  ) async {
+    final port = ReceivePort();
+    final isolate = await Isolate.spawn<_LoadArgs>(
+      entryPoint,
+      _LoadArgs(port.sendPort, path),
+    );
+    final result = await port.first;
+    isolate.kill(priority: Isolate.immediate);
+    port.close();
+    if (result is AppstreamCollection) {
+      return result;
+    }
+    log.warning('Failed to load AppStream catalog "$path": $result');
+    return null;
+  }
+
+  static void _loadXmlInIsolate(_LoadArgs args) =>
+      _parseInIsolate(args, AppstreamCollection.fromXml);
+
+  static void _loadYamlInIsolate(_LoadArgs args) =>
+      _parseInIsolate(args, AppstreamCollection.fromYaml);
+
+  static Future<void> _parseInIsolate(
+    _LoadArgs args,
+    AppstreamCollection Function(String contents) parse,
+  ) async {
+    try {
+      final contents = await _loadFile(args.path);
+      args.port.send(parse(contents));
+    } on Object catch (error) {
+      // Sent back as a plain string: exceptions thrown by the `appstream`
+      // package aren't guaranteed to be safe to send across the isolate
+      // boundary, and we only need the message for logging anyway.
+      args.port.send('$error');
+    }
+  }
+
+  static Future<String> _loadFile(String path) async {
+    var stream = File(path).openRead();
+    if (path.endsWith('.gz')) {
+      stream = gzip.decoder.bind(stream);
+    }
+    return utf8.decoder.bind(stream).join();
+  }
+}

--- a/packages/app_center/test/resilient_appstream_pool_test.dart
+++ b/packages/app_center/test/resilient_appstream_pool_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:app_center/appstream/appstream.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _goodYaml = '''
+File: DEP-11
+Version: '0.10'
+Origin: test
+---
+ID: com.example.Good
+Type: desktop-application
+Package: good-pkg
+Name:
+  C: Good App
+Summary:
+  C: A good app
+''';
+
+// Contains a release with `type: snapshot`, which the `appstream` package
+// doesn't recognize and throws a `FormatException` for (see #2142).
+const _badYaml = '''
+File: DEP-11
+Version: '0.10'
+Origin: test
+---
+ID: com.example.Bad
+Type: desktop-application
+Package: bad-pkg
+Name:
+  C: Bad App
+Summary:
+  C: A bad app
+Releases:
+  - version: '1.0'
+    type: snapshot
+''';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('resilient_appstream_pool');
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  test('skips malformed catalog files instead of hanging', () async {
+    final yamlDir = Directory('${tempDir.path}/swcatalog/yaml');
+    await yamlDir.create(recursive: true);
+    await File('${yamlDir.path}/good.yml').writeAsString(_goodYaml);
+    await File('${yamlDir.path}/bad.yml').writeAsString(_badYaml);
+
+    final pool = ResilientAppstreamPool(catalogDirPrefixes: [tempDir.path]);
+
+    // Regression test for #2142: previously, a single malformed catalog file
+    // would make `load()` hang forever.
+    await pool.load().timeout(const Duration(seconds: 10));
+
+    expect(pool.components, hasLength(1));
+    expect(pool.components.single.id, 'com.example.Good');
+  });
+
+  test('loads all valid catalog files when none are malformed', () async {
+    final yamlDir = Directory('${tempDir.path}/swcatalog/yaml');
+    await yamlDir.create(recursive: true);
+    await File('${yamlDir.path}/good.yml').writeAsString(_goodYaml);
+
+    final pool = ResilientAppstreamPool(catalogDirPrefixes: [tempDir.path]);
+    await pool.load().timeout(const Duration(seconds: 10));
+
+    expect(pool.components, hasLength(1));
+  });
+
+  test('returns no components when the catalog directory is absent', () async {
+    final pool = ResilientAppstreamPool(
+      catalogDirPrefixes: ['${tempDir.path}/does-not-exist'],
+    );
+
+    await pool.load().timeout(const Duration(seconds: 10));
+
+    expect(pool.components, isEmpty);
+  });
+}


### PR DESCRIPTION
## Problem

`AppstreamPool.load()` (from the `appstream` pub package) spawns one isolate
per AppStream catalog file and awaits them all via `Future.wait`. If a
single catalog file fails to parse — for example a release entry with
`type="snapshot"`, which `_parseReleaseType` doesn't recognize and throws a
`FormatException` for — the isolate dies from an unhandled async exception
**without ever responding on its `ReceivePort`**.

Since nothing ever arrives on that port, `Future.wait` never completes, and
`AppstreamPool.load()` hangs forever. This silently breaks **all**
AppStream-backed functionality app-wide (search, categories, snap/deb detail
pages), with no error, timeout, or log message — closes #2142.

## Fix

Added `ResilientAppstreamPool`
(`packages/app_center/lib/appstream/resilient_appstream_pool.dart`), which
re-implements the same directory-scanning/isolate-parsing logic as
`AppstreamPool.load()`, but wraps each file's parsing in a `try`/`catch`
*inside* the isolate, always sending back a result (either the parsed
`AppstreamCollection` or an error string). A single malformed catalog file
is now logged and skipped instead of blocking every other file from
loading.

`AppstreamService` now defaults to `ResilientAppstreamPool()` instead of the
upstream `AppstreamPool()`.

## Testing

Added `packages/app_center/test/resilient_appstream_pool_test.dart`
covering:
- A malformed catalog file (with `type: snapshot`, reproducing the exact
  bug) is skipped without hanging, while valid files still load.
- All files load normally when none are malformed.
- Missing catalog directories don't cause errors.

Ran locally:
- `melos test` — all tests pass
- `melos analyze --fatal-infos` — no issues
- `melos format:exclude` — no changes needed