### PR TITLE
ci: install FVM without Homebrew

### DIFF
--- a/.github/actions/setup-fvm/action.yml
+++ b/.github/actions/setup-fvm/action.yml
@@ -1,0 +1,27 @@
+name: Setup FVM
+description: >
+  Installs the Flutter SDK pinned in .fvmrc, plus FVM itself.
+
+  Equivalent to Atsumi3/actions-setup-fvm, except that FVM is installed from
+  its GitHub release with the repository's own scripts/install-fvm.sh, the same
+  way the snap build does it. That action installs FVM from the
+  leoafarias/fvm Homebrew tap, which Homebrew now ignores because third-party
+  taps require explicit trust, so every job using it fails at setup.
+
+runs:
+  using: composite
+  steps:
+    - uses: kuhnroyal/flutter-fvm-config-action@v2
+      id: fvm-config-action
+
+    - uses: subosito/flutter-action@v2
+      with:
+        cache: true
+        flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+        channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+
+    - name: Install FVM
+      shell: bash
+      run: |
+        bash "$GITHUB_WORKSPACE/scripts/install-fvm.sh"
+        fvm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
       - run: melos generate
       - run: melos gen-l10n
@@ -33,7 +33,7 @@ jobs:
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
           restore-keys: |
             ${{ runner.os }}-repo-
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
       - run: melos analyze --fatal-infos
 
@@ -49,7 +49,7 @@ jobs:
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
           restore-keys: |
             ${{ runner.os }}-repo-
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
       - run: melos format:exclude
 
@@ -63,7 +63,7 @@ jobs:
         with:
           path: .
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
       - run: melos gen-l10n
       - run: melos sync-desktop-titles
@@ -94,7 +94,7 @@ jobs:
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
           restore-keys: |
             ${{ runner.os }}-repo-
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
       - run: sudo apt update && sudo apt install -y lcov
       - run: melos coverage

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v3
       - run: sudo apt update
       - run: sudo apt install -y clang cmake debhelper libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xvfb


### PR DESCRIPTION
Fixes #2154.

`Atsumi3/actions-setup-fvm` installs FVM with `brew tap leoafarias/fvm && brew install fvm`. Homebrew now requires third-party taps to be explicitly trusted and ignores untrusted ones, so the install produces nothing and the action fails with `unknown install step: remove`. Every job dies at `setup`, and the jobs that declare `needs: setup` are skipped with it, so every PR reads as failing regardless of its contents.

### Why replace the action rather than wait for a fix

`Atsumi3/actions-setup-fvm` was last pushed in February 2024, its last release is 0.0.3 from the same month, and it has 0 stars and 0 open issues. Filing a bug there is unlikely to lead anywhere, so unblocking CI means changing what this repository calls.

Other options considered:

- **Trust the tap before the action runs.** Not possible, the `brew install` happens inside the composite action, so there is no way to insert a step ahead of it without forking the action.
- **`dart pub global activate fvm`.** The standard install path, and it can pin a version. A reasonable alternative, see the note below.
- **Drop FVM from CI.** The melos scripts invoke `fvm flutter`, so this would mean rewriting `melos.yaml`, far more invasive than the problem warrants.

### What this does

The action does three things: look up the version in `.fvmrc`, install the SDK via `subosito/flutter-action` with caching, and install FVM from Homebrew. Only the third is broken, so this keeps the first two and swaps the last for `scripts/install-fvm.sh`, which downloads the release binary from GitHub.

That script was chosen because it is already in the repository and already proven on a runner: it is what the snap build uses, and the `snap` job passes on the very commits where `setup` fails. It also leaves one way to install FVM across the project instead of two.

The three steps live in a local composite action so the six call sites stay one line each.

### Known limitation

`scripts/install-fvm.sh` fetches the latest FVM release rather than a pinned version, so a future FVM release could break CI the same way. This is not a regression, `brew install fvm` was equally unpinned, but it is not an improvement either. If you would rather pin the version, swapping the script for `dart pub global activate fvm <version>` is a three-line change to the composite action and I am happy to make it. I kept the existing mechanism here so that the fix restores the previous behaviour without also changing how FVM is installed.

I can't verify this locally, it only proves itself on a runner. But it is self-validating: if `setup` goes green on this PR, that is the proof.
