### PR TITLE
fix: bump appstream.dart

### DIFF
--- a/.github/actions/setup-fvm/action.yaml
+++ b/.github/actions/setup-fvm/action.yaml
@@ -1,0 +1,39 @@
+name: Setup FVM
+description: >
+  Installs FVM and the Flutter SDK version pinned in .fvmrc.
+
+  Equivalent to Atsumi3/actions-setup-fvm, except that FVM is installed from its
+  GitHub release using the repository's own scripts/install-fvm.sh, the same way
+  the snap build does it. That action installs FVM from the leoafarias/fvm
+  Homebrew tap, which Homebrew now ignores because third-party taps require
+  explicit trust, so every job using it fails at setup.
+
+inputs:
+  fvm-version:
+    description: FVM version to install. Empty installs the latest release.
+    required: false
+    default: 4.1.2
+
+runs:
+  using: composite
+  steps:
+    - uses: kuhnroyal/flutter-fvm-config-action@v2
+      id: fvm-config-action
+
+    - uses: subosito/flutter-action@v2
+      with:
+        cache: true
+        flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+        channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+
+    - name: Install FVM
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        bash "$GITHUB_WORKSPACE/scripts/install-fvm.sh" ${{ inputs.fvm-version }}
+        echo "$HOME/.fvm_flutter/bin" >> "$GITHUB_PATH"
+
+    - name: Install Flutter SDK
+      shell: bash
+      run: fvm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: 6.3.3
       - run: melos generate
       - run: melos gen-l10n
       - uses: actions/cache@v3
@@ -33,8 +35,10 @@ jobs:
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
           restore-keys: |
             ${{ runner.os }}-repo-
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: 6.3.3
       - run: melos analyze --fatal-infos
 
   format:
@@ -49,8 +53,10 @@ jobs:
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
           restore-keys: |
             ${{ runner.os }}-repo-
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: 6.3.3
       - run: melos format:exclude
 
   l10n:
@@ -63,8 +69,10 @@ jobs:
         with:
           path: .
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: 6.3.3
       - run: melos gen-l10n
       - run: melos sync-desktop-titles
       - name: Check for outdated l10n
@@ -94,8 +102,10 @@ jobs:
           key: ${{ runner.os }}-repo-${{ github.sha }}-generated
           restore-keys: |
             ${{ runner.os }}-repo-
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v2
+        with:
+          melos-version: 6.3.3
       - run: sudo apt update && sudo apt install -y lcov
       - run: melos coverage
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: Atsumi3/actions-setup-fvm@0.0.3
+      - uses: ./.github/actions/setup-fvm
       - uses: bluefireteam/melos-action@v3
+        with:
+          melos-version: 6.3.3
       - run: sudo apt update
       - run: sudo apt install -y clang cmake debhelper libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xvfb
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,4 +1,6 @@
 name: app_center
+# Melos prepends `<sdkPath>/bin` to the PATH of every script it runs, so the
+# scripts below resolve to the FVM-managed SDK without an explicit `fvm` prefix.
 sdkPath: .fvm/flutter_sdk
 
 packages:
@@ -18,12 +20,12 @@ scripts:
   # build all packages
   build: >
     melos exec -c 1 --fail-fast --flutter --dir-exists=linux -- \
-      fvm flutter build linux
+      flutter build linux
 
   # collect coverage information for all packages
   coverage: >
     melos exec -c 1 --fail-fast --dir-exists=test -- \
-      fvm flutter test --coverage && melos run coverage:cleanup
+      flutter test --coverage && melos run coverage:cleanup
 
   # cleanup generated files from coverage
   coverage:cleanup: >
@@ -46,17 +48,17 @@ scripts:
       ! -path '*/l10n/*.dart' \
       ! -name '*.pb*.dart' \
       ! -path '*/.*/*' \
-      | xargs fvm dart format --set-exit-if-changed
+      | xargs dart format --set-exit-if-changed
 
   # run build_runner to generate code in all packages
   generate: >
     melos exec -c 1 --fail-fast --depends-on=build_runner --order-dependents -- \
-      fvm dart run build_runner build --delete-conflicting-outputs
+      dart run build_runner build --delete-conflicting-outputs
 
   # run gen-l10n to generate localizations in all packages
   gen-l10n: >
     melos exec -c 1 --fail-fast --depends-on=flutter_localizations -- \
-     fvm flutter gen-l10n
+     flutter gen-l10n
 
   # sync app titles from l10n ARB files to desktop file
   sync-desktop-titles: >
@@ -65,15 +67,15 @@ scripts:
   # run integration tests in all packages
   integration_test: >
     melos exec -c 1 --fail-fast --dir-exists=integration_test -- \
-      fvm flutter test integration_test
+      flutter test integration_test
 
   # runs "flutter pub <arg(s)>" in all packages
