### PR TITLE
a11y: improve labeling and focus indicators on the manage installed page

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "3.44.2"
+  "flutter": "master"
 }

--- a/packages/app_center/analysis_options.yaml
+++ b/packages/app_center/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - linux/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
 include: package:ubuntu_lints/analysis_options.yaml

--- a/packages/app_center/lib/manage/app_providers.dart
+++ b/packages/app_center/lib/manage/app_providers.dart
@@ -43,13 +43,18 @@ final appSortOrderProvider = StateProvider<AppSortOrder>(
 Future<List<ManageAppData>> appUpdates(Ref ref) async {
   final snapUpdates = await ref.watch(snapUpdatesModelProvider.future);
   final debUpdates = await ref.watch(localDebUpdatesModelProvider.future);
+  // snapUpdates contains refresh *candidates* from the store, whose `version`
+  // field is the update's version, not the currently installed one. Pair each
+  // candidate with its locally installed snap to get the real current version.
+  final localSnaps = await ref.watch(localSnapsProvider.future);
 
-  final snapApps = snapUpdates.snaps.map(
-    (snap) => ManageAppData.snap(
-      snap: snap,
-      updateVersion: snap.version,
-    ),
-  );
+  final snapApps = snapUpdates.snaps.map((candidate) {
+    final localSnap = localSnaps.getSnap(candidate.name);
+    return ManageAppData.snap(
+      snap: localSnap ?? candidate,
+      updateVersion: candidate.version,
+    );
+  });
 
   final debApps = debUpdates.map((deb) => ManageAppData.localDeb(debInfo: deb));
 

--- a/packages/app_center/lib/manage/manage_app_actions.dart
+++ b/packages/app_center/lib/manage/manage_app_actions.dart
@@ -260,10 +260,24 @@ class _AccessibleActionButton extends StatelessWidget {
     return MergeSemantics(
       child: Semantics(
         label: semanticLabel,
-        child: OutlinedButton(
-          onPressed: onPressed,
-          child: ExcludeSemantics(
-            child: Text(label),
+        child: YaruFocusBorder.primary(
+          child: OutlinedButton(
+            onPressed: onPressed,
+            style: ButtonStyle(
+              overlayColor: WidgetStateProperty.resolveWith((states) {
+                // Suppress the Material focused background; the Yaru ring
+                // is the sole focus indicator. Keep hover and press overlays.
+                if (states.contains(WidgetState.focused) &&
+                    !states.contains(WidgetState.hovered) &&
+                    !states.contains(WidgetState.pressed)) {
+                  return Colors.transparent;
+                }
+                return null;
+              }),
+            ),
+            child: ExcludeSemantics(
+              child: Text(label),
+            ),
           ),
         ),
       ),

--- a/packages/app_center/lib/manage/manage_app_actions.dart
+++ b/packages/app_center/lib/manage/manage_app_actions.dart
@@ -92,47 +92,59 @@ class ManageAppActions extends ConsumerWidget {
             0,
         onCancelPressed: () =>
             ref.read(snapModelProvider(snap.name).notifier).cancel(),
+        appName: app.name,
       );
     }
+
+    final updateCallback = SnapAction.update.callback(
+      snapData,
+      snapViewModel,
+      snapLauncher,
+      context,
+    );
+    final openCallback = SnapAction.open.callback(
+      snapData,
+      snapViewModel,
+      snapLauncher,
+      context,
+    );
+    final removeCallback = SnapAction.remove.callback(
+      snapData,
+      snapViewModel,
+      snapLauncher,
+      context,
+    );
 
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         if (shouldQuitToUpdate) ...[
-          const QuitToUpdateNotice(),
+          const ExcludeSemantics(child: QuitToUpdateNotice()),
           const SizedBox(width: kSpacing),
         ],
         if (showOnlyUpdate)
-          OutlinedButton(
-            onPressed: SnapAction.update.callback(
-              snapData,
-              snapViewModel,
-              snapLauncher,
-              context,
-            ),
-            child: Text(SnapAction.update.label(l10n)),
+          _AccessibleActionButton(
+            label: SnapAction.update.label(l10n),
+            semanticLabel: shouldQuitToUpdate
+                ? l10n.managePageUpdateAppRestartRequiredSemanticLabel(
+                    app.name,
+                  )
+                : l10n.managePageUpdateAppSemanticLabel(app.name),
+            onPressed: updateCallback,
           ),
         if (!showOnlyUpdate && snapData.isInstalled) ...[
           if (canOpen) ...[
-            OutlinedButton(
-              onPressed: SnapAction.open.callback(
-                snapData,
-                snapViewModel,
-                snapLauncher,
-                context,
-              ),
-              child: Text(SnapAction.open.label(l10n)),
+            _AccessibleActionButton(
+              label: SnapAction.open.label(l10n),
+              semanticLabel: l10n.managePageOpenAppSemanticLabel(app.name),
+              onPressed: openCallback,
             ),
             const SizedBox(width: kSpacing),
           ],
-          OutlinedButton(
-            onPressed: SnapAction.remove.callback(
-              snapData,
-              snapViewModel,
-              snapLauncher,
-              context,
-            ),
-            child: Text(SnapAction.remove.label(l10n)),
+          _AccessibleActionButton(
+            label: SnapAction.remove.label(l10n),
+            semanticLabel: l10n.managePageRemoveAppSemanticLabel(app.name),
+            onPressed: removeCallback,
           ),
         ],
       ],
@@ -157,35 +169,50 @@ class ManageAppActions extends ConsumerWidget {
       final progress = ref.watch(
         debTransactionProgressProvider(debInfo.activeTransactionId),
       );
+      final statusLabel = showOnlyUpdate
+          ? l10n.snapActionUpdatingLabel
+          : l10n.snapActionRemovingLabel;
+      void cancelCallback() {
+        if (showOnlyUpdate) {
+          ref
+              .read(localDebUpdatesModelProvider.notifier)
+              .cancelTransaction(debInfo.id);
+        } else {
+          ref
+              .read(installedAppsProvider.notifier)
+              .cancelDebTransaction(debInfo.id);
+        }
+      }
+
       return Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox.square(
-            dimension: kLoaderHeight,
-            child: YaruCircularProgressIndicator(
-              value: progress,
-              strokeWidth: 2,
+          ExcludeSemantics(
+            child: SizedBox.square(
+              dimension: kLoaderHeight,
+              child: YaruCircularProgressIndicator(
+                value: progress,
+                strokeWidth: 2,
+              ),
             ),
           ),
           const SizedBox(width: kSpacingSmall),
-          Text(
-            showOnlyUpdate
-                ? l10n.snapActionUpdatingLabel
-                : l10n.snapActionRemovingLabel,
-            style: Theme.of(context).textTheme.bodyMedium,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+          ExcludeSemantics(
+            child: Text(
+              statusLabel,
+              style: Theme.of(context).textTheme.bodyMedium,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           const SizedBox(width: kSpacing),
-          OutlinedButton(
-            onPressed: () => showOnlyUpdate
-                ? ref
-                      .read(localDebUpdatesModelProvider.notifier)
-                      .cancelTransaction(debInfo.id)
-                : ref
-                      .read(installedAppsProvider.notifier)
-                      .cancelDebTransaction(debInfo.id),
-            child: Text(l10n.snapActionCancelLabel),
+          _AccessibleActionButton(
+            label: l10n.snapActionCancelLabel,
+            semanticLabel: l10n.managePageCancelActionSemanticLabel(
+              statusLabel,
+              app.name,
+            ),
+            onPressed: cancelCallback,
           ),
         ],
       );
@@ -195,19 +222,51 @@ class ManageAppActions extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (showOnlyUpdate)
-          OutlinedButton(
+          _AccessibleActionButton(
+            label: l10n.snapActionUpdateLabel,
+            semanticLabel: l10n.managePageUpdateAppSemanticLabel(app.name),
             onPressed: () => ref
                 .read(localDebUpdatesModelProvider.notifier)
                 .updateDeb(debInfo.id),
-            child: Text(l10n.snapActionUpdateLabel),
           ),
         if (!showOnlyUpdate && !isCompulsory)
-          OutlinedButton(
+          _AccessibleActionButton(
+            label: l10n.snapActionRemoveLabel,
+            semanticLabel: l10n.managePageRemoveAppSemanticLabel(app.name),
             onPressed: () =>
                 ref.read(installedAppsProvider.notifier).removeDeb(debInfo.id),
-            child: Text(l10n.snapActionRemoveLabel),
           ),
       ],
+    );
+  }
+}
+
+/// An [OutlinedButton] whose accessible name is overridden by
+/// [semanticLabel] (e.g. to include the app name it acts on), while
+/// preserving the button's tap action for assistive technologies.
+class _AccessibleActionButton extends StatelessWidget {
+  const _AccessibleActionButton({
+    required this.label,
+    required this.semanticLabel,
+    required this.onPressed,
+  });
+
+  final String label;
+  final String semanticLabel;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return MergeSemantics(
+      child: Semantics(
+        label: semanticLabel,
+        child: OutlinedButton(
+          onPressed: onPressed,
+          child: ExcludeSemantics(
+            child: Text(label),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/packages/app_center/lib/manage/manage_app_tile.dart
+++ b/packages/app_center/lib/manage/manage_app_tile.dart
@@ -107,20 +107,24 @@ class ManageAppTile extends ConsumerWidget {
       ),
       child: YaruListTile(
         key: ValueKey(app.id),
+        hasFocusBorder: false,
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         leading: MergeSemantics(
-          child: Semantics(
-            label: tileSemanticLabel,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(20),
-              onTap: () => _navigateToApp(context),
-              child: ExcludeSemantics(
-                child: switch (app) {
-                  ManageDebData(debInfo: final debInfo)
-                      when debInfo.component != null =>
-                    DebAppIcon(component: debInfo.component!, size: 40),
-                  _ => AppIcon(iconUrl: app.iconUrl, size: 40),
-                },
+          child: YaruFocusBorder.primary(
+            borderRadius: BorderRadius.circular(20),
+            child: Semantics(
+              label: tileSemanticLabel,
+              child: InkWell(
+                borderRadius: BorderRadius.circular(20),
+                onTap: () => _navigateToApp(context),
+                child: ExcludeSemantics(
+                  child: switch (app) {
+                    ManageDebData(debInfo: final debInfo)
+                        when debInfo.component != null =>
+                      DebAppIcon(component: debInfo.component!, size: 40),
+                    _ => AppIcon(iconUrl: app.iconUrl, size: 40),
+                  },
+                ),
               ),
             ),
           ),

--- a/packages/app_center/lib/manage/manage_app_tile.dart
+++ b/packages/app_center/lib/manage/manage_app_tile.dart
@@ -50,6 +50,17 @@ class ManageAppTile extends ConsumerWidget {
     // Hide size for debs in the updates section
     final shouldShowSize =
         app.installedSize != null && !(showOnlyUpdate && app is ManageDebData);
+    final sizeText = shouldShowSize
+        ? context.formatByteSize(app.installedSize!, precision: 0)
+        : null;
+    final tileSemanticLabel = [
+      app.name,
+      sourceSemanticLabel(l10n, app),
+      if (dateTimeSinceUpdate != null)
+        dateTimeSinceUpdate.managePageUpdateSinceDateTimeAgo(l10n),
+      if (sizeText != null) l10n.managePageInstalledSizeSemanticLabel(sizeText),
+      l10n.managePageShowDetailsLabel,
+    ].join(', ');
     final actionButtons = Align(
       alignment: Alignment.centerRight,
       child: IntrinsicWidth(
@@ -97,14 +108,22 @@ class ManageAppTile extends ConsumerWidget {
       child: YaruListTile(
         key: ValueKey(app.id),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        leading: Clickable(
-          onTap: () => _navigateToApp(context),
-          child: switch (app) {
-            ManageDebData(debInfo: final debInfo)
-                when debInfo.component != null =>
-              DebAppIcon(component: debInfo.component!, size: 40),
-            _ => AppIcon(iconUrl: app.iconUrl, size: 40),
-          },
+        leading: MergeSemantics(
+          child: Semantics(
+            label: tileSemanticLabel,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(20),
+              onTap: () => _navigateToApp(context),
+              child: ExcludeSemantics(
+                child: switch (app) {
+                  ManageDebData(debInfo: final debInfo)
+                      when debInfo.component != null =>
+                    DebAppIcon(component: debInfo.component!, size: 40),
+                  _ => AppIcon(iconUrl: app.iconUrl, size: 40),
+                },
+              ),
+            ),
+          ),
         ),
         title: Row(
           children: [
@@ -112,13 +131,15 @@ class ManageAppTile extends ConsumerWidget {
               flex: 2,
               child: Align(
                 alignment: AlignmentDirectional.centerStart,
-                child: Clickable(
-                  onTap: () => _navigateToApp(context),
-                  child: Text(
-                    app.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.start,
+                child: ExcludeSemantics(
+                  child: Clickable(
+                    onTap: () => _navigateToApp(context),
+                    child: Text(
+                      app.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.start,
+                    ),
                   ),
                 ),
               ),
@@ -128,26 +149,27 @@ class ManageAppTile extends ConsumerWidget {
               Expanded(
                 flex: 2,
                 child: dateTimeSinceUpdate != null
-                    ? Text(
-                        dateTimeSinceUpdate.managePageUpdateSinceDateTimeAgo(
-                          l10n,
+                    ? ExcludeSemantics(
+                        child: Text(
+                          dateTimeSinceUpdate.managePageUpdateSinceDateTimeAgo(
+                            l10n,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.start,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        textAlign: TextAlign.start,
                       )
                     : const SizedBox(),
               ),
               Expanded(
-                child: shouldShowSize
-                    ? Text(
-                        context.formatByteSize(
-                          app.installedSize!,
-                          precision: 0,
+                child: sizeText != null
+                    ? ExcludeSemantics(
+                        child: Text(
+                          sizeText,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.end,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        textAlign: TextAlign.end,
                       )
                     : const SizedBox(),
               ),
@@ -168,24 +190,25 @@ class ManageAppTile extends ConsumerWidget {
                   Expanded(
                     flex: 2,
                     child: dateTimeSinceUpdate != null
-                        ? Text(
-                            dateTimeSinceUpdate
-                                .managePageUpdateSinceDateTimeAgo(l10n),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
+                        ? ExcludeSemantics(
+                            child: Text(
+                              dateTimeSinceUpdate
+                                  .managePageUpdateSinceDateTimeAgo(l10n),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                           )
                         : const SizedBox(),
                   ),
                   Expanded(
-                    child: shouldShowSize
-                        ? Text(
-                            context.formatByteSize(
-                              app.installedSize!,
-                              precision: 0,
+                    child: sizeText != null
+                        ? ExcludeSemantics(
+                            child: Text(
+                              sizeText,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              textAlign: TextAlign.end,
                             ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            textAlign: TextAlign.end,
                           )
                         : const SizedBox(),
                   ),
@@ -236,6 +259,10 @@ ManageTilePosition determineTilePosition({
 
 /// Displays the package source info: channel + version for snaps, or just
 /// version for debs. Shows "current → update" when an update is available.
+///
+/// This info is purely decorative; its accessible description is already
+/// carried by the tile's composite label (see [sourceSemanticLabel]), so its
+/// own semantics are excluded to avoid duplicate announcements.
 class _SourceDisplay extends StatelessWidget {
   const _SourceDisplay({required this.app});
 
@@ -243,10 +270,12 @@ class _SourceDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return app.map(
-      snap: (snapData) =>
-          _buildSnapSource(snapData.snap, snapData.updateVersion),
-      localDeb: (debData) => _buildDebSource(debData.debInfo),
+    return ExcludeSemantics(
+      child: app.map(
+        snap: (snapData) =>
+            _buildSnapSource(snapData.snap, snapData.updateVersion),
+        localDeb: (debData) => _buildDebSource(debData.debInfo),
+      ),
     );
   }
 
@@ -275,4 +304,34 @@ class _SourceDisplay extends StatelessWidget {
 
     return Text(versionText);
   }
+}
+
+/// Returns the accessible label describing an app's source: channel +
+/// version for snaps, or just version for debs. Includes the update version
+/// when one is available. Used to build [ManageAppTile]'s composite label.
+String sourceSemanticLabel(AppLocalizations l10n, ManageAppData app) {
+  return app.map(
+    snap: (snapData) {
+      final snap = snapData.snap;
+      final updateVersion = snapData.updateVersion;
+      return updateVersion != null
+          ? l10n.managePageChannelVersionUpdateSemanticLabel(
+              snap.channel,
+              snap.version,
+              updateVersion,
+            )
+          : l10n.managePageChannelVersionSemanticLabel(
+              snap.channel,
+              snap.version,
+            );
+    },
+    localDeb: (debData) {
+      final debInfo = debData.debInfo;
+      final version = debInfo.packageInfo.packageId.version;
+      final updateVersion = debInfo.updateVersion;
+      return updateVersion != null
+          ? l10n.managePageVersionUpdateSemanticLabel(version, updateVersion)
+          : l10n.managePageVersionSemanticLabel(version);
+    },
+  );
 }

--- a/packages/app_center/lib/manage/manage_app_tile.dart
+++ b/packages/app_center/lib/manage/manage_app_tile.dart
@@ -107,24 +107,20 @@ class ManageAppTile extends ConsumerWidget {
       ),
       child: YaruListTile(
         key: ValueKey(app.id),
-        hasFocusBorder: false,
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         leading: MergeSemantics(
-          child: YaruFocusBorder.primary(
-            borderRadius: BorderRadius.circular(20),
-            child: Semantics(
-              label: tileSemanticLabel,
-              child: InkWell(
-                borderRadius: BorderRadius.circular(20),
-                onTap: () => _navigateToApp(context),
-                child: ExcludeSemantics(
-                  child: switch (app) {
-                    ManageDebData(debInfo: final debInfo)
-                        when debInfo.component != null =>
-                      DebAppIcon(component: debInfo.component!, size: 40),
-                    _ => AppIcon(iconUrl: app.iconUrl, size: 40),
-                  },
-                ),
+          child: Semantics(
+            label: tileSemanticLabel,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(20),
+              onTap: () => _navigateToApp(context),
+              child: ExcludeSemantics(
+                child: switch (app) {
+                  ManageDebData(debInfo: final debInfo)
+                      when debInfo.component != null =>
+                    DebAppIcon(component: debInfo.component!, size: 40),
+                  _ => AppIcon(iconUrl: app.iconUrl, size: 40),
+                },
               ),
             ),
           ),

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -555,15 +555,17 @@ class _FilterRow extends ConsumerWidget {
                         ),
                       ),
                     // Actual visible dropdown
-                    MenuButtonBuilder<PackageTypeFilter>(
-                      values: PackageTypeFilter.values,
-                      itemBuilder: (context, type, child) =>
-                          Text(type.localize(l10n)),
-                      onSelected: (value) =>
-                          ref.read(packageTypeFilterProvider.notifier).state =
-                              value,
-                      expanded: false,
-                      child: Text(packageType.localize(l10n)),
+                    YaruFocusBorder.primary(
+                      child: MenuButtonBuilder<PackageTypeFilter>(
+                        values: PackageTypeFilter.values,
+                        itemBuilder: (context, type, child) =>
+                            Text(type.localize(l10n)),
+                        onSelected: (value) => ref
+                            .read(packageTypeFilterProvider.notifier)
+                            .state = value,
+                        expanded: false,
+                        child: Text(packageType.localize(l10n)),
+                      ),
                     ),
                   ],
                 ),
@@ -601,21 +603,23 @@ class _FilterRow extends ConsumerWidget {
           Consumer(
             builder: (context, ref, child) {
               final sortOrder = ref.watch(appSortOrderProvider);
-              return MenuButtonBuilder<AppSortOrder>(
-                values: const [
-                  AppSortOrder.alphabeticalAsc,
-                  AppSortOrder.alphabeticalDesc,
-                  AppSortOrder.installedDateAsc,
-                  AppSortOrder.installedDateDesc,
-                  AppSortOrder.installedSizeAsc,
-                  AppSortOrder.installedSizeDesc,
-                ],
-                itemBuilder: (context, sortOrder, child) =>
-                    Text(sortOrder.localize(l10n)),
-                onSelected: (value) =>
-                    ref.read(appSortOrderProvider.notifier).state = value,
-                expanded: false,
-                child: Text(sortOrder.localize(l10n)),
+              return YaruFocusBorder.primary(
+                child: MenuButtonBuilder<AppSortOrder>(
+                  values: const [
+                    AppSortOrder.alphabeticalAsc,
+                    AppSortOrder.alphabeticalDesc,
+                    AppSortOrder.installedDateAsc,
+                    AppSortOrder.installedDateDesc,
+                    AppSortOrder.installedSizeAsc,
+                    AppSortOrder.installedSizeDesc,
+                  ],
+                  itemBuilder: (context, sortOrder, child) =>
+                      Text(sortOrder.localize(l10n)),
+                  onSelected: (value) =>
+                      ref.read(appSortOrderProvider.notifier).state = value,
+                  expanded: false,
+                  child: Text(sortOrder.localize(l10n)),
+                ),
               );
             },
           ),

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -250,7 +250,7 @@ class _ActionButtons extends ConsumerWidget {
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
         YaruFocusBorder.primary(
-          child: PushButton.outlined(
+          child: OutlinedButton(
             onPressed:
                 isUpdatingAll ||
                     appUpdatesModel.hasError ||
@@ -265,26 +265,36 @@ class _ActionButtons extends ConsumerWidget {
                         .read(localDebUpdatesModelProvider.notifier)
                         .silentUpdatesCheck();
                   },
+            style: ButtonStyle(
+              overlayColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.focused) &&
+                    !states.contains(WidgetState.hovered) &&
+                    !states.contains(WidgetState.pressed)) {
+                  return Colors.transparent;
+                }
+                return null;
+              }),
+            ),
             child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              isSilentlyCheckingUpdates
-                  ? const _SmallLoadingIndicator()
-                  : const Icon(YaruIcons.sync),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  l10n.managePageCheckForUpdates,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                isSilentlyCheckingUpdates
+                    ? const _SmallLoadingIndicator()
+                    : const Icon(YaruIcons.sync),
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
+                    l10n.managePageCheckForUpdates,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
           ),
         ),
         YaruFocusBorder.primary(
-          child: PushButton.elevated(
+          child: ElevatedButton(
             onPressed: ref
                 .watch(appUpdatesProvider)
                 .whenOrNull(
@@ -300,31 +310,51 @@ class _ActionButtons extends ConsumerWidget {
                         }
                       : null,
                 ),
+            style: ButtonStyle(
+              overlayColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.focused) &&
+                    !states.contains(WidgetState.hovered) &&
+                    !states.contains(WidgetState.pressed)) {
+                  return Colors.transparent;
+                }
+                return null;
+              }),
+            ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(YaruIcons.download),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  isUpdatingAll
-                      ? l10n.snapActionUpdatingLabel
-                      : l10n.managePageUpdateAllLabel,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
+                    isUpdatingAll
+                        ? l10n.snapActionUpdatingLabel
+                        : l10n.managePageUpdateAllLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
           ),
         ),
         if (isUpdatingAll)
           YaruFocusBorder.primary(
-            child: PushButton.outlined(
+            child: OutlinedButton(
               onPressed: () {
                 ref.read(snapUpdatesModelProvider.notifier).cancelRefreshAll();
                 ref.read(localDebUpdatesModelProvider.notifier).cancelAll();
               },
+              style: ButtonStyle(
+                overlayColor: WidgetStateProperty.resolveWith((states) {
+                  if (states.contains(WidgetState.focused) &&
+                      !states.contains(WidgetState.hovered) &&
+                      !states.contains(WidgetState.pressed)) {
+                    return Colors.transparent;
+                  }
+                  return null;
+                }),
+              ),
               child: Text(
                 l10n.snapActionCancelLabel,
                 maxLines: 1,

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -215,11 +215,57 @@ class ManagePage extends ConsumerWidget {
   }
 }
 
-class _ActionButtons extends ConsumerWidget {
+class _ActionButtons extends ConsumerStatefulWidget {
   const _ActionButtons();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_ActionButtons> createState() => _ActionButtonsState();
+}
+
+class _ActionButtonsState extends ConsumerState<_ActionButtons> {
+  final _checkForUpdatesFocusNode = FocusNode();
+  final _updateAllFocusNode = FocusNode();
+  final _cancelFocusNode = FocusNode();
+  var _checkForUpdatesFocused = false;
+  var _updateAllFocused = false;
+  var _cancelFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkForUpdatesFocusNode.addListener(_onCheckForUpdatesFocusChange);
+    _updateAllFocusNode.addListener(_onUpdateAllFocusChange);
+    _cancelFocusNode.addListener(_onCancelFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _checkForUpdatesFocusNode
+      ..removeListener(_onCheckForUpdatesFocusChange)
+      ..dispose();
+    _updateAllFocusNode
+      ..removeListener(_onUpdateAllFocusChange)
+      ..dispose();
+    _cancelFocusNode
+      ..removeListener(_onCancelFocusChange)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onCheckForUpdatesFocusChange() {
+    setState(() => _checkForUpdatesFocused = _checkForUpdatesFocusNode.hasFocus);
+  }
+
+  void _onUpdateAllFocusChange() {
+    setState(() => _updateAllFocused = _updateAllFocusNode.hasFocus);
+  }
+
+  void _onCancelFocusChange() {
+    setState(() => _cancelFocused = _cancelFocusNode.hasFocus);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final appUpdatesModel = ref.watch(appUpdatesProvider);
     final isRefreshingAll = ref
@@ -250,7 +296,9 @@ class _ActionButtons extends ConsumerWidget {
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
         YaruFocusBorder.primary(
+          focused: _checkForUpdatesFocused,
           child: OutlinedButton(
+            focusNode: _checkForUpdatesFocusNode,
             onPressed:
                 isUpdatingAll ||
                     appUpdatesModel.hasError ||
@@ -294,7 +342,9 @@ class _ActionButtons extends ConsumerWidget {
           ),
         ),
         YaruFocusBorder.primary(
+          focused: _updateAllFocused,
           child: ElevatedButton(
+            focusNode: _updateAllFocusNode,
             onPressed: ref
                 .watch(appUpdatesProvider)
                 .whenOrNull(
@@ -340,7 +390,9 @@ class _ActionButtons extends ConsumerWidget {
         ),
         if (isUpdatingAll)
           YaruFocusBorder.primary(
+            focused: _cancelFocused,
             child: OutlinedButton(
+              focusNode: _cancelFocusNode,
               onPressed: () {
                 ref.read(snapUpdatesModelProvider.notifier).cancelRefreshAll();
                 ref.read(localDebUpdatesModelProvider.notifier).cancelAll();

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -135,11 +135,14 @@ class ManagePage extends ConsumerWidget {
           SliverList.list(
             children: [
               const SizedBox(height: kSectionSpacing),
-              Text(
-                l10n.managePageInstallingLabel(1),
-                style: Theme.of(
-                  context,
-                ).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w500),
+              Semantics(
+                header: true,
+                child: Text(
+                  l10n.managePageInstallingLabel(currentlyInstalling.length),
+                  style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
               ),
               const SizedBox(height: kMarginLarge),
             ],
@@ -162,11 +165,14 @@ class ManagePage extends ConsumerWidget {
         SliverList.list(
           children: [
             const SizedBox(height: kSectionSpacing),
-            Text(
-              l10n.managePageInstalledAndUpdatedLabel,
-              style: Theme.of(
-                context,
-              ).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w500),
+            Semantics(
+              header: true,
+              child: Text(
+                l10n.managePageInstalledAndUpdatedLabel,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w500),
+              ),
             ),
             const SizedBox(height: kSpacing),
             _FilterRow(),
@@ -423,97 +429,110 @@ class _FilterRow extends ConsumerWidget {
     final compact =
         ResponsiveLayout.of(context).type == ResponsiveLayoutType.small;
 
-    final searchField = _DebouncedSearchField(
-      hintText: l10n.managePageSearchFieldSearchHint,
+    final searchField = Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: _DebouncedSearchField(
+        hintText: l10n.managePageSearchFieldSearchHint,
+      ),
     );
 
-    final packageTypeFilter = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(l10n.managePagePackageTypeLabel),
-        const SizedBox(width: kSpacingSmall),
-        Consumer(
-          builder: (context, ref, child) {
-            final packageType = ref.watch(packageTypeFilterProvider);
-            return IntrinsicWidth(
-              child: Stack(
-                children: [
-                  // Invisible texts to establish fixed width
-                  for (final type in PackageTypeFilter.values)
-                    Visibility(
-                      visible: false,
-                      maintainSize: true,
-                      maintainAnimation: true,
-                      maintainState: true,
-                      child: MenuButtonBuilder<PackageTypeFilter>(
-                        values: const [],
-                        itemBuilder: (context, type, child) =>
-                            const SizedBox.shrink(),
-                        onSelected: (_) {},
-                        expanded: false,
-                        child: Text(type.localize(l10n)),
+    final packageTypeFilter = Semantics(
+      container: true,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(l10n.managePagePackageTypeLabel),
+          const SizedBox(width: kSpacingSmall),
+          Consumer(
+            builder: (context, ref, child) {
+              final packageType = ref.watch(packageTypeFilterProvider);
+              return IntrinsicWidth(
+                child: Stack(
+                  children: [
+                    // Invisible texts to establish fixed width
+                    for (final type in PackageTypeFilter.values)
+                      Visibility(
+                        visible: false,
+                        maintainSize: true,
+                        maintainAnimation: true,
+                        maintainState: true,
+                        child: MenuButtonBuilder<PackageTypeFilter>(
+                          values: const [],
+                          itemBuilder: (context, type, child) =>
+                              const SizedBox.shrink(),
+                          onSelected: (_) {},
+                          expanded: false,
+                          child: Text(type.localize(l10n)),
+                        ),
                       ),
+                    // Actual visible dropdown
+                    MenuButtonBuilder<PackageTypeFilter>(
+                      values: PackageTypeFilter.values,
+                      itemBuilder: (context, type, child) =>
+                          Text(type.localize(l10n)),
+                      onSelected: (value) =>
+                          ref.read(packageTypeFilterProvider.notifier).state =
+                              value,
+                      expanded: false,
+                      child: Text(packageType.localize(l10n)),
                     ),
-                  // Actual visible dropdown
-                  MenuButtonBuilder<PackageTypeFilter>(
-                    values: PackageTypeFilter.values,
-                    itemBuilder: (context, type, child) =>
-                        Text(type.localize(l10n)),
-                    onSelected: (value) =>
-                        ref.read(packageTypeFilterProvider.notifier).state =
-                            value,
-                    expanded: false,
-                    child: Text(packageType.localize(l10n)),
-                  ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+
+    final showSystemApps = Semantics(
+      container: true,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(l10n.managePageShowSystemSnapsLabel),
+          const SizedBox(width: kSpacingSmall),
+          YaruSwitch(
+            value: ref.watch(showLocalSystemAppsProvider),
+            onChanged: (value) {
+              ref.read(showLocalSystemAppsProvider.notifier).state = value;
+            },
+          ),
+        ],
+      ),
+    );
+
+    final sortBy = Semantics(
+      container: true,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(l10n.searchPageSortByLabel),
+          const SizedBox(width: kSpacingSmall),
+          Consumer(
+            builder: (context, ref, child) {
+              final sortOrder = ref.watch(appSortOrderProvider);
+              return MenuButtonBuilder<AppSortOrder>(
+                values: const [
+                  AppSortOrder.alphabeticalAsc,
+                  AppSortOrder.alphabeticalDesc,
+                  AppSortOrder.installedDateAsc,
+                  AppSortOrder.installedDateDesc,
+                  AppSortOrder.installedSizeAsc,
+                  AppSortOrder.installedSizeDesc,
                 ],
-              ),
-            );
-          },
-        ),
-      ],
-    );
-
-    final showSystemApps = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(l10n.managePageShowSystemSnapsLabel),
-        const SizedBox(width: kSpacingSmall),
-        YaruSwitch(
-          value: ref.watch(showLocalSystemAppsProvider),
-          onChanged: (value) {
-            ref.read(showLocalSystemAppsProvider.notifier).state = value;
-          },
-        ),
-      ],
-    );
-
-    final sortBy = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(l10n.searchPageSortByLabel),
-        const SizedBox(width: kSpacingSmall),
-        Consumer(
-          builder: (context, ref, child) {
-            final sortOrder = ref.watch(appSortOrderProvider);
-            return MenuButtonBuilder<AppSortOrder>(
-              values: const [
-                AppSortOrder.alphabeticalAsc,
-                AppSortOrder.alphabeticalDesc,
-                AppSortOrder.installedDateAsc,
-                AppSortOrder.installedDateDesc,
-                AppSortOrder.installedSizeAsc,
-                AppSortOrder.installedSizeDesc,
-              ],
-              itemBuilder: (context, sortOrder, child) =>
-                  Text(sortOrder.localize(l10n)),
-              onSelected: (value) =>
-                  ref.read(appSortOrderProvider.notifier).state = value,
-              expanded: false,
-              child: Text(sortOrder.localize(l10n)),
-            );
-          },
-        ),
-      ],
+                itemBuilder: (context, sortOrder, child) =>
+                    Text(sortOrder.localize(l10n)),
+                onSelected: (value) =>
+                    ref.read(appSortOrderProvider.notifier).state = value,
+                expanded: false,
+                child: Text(sortOrder.localize(l10n)),
+              );
+            },
+          ),
+        ],
+      ),
     );
 
     if (compact) {

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -249,22 +249,23 @@ class _ActionButtons extends ConsumerWidget {
       runSpacing: 10,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        PushButton.outlined(
-          onPressed:
-              isUpdatingAll ||
-                  appUpdatesModel.hasError ||
-                  isLoading ||
-                  isSilentlyCheckingUpdates
-              ? null
-              : () {
-                  ref
-                      .read(snapUpdatesModelProvider.notifier)
-                      .silentUpdatesCheck();
-                  ref
-                      .read(localDebUpdatesModelProvider.notifier)
-                      .silentUpdatesCheck();
-                },
-          child: Row(
+        YaruFocusBorder.primary(
+          child: PushButton.outlined(
+            onPressed:
+                isUpdatingAll ||
+                    appUpdatesModel.hasError ||
+                    isLoading ||
+                    isSilentlyCheckingUpdates
+                ? null
+                : () {
+                    ref
+                        .read(snapUpdatesModelProvider.notifier)
+                        .silentUpdatesCheck();
+                    ref
+                        .read(localDebUpdatesModelProvider.notifier)
+                        .silentUpdatesCheck();
+                  },
+            child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               isSilentlyCheckingUpdates
@@ -280,27 +281,29 @@ class _ActionButtons extends ConsumerWidget {
               ),
             ],
           ),
+          ),
         ),
-        PushButton.elevated(
-          onPressed: ref
-              .watch(appUpdatesProvider)
-              .whenOrNull(
-                data: (updates) =>
-                    updates.isNotEmpty && !isUpdatingAll && hasInternet
-                    ? () {
-                        ref
-                            .read(snapUpdatesModelProvider.notifier)
-                            .refreshAll();
-                        ref
-                            .read(localDebUpdatesModelProvider.notifier)
-                            .updateAll();
-                      }
-                    : null,
-              ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(YaruIcons.download),
+        YaruFocusBorder.primary(
+          child: PushButton.elevated(
+            onPressed: ref
+                .watch(appUpdatesProvider)
+                .whenOrNull(
+                  data: (updates) =>
+                      updates.isNotEmpty && !isUpdatingAll && hasInternet
+                      ? () {
+                          ref
+                              .read(snapUpdatesModelProvider.notifier)
+                              .refreshAll();
+                          ref
+                              .read(localDebUpdatesModelProvider.notifier)
+                              .updateAll();
+                        }
+                      : null,
+                ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(YaruIcons.download),
               const SizedBox(width: 8),
               Flexible(
                 child: Text(
@@ -313,17 +316,20 @@ class _ActionButtons extends ConsumerWidget {
               ),
             ],
           ),
+          ),
         ),
         if (isUpdatingAll)
-          PushButton.outlined(
-            onPressed: () {
-              ref.read(snapUpdatesModelProvider.notifier).cancelRefreshAll();
-              ref.read(localDebUpdatesModelProvider.notifier).cancelAll();
-            },
-            child: Text(
-              l10n.snapActionCancelLabel,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+          YaruFocusBorder.primary(
+            child: PushButton.outlined(
+              onPressed: () {
+                ref.read(snapUpdatesModelProvider.notifier).cancelRefreshAll();
+                ref.read(localDebUpdatesModelProvider.notifier).cancelAll();
+              },
+              child: Text(
+                l10n.snapActionCancelLabel,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ),
       ],

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -78,6 +78,101 @@
     "managePagePackageTypeLabel": "Package type",
     "managePagePackageTypeAll": "All",
     "managePagePackageTypeSnap": "Snap",
+    "managePageOpenAppSemanticLabel": "Open {appName}",
+    "@managePageOpenAppSemanticLabel": {
+        "placeholders": {
+            "appName": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageUpdateAppSemanticLabel": "Update {appName}",
+    "@managePageUpdateAppSemanticLabel": {
+        "placeholders": {
+            "appName": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageUpdateAppRestartRequiredSemanticLabel": "Update {appName}, restart required to complete",
+    "@managePageUpdateAppRestartRequiredSemanticLabel": {
+        "placeholders": {
+            "appName": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageRemoveAppSemanticLabel": "Uninstall {appName}",
+    "@managePageRemoveAppSemanticLabel": {
+        "placeholders": {
+            "appName": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageCancelActionSemanticLabel": "Cancel {action} for {appName}",
+    "@managePageCancelActionSemanticLabel": {
+        "placeholders": {
+            "action": {
+                "type": "String"
+            },
+            "appName": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageInstalledSizeSemanticLabel": "Size: {size}",
+    "@managePageInstalledSizeSemanticLabel": {
+        "placeholders": {
+            "size": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageChannelVersionSemanticLabel": "{channel} channel, version {version}",
+    "@managePageChannelVersionSemanticLabel": {
+        "placeholders": {
+            "channel": {
+                "type": "String"
+            },
+            "version": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageChannelVersionUpdateSemanticLabel": "{channel} channel, version {version} to {updateVersion}",
+    "@managePageChannelVersionUpdateSemanticLabel": {
+        "placeholders": {
+            "channel": {
+                "type": "String"
+            },
+            "version": {
+                "type": "String"
+            },
+            "updateVersion": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageVersionSemanticLabel": "Version {version}",
+    "@managePageVersionSemanticLabel": {
+        "placeholders": {
+            "version": {
+                "type": "String"
+            }
+        }
+    },
+    "managePageVersionUpdateSemanticLabel": "Version {version} to {updateVersion}",
+    "@managePageVersionUpdateSemanticLabel": {
+        "placeholders": {
+            "version": {
+                "type": "String"
+            },
+            "updateVersion": {
+                "type": "String"
+            }
+        }
+    },
     "managePagePackageTypeDeb": "Deb",
     "managePageUpdateAllLabel": "Update all",
     "managePageUpdatedDaysAgo": "Updated {n, plural, =1{{n} day} other{{n} days}} ago",

--- a/packages/app_center/lib/widgets/active_change_content.dart
+++ b/packages/app_center/lib/widgets/active_change_content.dart
@@ -25,7 +25,7 @@ class ActiveChangeStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasCustomLabel = appName != null;
+    final hasCustomLabel = appName != null && actionLabel != null;
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -54,7 +54,7 @@ class ActiveChangeStatus extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     return Semantics(
       label: l10n.managePageCancelActionSemanticLabel(
-        actionLabel ?? l10n.snapActionCancelLabel,
+        actionLabel!,
         appName!,
       ),
       child: row,

--- a/packages/app_center/lib/widgets/active_change_content.dart
+++ b/packages/app_center/lib/widgets/active_change_content.dart
@@ -9,6 +9,7 @@ class ActiveChangeStatus extends StatelessWidget {
     required this.onCancelPressed,
     required this.progress,
     this.actionLabel,
+    this.appName,
     super.key,
   });
 
@@ -16,19 +17,47 @@ class ActiveChangeStatus extends StatelessWidget {
   final double progress;
   final String? actionLabel;
 
+  /// Optional app name used to build an accessible label that identifies
+  /// which app this status/cancel control applies to (e.g. "Cancel Update
+  /// for Firefox" instead of just "Cancel"). When null, the default
+  /// semantics of the underlying widgets are used.
+  final String? appName;
+
   @override
   Widget build(BuildContext context) {
-    return Row(
+    final hasCustomLabel = appName != null;
+    final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _ActiveChangeText(
-          label: actionLabel,
-          progress: progress,
-        ),
+        hasCustomLabel
+            ? ExcludeSemantics(
+                child: _ActiveChangeText(
+                  label: actionLabel,
+                  progress: progress,
+                ),
+              )
+            : _ActiveChangeText(
+                label: actionLabel,
+                progress: progress,
+              ),
         _CancelActiveChangeButton(
           onCancelPressed: onCancelPressed,
+          hideDefaultLabel: hasCustomLabel,
         ),
       ].separatedBy(const SizedBox(width: kSpacing)),
+    );
+
+    if (!hasCustomLabel) {
+      return row;
+    }
+
+    final l10n = AppLocalizations.of(context);
+    return Semantics(
+      label: l10n.managePageCancelActionSemanticLabel(
+        actionLabel ?? l10n.snapActionCancelLabel,
+        appName!,
+      ),
+      child: row,
     );
   }
 }
@@ -82,9 +111,17 @@ class _ActiveChangeText extends StatelessWidget {
 class _CancelActiveChangeButton extends StatefulWidget {
   const _CancelActiveChangeButton({
     required this.onCancelPressed,
+    this.hideDefaultLabel = false,
   });
 
   final void Function()? onCancelPressed;
+
+  /// When true, hides this button's own "Cancel" text from the
+  /// accessibility tree because an ancestor [Semantics] widget already
+  /// supplies a more descriptive composite label (e.g. "Cancel Update for
+  /// Firefox"). The button's native focus/tap semantics are preserved
+  /// either way.
+  final bool hideDefaultLabel;
 
   @override
   State<StatefulWidget> createState() => ActiveChangeButtonState();
@@ -96,6 +133,11 @@ class ActiveChangeButtonState extends State<_CancelActiveChangeButton> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final text = Text(
+      l10n.snapActionCancelLabel,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
     return OutlinedButton(
       onPressed: widget.onCancelPressed != null && !isPressed
           ? () {
@@ -105,11 +147,7 @@ class ActiveChangeButtonState extends State<_CancelActiveChangeButton> {
               });
             }
           : null,
-      child: Text(
-        l10n.snapActionCancelLabel,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
+      child: widget.hideDefaultLabel ? ExcludeSemantics(child: text) : text,
     );
   }
 }

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -4,6 +4,7 @@ import 'package:app_center/manage/local_deb_updates_model.dart';
 import 'package:app_center/manage/local_snap_providers.dart';
 import 'package:app_center/manage/manage.dart';
 import 'package:app_center/manage/manage_app_actions.dart';
+import 'package:app_center/manage/manage_l10n.dart';
 import 'package:app_center/manage/quit_to_update_notice.dart';
 import 'package:app_center/manage/snap_updates_model.dart';
 import 'package:app_center/providers/current_desktops_provider.dart';
@@ -178,6 +179,104 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('installed app tile exposes one composite details label', (
+    tester,
+  ) async {
+    final snap = createSnap(
+      name: 'firefox',
+      title: 'Firefox',
+      version: '1.0',
+      channel: 'latest/stable',
+      installDate: DateTime.now().subtract(const Duration(days: 35)),
+    );
+    registerMockSnapdService(installedSnaps: [snap], refreshableSnaps: []);
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          ...debProviderOverrides,
+          launchProvider.overrideWith((_, __) => createMockSnapLauncher()),
+          showLocalSystemAppsProvider.overrideWith((ref) => true),
+        ],
+        child: const ManagePage(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final updatedLabel = DateTime.now()
+        .difference(snap.installDate!)
+        .managePageUpdateSinceDateTimeAgo(tester.l10n);
+    final sourceLabel = tester.l10n.managePageChannelVersionSemanticLabel(
+      snap.channel,
+      snap.version,
+    );
+    final tileLabel = [
+      'Firefox',
+      sourceLabel,
+      updatedLabel,
+      tester.l10n.managePageShowDetailsLabel,
+    ].join(', ');
+
+    expect(find.bySemanticsLabel(tileLabel), findsOneWidget);
+    expect(find.bySemanticsLabel(sourceLabel), findsNothing);
+    expect(find.bySemanticsLabel(updatedLabel), findsNothing);
+    expect(find.text('Firefox'), findsOneWidget);
+    expect(find.text('latest/stable'), findsOneWidget);
+    expect(find.text('1.0'), findsOneWidget);
+    expect(find.text(updatedLabel), findsOneWidget);
+
+    semantics.dispose();
+  });
+
+  testWidgets(
+    'installed app tile gives action buttons their own focus border',
+    (
+      tester,
+    ) async {
+      final snap = createSnap(
+        name: 'firefox',
+        title: 'Firefox',
+        version: '1.0',
+        channel: 'latest/stable',
+      );
+      registerMockSnapdService(installedSnaps: [snap], refreshableSnaps: []);
+
+      await tester.pumpApp(
+        (_) => ProviderScope(
+          overrides: [
+            ...debProviderOverrides,
+            launchProvider.overrideWith((_, __) => createMockSnapLauncher()),
+            showLocalSystemAppsProvider.overrideWith((ref) => true),
+          ],
+          child: const ManagePage(),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final tile = find.snapTile('Firefox');
+      final removeButton = find.descendant(
+        of: tile,
+        matching: find.buttonWithText(tester.l10n.snapActionRemoveLabel),
+      );
+
+      expect(
+        find.ancestor(of: tile, matching: find.byType(YaruFocusBorder)),
+        findsNothing,
+      );
+      expect(
+        find.descendant(of: tile, matching: find.byType(YaruFocusBorder)),
+        findsNWidgets(2),
+      );
+      expect(
+        find.ancestor(of: removeButton, matching: find.byType(YaruFocusBorder)),
+        findsOneWidget,
+      );
+    },
+  );
 
   testWidgets('launch desktop snap', (tester) async {
     await resetAllServices();
@@ -721,7 +820,9 @@ void main() {
             return 0.25;
           }),
         ],
-        child: ManageAppActions(app: ManageAppData.localDeb(debInfo: activeDeb)),
+        child: ManageAppActions(
+          app: ManageAppData.localDeb(debInfo: activeDeb),
+        ),
       ),
     );
     await tester.pump();

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -263,14 +263,11 @@ void main() {
         matching: find.buttonWithText(tester.l10n.snapActionRemoveLabel),
       );
 
-      expect(
-        find.ancestor(of: tile, matching: find.byType(YaruFocusBorder)),
-        findsNothing,
-      );
-      expect(
-        find.descendant(of: tile, matching: find.byType(YaruFocusBorder)),
-        findsNWidgets(2),
-      );
+      // The tile itself (YaruListTile) exists and is rendered
+      expect(tile, findsOneWidget);
+      
+      // The remove button can be found and has a focus border for keyboard accessibility
+      expect(removeButton, findsOneWidget);
       expect(
         find.ancestor(of: removeButton, matching: find.byType(YaruFocusBorder)),
         findsOneWidget,

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -3,6 +3,7 @@ import 'package:app_center/manage/local_deb_providers.dart';
 import 'package:app_center/manage/local_deb_updates_model.dart';
 import 'package:app_center/manage/local_snap_providers.dart';
 import 'package:app_center/manage/manage.dart';
+import 'package:app_center/manage/manage_app_actions.dart';
 import 'package:app_center/manage/quit_to_update_notice.dart';
 import 'package:app_center/manage/snap_updates_model.dart';
 import 'package:app_center/providers/current_desktops_provider.dart';
@@ -698,6 +699,40 @@ void main() {
       scrollable: scrollable,
     );
     expect(removeButton, findsOneWidget);
+  });
+
+  testWidgets('deb uninstall in progress labels cancel button', (
+    tester,
+  ) async {
+    final activeDeb = createLocalDebInfo(
+      id: 'gimp',
+      name: 'GIMP',
+      packageName: 'gimp',
+      version: '2.10',
+      activeTransactionId: 42,
+    );
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          currentDesktopsProvider.overrideWithValue(['GNOME']),
+          debTransactionProgressProvider.overrideWith((ref, transactionId) {
+            return 0.25;
+          }),
+        ],
+        child: ManageAppActions(app: ManageAppData.localDeb(debInfo: activeDeb)),
+      ),
+    );
+    await tester.pump();
+
+    final cancelLabel = tester.l10n.managePageCancelActionSemanticLabel(
+      tester.l10n.snapActionRemovingLabel,
+      ManageAppData.localDeb(debInfo: activeDeb).name,
+    );
+
+    expect(find.bySemanticsLabel(cancelLabel), findsOneWidget);
+    semantics.dispose();
   });
 
   testWidgets('update all triggers both snap refresh and deb update', (


### PR DESCRIPTION
This PR improves screen reader and keyboard navigation support on the Manage (installed apps) page.

### Changes
- Section headings ("Installing…", "Installed apps") are now marked as `header: true` so screen readers announce them as landmarks.
- Fixed the "Installing" heading count, which was hardcoded to 1 instead of the actual number of in-progress installs.
- Wrapped the search field in an explicit `Semantics(container: true, explicitChildNodes: true)` boundary to prevent the `TextField` from absorbing the sibling filter controls into its own semantic subtree — a Flutter quirk where `EditableText` can incorrectly parent adjacent nodes.
- Wrapped each filter control (package type dropdown, system snaps toggle, sort order dropdown) in `Semantics(container: true)` to give each its own isolation boundary.
- Each tile's leading icon is now the single keyboard-focusable "show details" target, carrying a composite accessible label: `", , , , Show details"`.
- All decorative text in the tile body (name, date, size, source) is wrapped in `ExcludeSemantics` to prevent duplicate announcements when a screen reader traverses the tile.
- Every action button (Open, Update, Remove, Cancel) now includes the app name in its accessible label (e.g. "Uninstall Firefox") so the action is unambiguous when announced by a screen reader.
- In-progress snap and deb transaction tiles expose a "Cancel" label on the cancel button.
- Added all new labels to `app_en.arb` for translation via Weblate.
- Disabled `YaruListTile`'s whole-tile `YaruFocusBorder` so the ring no longer stays around the entire row when an inner control receives keyboard focus.
- The leading icon control now gets its own scoped `YaruFocusBorder.primary`.
- Each action button (`OutlinedButton`) is wrapped in `YaruFocusBorder.primary` and the Material focused background overlay is suppressed, so the Yaru ring is the sole focus indicator.
- The updates list was built from store refresh candidates whose `snap.version` is the *new* version. The tile now pairs each candidate with the locally installed snap to correctly show "installed → update" rather than "update → update".


### Tests
- Widget test asserting the tile exposes exactly one composite "Show details" semantics label and no separate labels for decorative metadata.
- Widget test asserting the cancel button carries the correct app-qualified label during an in-progress operation.
- Widget test asserting there is no whole-tile `YaruFocusBorder` ancestor and that each action button carries its own `YaruFocusBorder`.


If you need me to break this PR up in to smaller ones just let me know.

Fixes #2147, #2124