### PR TITLE
fix: Don't let a failed catalog load hide snap updates

### DIFF
--- a/packages/app_center/lib/appstream/appstream_service.dart
+++ b/packages/app_center/lib/appstream/appstream_service.dart
@@ -159,6 +159,7 @@ class AppstreamService {
       .load()
       .onError<Exception>((error, _) {
         log.error('Failed to load the Appstream pool', error);
+        _catalogLoadFailed = true;
       })
       .then((_) {
         _populateCache();
@@ -167,6 +168,14 @@ class AppstreamService {
 
   bool get initialized => _initialized;
   bool _initialized = false;
+
+  /// Whether the catalog failed to load.
+  ///
+  /// A failed load leaves the pool empty, which is indistinguishable from a
+  /// system with no Appstream metadata. Callers that need to tell the user
+  /// their view is incomplete have to ask.
+  bool get catalogLoadFailed => _catalogLoadFailed;
+  bool _catalogLoadFailed = false;
 
   final HashSet<_CachedComponent> _cache = HashSet<_CachedComponent>();
 

--- a/packages/app_center/lib/appstream/appstream_service.dart
+++ b/packages/app_center/lib/appstream/appstream_service.dart
@@ -146,10 +146,24 @@ class AppstreamService {
     };
   }
   final AppstreamPool _pool;
-  late final Future<void> _loader = _pool.load().then((_) {
-    _populateCache();
-    _initialized = true;
-  });
+
+  /// Loads the pool, tolerating a failure to read the system catalogs.
+  ///
+  /// [AppstreamPool.load] aborts as soon as a single catalog file fails to
+  /// parse, e.g. because it contains metadata newer than the `appstream`
+  /// package understands. Letting that propagate would take down every
+  /// consumer of this service - including the deb providers that the manage
+  /// page's update list waits on - so the failure is logged and the service
+  /// carries on with whatever the pool managed to collect.
+  late final Future<void> _loader = _pool
+      .load()
+      .onError<Exception>((error, _) {
+        log.error('Failed to load the Appstream pool', error);
+      })
+      .then((_) {
+        _populateCache();
+        _initialized = true;
+      });
 
   bool get initialized => _initialized;
   bool _initialized = false;

--- a/packages/app_center/lib/manage/app_providers.dart
+++ b/packages/app_center/lib/manage/app_providers.dart
@@ -1,3 +1,4 @@
+import 'package:app_center/appstream/appstream.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/manage/local_deb_providers.dart';
 import 'package:app_center/manage/local_deb_updates_model.dart';
@@ -73,10 +74,14 @@ Future<List<ManageAppData>> appUpdates(Ref ref) async {
 Future<bool> debSourcesAvailable(Ref ref) async {
   try {
     await ref.watch(localDebsProvider.future);
-    return true;
   } on Exception {
     return false;
   }
+  // A catalog that failed to load leaves the service with no components, so
+  // the deb list comes back empty rather than throwing. Ask the service
+  // directly, otherwise the very failure this warning exists for is the one
+  // case it would miss.
+  return !getService<AppstreamService>().catalogLoadFailed;
 }
 
 /// Returns all installed debs, or an empty list if they could not be

--- a/packages/app_center/lib/manage/app_providers.dart
+++ b/packages/app_center/lib/manage/app_providers.dart
@@ -62,6 +62,23 @@ Future<List<ManageAppData>> appUpdates(Ref ref) async {
   );
 }
 
+/// Whether the deb sources could be read at all.
+///
+/// [appUpdates] and [InstalledApps] degrade to snap-only lists when the
+/// Appstream catalog or PackageKit is unavailable. That keeps the page
+/// working, but a store that quietly lists fewer updates than exist is its
+/// own hazard, so the manage page uses this to tell the user the list is
+/// incomplete.
+@riverpod
+Future<bool> debSourcesAvailable(Ref ref) async {
+  try {
+    await ref.watch(localDebsProvider.future);
+    return true;
+  } on Exception {
+    return false;
+  }
+}
+
 /// Returns all installed debs, or an empty list if they could not be
 /// determined. See [appUpdates].
 Future<List<LocalDebInfo>> _localDebsOrEmpty(Ref ref) async {

--- a/packages/app_center/lib/manage/app_providers.dart
+++ b/packages/app_center/lib/manage/app_providers.dart
@@ -42,7 +42,11 @@ final appSortOrderProvider = StateProvider<AppSortOrder>(
 @riverpod
 Future<List<ManageAppData>> appUpdates(Ref ref) async {
   final snapUpdates = await ref.watch(snapUpdatesModelProvider.future);
-  final debUpdates = await ref.watch(localDebUpdatesModelProvider.future);
+  // Snaps and debs are independent sources of updates, so a failure to
+  // enumerate one must not hide the other. Without this, an unreadable
+  // Appstream catalog or an unavailable PackageKit turns the whole updates
+  // list into an error page even when snapd has updates to offer.
+  final debUpdates = await _debUpdatesOrEmpty(ref);
 
   final snapApps = snapUpdates.snaps.map(
     (snap) => ManageAppData.snap(
@@ -56,6 +60,28 @@ Future<List<ManageAppData>> appUpdates(Ref ref) async {
   return [...snapApps, ...debApps]..sort(
     (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
   );
+}
+
+/// Returns all installed debs, or an empty list if they could not be
+/// determined. See [appUpdates].
+Future<List<LocalDebInfo>> _localDebsOrEmpty(Ref ref) async {
+  try {
+    return await ref.watch(localDebsProvider.future);
+  } on Exception catch (e) {
+    log.error('Failed to list installed debs', e);
+    return [];
+  }
+}
+
+/// Returns the debs with pending updates, or an empty list if they could not
+/// be determined. See [appUpdates].
+Future<List<LocalDebInfo>> _debUpdatesOrEmpty(Ref ref) async {
+  try {
+    return await ref.watch(localDebUpdatesModelProvider.future);
+  } on Exception catch (e) {
+    log.error('Failed to determine deb updates', e);
+    return [];
+  }
 }
 
 /// Manages the list of installed apps (snaps and debs) that do not have
@@ -73,7 +99,7 @@ class InstalledApps extends _$InstalledApps {
   @override
   Future<List<ManageAppData>> build() async {
     final snapListState = await ref.watch(localSnapsProvider.future);
-    final debs = await ref.watch(localDebsProvider.future);
+    final debs = await _localDebsOrEmpty(ref);
     final refreshableSnaps = (await ref.read(
       snapUpdatesModelProvider.future,
     )).snaps.map((s) => s.name);

--- a/packages/app_center/lib/manage/manage_page.dart
+++ b/packages/app_center/lib/manage/manage_page.dart
@@ -65,6 +65,7 @@ class ManagePage extends ConsumerWidget {
                 ),
               ),
               _SelfUpdateInfoBox(),
+              const _DebSourcesUnavailableInfoBox(),
               Builder(
                 builder: (context) {
                   final compact =
@@ -205,6 +206,34 @@ class ManagePage extends ConsumerWidget {
           padding: EdgeInsets.only(bottom: kPagePadding),
         ),
       ],
+    );
+  }
+}
+
+/// Warns that the deb sources could not be read, so the lists on this page
+/// only cover snaps. Without this the page would silently show fewer updates
+/// than are actually available.
+class _DebSourcesUnavailableInfoBox extends ConsumerWidget {
+  const _DebSourcesUnavailableInfoBox();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final debSourcesAvailable = ref.watch(
+      debSourcesAvailableProvider.select((value) => value.valueOrNull ?? true),
+    );
+
+    if (debSourcesAvailable) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: kMarginLarge),
+      child: YaruInfoBox(
+        yaruInfoType: YaruInfoType.warning,
+        title: Text(l10n.managePageDebSourcesUnavailableTitle),
+        subtitle: Text(l10n.managePageDebSourcesUnavailableDescription),
+      ),
     );
   }
 }

--- a/packages/app_center/lib/src/l10n/app_en.arb
+++ b/packages/app_center/lib/src/l10n/app_en.arb
@@ -60,6 +60,8 @@
     "managePageNoInternet": "Can't reach server, check your internet connection or try again later.",
     "managePageDescription": "Check for available updates, update your apps, and manage the status of all your apps.",
     "managePageDebUpdatesMessage": "Debian package updates are handled by the Software Updater.",
+    "managePageDebSourcesUnavailableTitle": "Some apps may be missing",
+    "managePageDebSourcesUnavailableDescription": "Debian package information couldn't be read, so these lists only cover snaps.",
     "managePageInstalledAndUpdatedLabel": "Installed apps",
     "managePageInstallingLabel": "Installing ({n})",
     "@managePageInstallingLabel": {

--- a/packages/app_center/test/appstream_service_test.dart
+++ b/packages/app_center/test/appstream_service_test.dart
@@ -67,6 +67,24 @@ void main() {
     expect(service.initialized, isTrue);
   });
 
+  test('initialize service when the pool fails to load', () async {
+    // A single unparseable catalog file makes `AppstreamPool.load()` throw.
+    // The service must survive it, so that the providers waiting on it - such
+    // as the manage page's update list - are not taken down with it.
+    when(pool.load()).thenAnswer(
+      (_) async => throw const AppstreamCollectionLoadException(
+        '/var/lib/swcatalog/yaml/some-catalog.yml.gz',
+        "Unknown release type 'snapshot'",
+      ),
+    );
+
+    await expectLater(service.init(), completes);
+    expect(service.initialized, isTrue);
+    expect(service.cacheSize, 0);
+    expect(await service.search('0ad'), isEmpty);
+    expect(service.getComponentsByPackage(), isEmpty);
+  });
+
   test('load and cache components', () async {
     components.add(component1);
     await service.init();

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -431,6 +431,36 @@ void main() {
     });
   });
 
+  group('debSourcesAvailable provider', () {
+    tearDown(resetAllServices);
+
+    test('is true when the debs can be listed', () async {
+      registerMockSnapdService();
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith((ref) async => [defaultInstalledDeb]),
+        ],
+      );
+
+      expect(await container.read(debSourcesAvailableProvider.future), isTrue);
+    });
+
+    test('is false when the debs cannot be listed', () async {
+      registerMockSnapdService();
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith(
+            (ref) async => throw Exception('no appstream catalog'),
+          ),
+        ],
+      );
+
+      expect(await container.read(debSourcesAvailableProvider.future), isFalse);
+    });
+  });
+
   group('installedApps provider', () {
     tearDown(resetAllServices);
 

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -436,6 +436,7 @@ void main() {
 
     test('is true when the debs can be listed', () async {
       registerMockSnapdService();
+      createMockAppstreamService();
 
       final container = createContainer(
         overrides: [
@@ -444,6 +445,20 @@ void main() {
       );
 
       expect(await container.read(debSourcesAvailableProvider.future), isTrue);
+    });
+
+    test('is false when the catalog failed to load', () async {
+      // The catalog failure is swallowed by AppstreamService, so the deb list
+      // resolves empty rather than throwing. This is the path that actually
+      // occurs when a catalog file cannot be parsed.
+      registerMockSnapdService();
+      createMockAppstreamService(catalogLoadFailed: true);
+
+      final container = createContainer(
+        overrides: [localDebsProvider.overrideWith((ref) async => [])],
+      );
+
+      expect(await container.read(debSourcesAvailableProvider.future), isFalse);
     });
 
     test('is false when the debs cannot be listed', () async {

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -257,6 +257,28 @@ void main() {
       expect(updates[1].name, equals('Inkscape'));
       expect(updates[1], isA<ManageDebData>());
     });
+
+    test('still reports snap updates when the deb lookup fails', () async {
+      registerMockSnapdService(
+        refreshableSnaps: [createSnap(name: 'firefox', title: 'Firefox')],
+        installedSnaps: [createSnap(name: 'firefox', title: 'Firefox')],
+      );
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith(
+            (ref) async => throw Exception('no appstream catalog'),
+          ),
+          localDebUpdatesModelProvider.overrideWith(LocalDebUpdatesModel.new),
+        ],
+      );
+
+      final updates = await container.read(appUpdatesProvider.future);
+
+      expect(updates, hasLength(1));
+      expect(updates.single.name, equals('Firefox'));
+      expect(updates.single, isA<ManageSnapData>());
+    });
   });
 
   group('localDebUpdatesModel actions', () {
@@ -411,6 +433,28 @@ void main() {
 
   group('installedApps provider', () {
     tearDown(resetAllServices);
+
+    test('still lists snaps when the deb lookup fails', () async {
+      registerMockSnapdService(
+        installedSnaps: [createSnap(name: 'firefox', title: 'Firefox')],
+      );
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith(
+            (ref) async => throw Exception('no appstream catalog'),
+          ),
+          localDebUpdatesModelProvider.overrideWith(LocalDebUpdatesModel.new),
+          showLocalSystemAppsProvider.overrideWith((ref) => true),
+        ],
+      );
+
+      final apps = await container.read(installedAppsProvider.future);
+
+      expect(apps, hasLength(1));
+      expect(apps.single.name, equals('Firefox'));
+      expect(apps.single, isA<ManageSnapData>());
+    });
 
     test('includes both snaps and debs', () async {
       registerMockSnapdService(

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -128,6 +128,49 @@ void main() {
   });
   tearDown(resetAllServices);
 
+  testWidgets('warns when the deb sources are unavailable', (tester) async {
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          localDebsProvider.overrideWith(
+            (ref) async => throw Exception('no appstream catalog'),
+          ),
+          localDebUpdatesModelProvider.overrideWith(LocalDebUpdatesModel.new),
+          launchProvider.overrideWith((_, __) => createMockSnapLauncher()),
+          showLocalSystemAppsProvider.overrideWith((ref) => true),
+        ],
+        child: const ManagePage(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(tester.l10n.managePageDebSourcesUnavailableTitle),
+      findsOneWidget,
+    );
+    // The snap updates must still be listed alongside the warning.
+    expect(find.snapTile('Snap with an update'), findsOneWidget);
+  });
+
+  testWidgets('no warning when the deb sources are available', (tester) async {
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          ...debProviderOverrides,
+          launchProvider.overrideWith((_, __) => createMockSnapLauncher()),
+          showLocalSystemAppsProvider.overrideWith((ref) => true),
+        ],
+        child: const ManagePage(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(tester.l10n.managePageDebSourcesUnavailableTitle),
+      findsNothing,
+    );
+  });
+
   testWidgets('list installed snaps', (tester) async {
     await tester.pumpApp(
       (_) => ProviderScope(

--- a/packages/app_center/test/manage_page_test.dart
+++ b/packages/app_center/test/manage_page_test.dart
@@ -128,13 +128,14 @@ void main() {
   });
   tearDown(resetAllServices);
 
-  testWidgets('warns when the deb sources are unavailable', (tester) async {
+  testWidgets('warns when the catalog failed to load', (tester) async {
+    // The realistic failure: AppstreamService swallows the catalog error, so
+    // the deb list resolves empty instead of throwing.
+    createMockAppstreamService(catalogLoadFailed: true);
     await tester.pumpApp(
       (_) => ProviderScope(
         overrides: [
-          localDebsProvider.overrideWith(
-            (ref) async => throw Exception('no appstream catalog'),
-          ),
+          localDebsProvider.overrideWith((ref) async => []),
           localDebUpdatesModelProvider.overrideWith(LocalDebUpdatesModel.new),
           launchProvider.overrideWith((_, __) => createMockSnapLauncher()),
           showLocalSystemAppsProvider.overrideWith((ref) => true),

--- a/packages/app_center/test/test_utils.dart
+++ b/packages/app_center/test/test_utils.dart
@@ -362,9 +362,11 @@ MockAppstreamService createMockAppstreamService({
   AppstreamComponent? component,
   List<AppstreamComponent>? components,
   bool initialized = true,
+  bool catalogLoadFailed = false,
 }) {
   final appstream = MockAppstreamService();
   when(appstream.initialized).thenReturn(initialized);
+  when(appstream.catalogLoadFailed).thenReturn(catalogLoadFailed);
   when(appstream.init()).thenAnswer((_) async {});
 
   final allComponents = components ?? [if (component != null) component];


### PR DESCRIPTION
## Problem

`AppstreamPool.load()` runs every catalog file through a single
`Future.wait`, so one file it cannot parse fails the entire load. Since
0.2.11 the package surfaces that as `AppstreamCollectionLoadException`
rather than hanging, but the whole-load failure remains.

App Center then amplifies it. The failure propagates
`componentsByPackage` -> `localDebs` -> `localDebUpdatesModel`, and
`appUpdates` awaits the snap and deb sources in the same function body:

```dart
final snapUpdates = await ref.watch(snapUpdatesModelProvider.future);
final debUpdates = await ref.watch(localDebUpdatesModelProvider.future);
```

So an unreadable deb catalog takes the *snap* updates down with it, even
though snapd has updates to offer and was never involved in the failure.
An unavailable PackageKit does the same thing.

This is close to what #2156 fixed: a `snapshot` release type that the
pinned `appstream` did not recognise made the catalog unparseable, and
users saw an App Center that listed no updates at all. That specific
trigger is gone, but the amplification that turned a metadata problem
into "no updates" is still here, waiting for the next catalog file the
parser cannot handle — a future release type, or metadata from a
third-party repo.

This PR does not change any parsing. It limits the blast radius.

## Changes

- `AppstreamService` logs a pool load failure and continues with an empty
  catalog instead of propagating it to every consumer.
- `appUpdates` and `InstalledApps` treat snaps and debs as independent
  sources, so a failure in one no longer hides the other.
- A warning info box on the manage page tells the user the lists only
  cover snaps, so the degraded state is visible rather than silent.

The third point is deliberate: a store that quietly lists fewer updates
than exist is its own hazard. The existing error stream was not usable
for it — the listener in `store_app.dart` only forwards `SnapdException`,
and widening that would route every uncaught zone error into a modal. An
inline box on the affected page says it where it matters. It is a
separate commit if you would rather not take it.

## Testing

New tests, each of which fails without the corresponding change:

- `appstream_service_test`: the service still initialises when the pool
  throws.
- `manage_models_test`: snap updates and installed snaps still resolve
  when the deb lookup throws; `debSourcesAvailable` reflects the failure.
- `manage_page_test`: the warning renders when the deb sources fail, and
  the snap update tile is still listed alongside it.

`melos test`, `melos analyze --fatal-infos` and `melos format:exclude`
all pass.