-  pub: melos exec -c 1 -- fvm flutter pub "$@"
+  pub: melos exec -c 1 -- flutter pub "$@"
 
   # run tests in all packages
   test: >
     melos exec -c 1 --fail-fast --dir-exists=test -- \
-      fvm flutter test
+      flutter test
 
   # run pub upgrade in all packages
   upgrade: melos pub upgrade
@@ -81,7 +83,7 @@ scripts:
   # run the app in dev mode
   start: >
     melos exec -c 1 --flutter --scope=app_center -- \
-      fvm flutter run "$@"
+      flutter run "$@"
 
   # generate protobuf files in app_center_ratings_client
   protoc:

--- a/packages/app_center/pubspec.lock
+++ b/packages/app_center/pubspec.lock
@@ -51,11 +51,12 @@ packages:
   appstream:
     dependency: "direct main"
     description:
-      name: appstream
-      sha256: "0c601137b47559083979da73f867559f01f4de1b929827e5d927431ed2b73321"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.10"
+      path: "."
+      ref: "12c359e5ca0a40f954025f9a42f59799b292fcee"
+      resolved-ref: "12c359e5ca0a40f954025f9a42f59799b292fcee"
+      url: "https://github.com/canonical/appstream.dart"
+    source: git
+    version: "0.2.11"
   archive:
     dependency: transitive
     description:

--- a/packages/app_center/pubspec.yaml
+++ b/packages/app_center/pubspec.yaml
@@ -9,7 +9,10 @@ environment:
 
 dependencies:
   app_center_ratings_client: ^1.0.0
-  appstream: ^0.2.9
+  appstream:
+    git:
+      url: https://github.com/canonical/appstream.dart
+      ref: 12c359e5ca0a40f954025f9a42f59799b292fcee
   args: ^2.5.0
   cached_network_image: ^3.4.1
   clock: ^1.1.1

--- a/scripts/install-fvm.sh
+++ b/scripts/install-fvm.sh
@@ -107,15 +107,23 @@ if ! mv "$FVM_DIR/fvm" "$FMV_DIR_BIN"; then
     error "Failed to move fvm to bin directory."
 fi
 
-# Create a symlink
-if ! ln -sf "$FMV_DIR_BIN/fvm" "$SYMLINK_TARGET"; then
-    error "Failed to create symlink."
+# Create a symlink. This needs write access to the parent directory, which an
+# unprivileged user does not have, so fall back to sudo and then to leaving the
+# binary in place. Callers that cannot write the symlink are expected to add
+# $FMV_DIR_BIN to their PATH themselves.
+if ln -sf "$FMV_DIR_BIN/fvm" "$SYMLINK_TARGET" 2>/dev/null; then
+    log_message "Linked $SYMLINK_TARGET."
+elif command -v sudo &> /dev/null && sudo -n ln -sf "$FMV_DIR_BIN/fvm" "$SYMLINK_TARGET" 2>/dev/null; then
+    log_message "Linked $SYMLINK_TARGET (required sudo)."
+else
+    log_message "Could not link $SYMLINK_TARGET, add $FMV_DIR_BIN to your PATH instead."
 fi
 
-# Verify installation
-if ! command -v fvm &> /dev/null; then
-    error "Installation verification failed. FVM may not be in PATH or failed to execute."
+# Verify installation, preferring the just-installed binary over any other fvm
+# that may already be on the PATH.
+if ! "$FMV_DIR_BIN/fvm" --version &> /dev/null; then
+    error "Installation verification failed. FVM failed to execute."
 fi
 
-INSTALLED_FVM_VERSION=$(fvm --version 2>&1) || error "Failed to verify installed FVM version."
+INSTALLED_FVM_VERSION=$("$FMV_DIR_BIN/fvm" --version 2>&1) || error "Failed to verify installed FVM version."
 success "FVM $INSTALLED_FVM_VERSION installed successfully."


### PR DESCRIPTION
## Summary

Fixes a parsing error that was occurring due to the inclusion of the `snapshot` field, which appstream.dart did not know how to parse.

Points the `appstream` dependency at the canonical/appstream.dart git ref `12c359e5ca0a40f954025f9a42f59799b292fcee` until a new version is published to pub.dev.

## Before

```sh
...
FormatException: Unknown release type 'snapshot'
#0      _parseReleaseType (package:appstream/src/collection.dart:944)
#1      new AppstreamCollection.fromYaml (package:appstream/src/collection.dart:641)
#2      AppstreamPool._loadYamlCollectionInIsolate (package:appstream/src/pool.dart:94)
```

[Screencast From 2026-08-07 17-12-53.webm](https://github.com/user-attachments/assets/9e703ee8-f76e-4658-9052-7e155dc88297)

## After
[Screencast From 2026-08-07 17-23-11.webm](https://github.com/user-attachments/assets/2cc5ae6f-10c0-42d2-a5e9-4c70d60dbc00)


