### PR TITLE
fix(packagekit): recover connection when loading deb details

### DIFF
--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -13,6 +13,8 @@ import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 
 export 'package:packagekit/packagekit.dart' show PackageKitTransaction;
 
+const _packageKitBusName = 'org.freedesktop.PackageKit';
+
 typedef PackageKitPackageInfo = PackageKitPackageEvent;
 typedef PackageKitServiceError = PackageKitErrorCodeEvent;
 typedef PackageKitPackageDetails = PackageKitDetailsEvent;
@@ -34,7 +36,13 @@ class PackageKitService {
     @visibleForTesting this._runtimeDir,
   }) : _client = client ?? getService<PackageKitClient>(),
        _dbus = dbus ?? DBusClient.system(),
-       _fs = fs ?? const LocalFileSystem();
+       _fs = fs ?? const LocalFileSystem() {
+    _nameOwnerSubscription = _dbus.nameOwnerChanged.listen((event) {
+      if (event.name == _packageKitBusName && event.newOwner == null) {
+        _isAvailable = false;
+      }
+    });
+  }
 
   final PackageKitClient _client;
   final DBusClient _dbus;
@@ -43,6 +51,8 @@ class PackageKitService {
   final String? _runtimeDir;
   XdgDesktopPortalClient? _desktopPortalClient;
   io.Directory? _mountPoint;
+  late final StreamSubscription<DBusNameOwnerChangedEvent>
+  _nameOwnerSubscription;
 
   bool get isAvailable => _isAvailable;
   bool _isAvailable = false;
@@ -79,7 +89,7 @@ class PackageKitService {
     await object.callMethod(
       'org.freedesktop.DBus',
       'StartServiceByName',
-      const [DBusString('org.freedesktop.PackageKit'), DBusUint32(0)],
+      const [DBusString(_packageKitBusName), DBusUint32(0)],
     );
     try {
       await _client.connect();
@@ -101,6 +111,7 @@ class PackageKitService {
     void Function(PackageKitEvent event)? listener,
     void Function()? onDone,
   }) async {
+    await activateService();
     final transaction = await _client.createTransaction();
     final id = _nextId++;
     _transactions[id] = transaction;
@@ -459,6 +470,7 @@ class PackageKitService {
   }
 
   Future<void> dispose() async {
+    await _nameOwnerSubscription.cancel();
     await _dbus.close();
     await _client.close();
     await _errorStreamController.close();

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -79,6 +79,42 @@ void main() {
       ).called(1);
       expect(packageKit.isAvailable, isFalse);
     });
+
+    test('service reactivated after losing its D-Bus owner', () async {
+      final ownerChanges = StreamController<DBusNameOwnerChangedEvent>();
+      final dbus = createMockDbusClient();
+      when(dbus.nameOwnerChanged).thenAnswer((_) => ownerChanges.stream);
+      final packageKit = PackageKitService(
+        dbus: dbus,
+        client: createMockPackageKitClient(),
+        fs: MemoryFileSystem.test(),
+      );
+
+      await packageKit.install(
+        const PackageKitPackageId(name: 'foo', version: '1.0'),
+      );
+      ownerChanges.add(
+        const DBusNameOwnerChangedEvent(
+          _packageKitDBusName,
+          oldOwner: ':1.0',
+        ),
+      );
+      await pumpEventQueue();
+      expect(packageKit.isAvailable, isFalse);
+
+      await packageKit.activateService();
+
+      verify(
+        dbus.callMethod(
+          path: DBusObjectPath(_dBusObjectPath),
+          destination: _dBusName,
+          name: 'StartServiceByName',
+          interface: _dBusInterface,
+          values: const [DBusString(_packageKitDBusName), DBusUint32(0)],
+        ),
+      ).called(2);
+      await ownerChanges.close();
+    });
   });
 
   test('install', () async {
@@ -671,6 +707,7 @@ void main() {
 @GenerateMocks([DBusClient, XdgDocumentsPortal])
 MockDBusClient createMockDbusClient() {
   final dbus = MockDBusClient();
+  when(dbus.nameOwnerChanged).thenAnswer((_) => const Stream.empty());
   when(
     dbus.callMethod(
       path: DBusObjectPath(_dBusObjectPath),


### PR DESCRIPTION
Recover the PackageKit connection when loading Debian package details after the PackageKit daemon has stopped.

App Center now monitors PackageKit’s D-Bus name ownership and marks the service as unavailable when its owner disappears. Before creating each transaction, App Center activates the service again using the existing client.

The D-Bus subscription is cancelled when the service is disposed.

## Testing

- Added coverage for PackageKit losing its D-Bus owner.
- Verified the service is marked as unavailable.
- Verified PackageKit is activated again before the next transaction.

Commands:

- `fvm flutter test test/packagekit_service_test.dart`
- `fvm flutter test test/drivers_service_test.dart`
- `fvm flutter analyze --fatal-infos lib/packagekit/packagekit_service.dart test/packagekit_service_test.dart`
- `fvm flutter build linux`
---

UDENG-11237

