### PR TITLE
fix: Added focus border to screenshots in Gallery

### DIFF
--- a/packages/app_center/lib/widgets/screenshot_gallery.dart
+++ b/packages/app_center/lib/widgets/screenshot_gallery.dart
@@ -76,17 +76,21 @@ class MediaTile extends StatelessWidget {
         color: Colors.transparent,
         child: Semantics(
           button: true,
-          child: InkWell(
+          child: YaruFocusBorder.primary(
             borderRadius: borderRadius.outer(padding),
-            excludeFromSemantics: true,
-            onTap: onTap,
-            child: Padding(
-              padding: padding,
-              child: ClipRRect(
-                borderRadius: borderRadius,
-                child: SafeNetworkImage(
-                  url: url,
-                  semanticLabel: semanticLabel,
+            child: InkWell(
+              borderRadius: borderRadius.outer(padding),
+              focusColor: Colors.transparent,
+              excludeFromSemantics: true,
+              onTap: onTap,
+              child: Padding(
+                padding: padding,
+                child: ClipRRect(
+                  borderRadius: borderRadius,
+                  child: SafeNetworkImage(
+                    url: url,
+                    semanticLabel: semanticLabel,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Previously the image control in the gallery was lacking a focus border so was unlike the other controls in the app center and defaulted to Flutters default material focus background which did not meet color contrast guidelines.
I have now added the Yaru focus border component to wrap the control and provide the focus border along with removing the old focus ring.

### New look:
<img width="2938" height="1856" alt="image" src="https://github.com/user-attachments/assets/bcb1e062-0e54-4ce4-8328-d88fab1c3c54" />

### Old look:
<img width="2938" height="1856" alt="image" src="https://github.com/user-attachments/assets/fe0f6438-9944-4592-a895-e99ca8e3feca" />

