### PR TITLE
fix(manage): exclude blocked (phased) deb updates from update lists

### DIFF
--- a/packages/app_center/lib/deb/deb_model.dart
+++ b/packages/app_center/lib/deb/deb_model.dart
@@ -150,18 +150,24 @@ class DebModel extends _$DebModel {
     final updates = detailsEvent?.updates.where(
       (pid) => pid != packageInfo.packageId,
     );
-    var hasUpdate = false;
+    if (updates == null || updates.isEmpty) return false;
 
-    for (final packageUpdate in updates ?? <PackageKitPackageId>[]) {
+    // getUpdateDetails doesn't flag blocked (e.g. phased) updates, so
+    // cross-check against the installable updates from GetUpdates.
+    final installableNames = (await packageKit.getUpdates())
+        .map((u) => u.packageId.name)
+        .toSet();
+
+    for (final packageUpdate in updates) {
       final packageName = packageUpdate.name;
+      if (!installableNames.contains(packageName)) continue;
       final results = await packageKit.resolve([
         packageName,
       ], installedOnly: true);
-      hasUpdate = results[packageName]?.info == PackageKitInfo.installed;
-      break;
+      return results[packageName]?.info == PackageKitInfo.installed;
     }
 
-    return hasUpdate;
+    return false;
   }
 
   Future<void> _packageKitAction(Future<int> Function() action) async {
@@ -169,7 +175,18 @@ class DebModel extends _$DebModel {
     state = AsyncValue.data(
       state.value!.copyWith(activeTransactionId: transactionId),
     );
-    await packageKit.waitTransaction(transactionId);
+    try {
+      await packageKit.waitTransaction(transactionId);
+    } on Exception catch (e) {
+      // Report via the same path as PackageKitServiceError events so the
+      // page shows the error and clears the stuck transaction state.
+      await _onError(
+        PackageKitServiceError(
+          code: PackageKitError.internalError,
+          details: e.toString(),
+        ),
+      );
+    }
     ref.invalidateSelf();
   }
 }

--- a/packages/app_center/lib/deb/deb_model.dart
+++ b/packages/app_center/lib/deb/deb_model.dart
@@ -152,8 +152,8 @@ class DebModel extends _$DebModel {
     );
     if (updates == null || updates.isEmpty) return false;
 
-    // getUpdateDetails doesn't flag blocked (e.g. phased) updates, so
-    // cross-check against the installable updates from GetUpdates.
+    /* getUpdateDetails doesn't flag blocked (e.g. phased) updates, so
+       cross-check against the installable updates from GetUpdates. */
     final installableNames = (await packageKit.getUpdates())
         .map((u) => u.packageId.name)
         .toSet();
@@ -180,8 +180,8 @@ class DebModel extends _$DebModel {
     } on PackageKitTransactionCancelled {
       // User cancelled (e.g. dismissed the polkit dialog) — not an error.
     } on Exception catch (e) {
-      // Report via the same path as PackageKitServiceError events so the
-      // page shows the error and clears the stuck transaction state.
+      /* Report via the same path as PackageKitServiceError events so the
+         page shows the error and clears the stuck transaction state. */
       await _onError(
         PackageKitServiceError(
           code: PackageKitError.internalError,

--- a/packages/app_center/lib/deb/deb_model.dart
+++ b/packages/app_center/lib/deb/deb_model.dart
@@ -177,6 +177,8 @@ class DebModel extends _$DebModel {
     );
     try {
       await packageKit.waitTransaction(transactionId);
+    } on PackageKitTransactionCancelled {
+      // User cancelled (e.g. dismissed the polkit dialog) — not an error.
     } on Exception catch (e) {
       // Report via the same path as PackageKitServiceError events so the
       // page shows the error and clears the stuck transaction state.
@@ -185,6 +187,10 @@ class DebModel extends _$DebModel {
           code: PackageKitError.internalError,
           details: e.toString(),
         ),
+      );
+    } finally {
+      state = AsyncValue.data(
+        state.value!.copyWith(activeTransactionId: null),
       );
     }
     ref.invalidateSelf();

--- a/packages/app_center/lib/manage/local_deb_updates_model.dart
+++ b/packages/app_center/lib/manage/local_deb_updates_model.dart
@@ -127,7 +127,8 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
 
   /// Updates a single deb package by starting a PackageKit transaction,
   /// waiting for it to complete, then moving the deb from the updates list
-  /// to the installed apps list.
+  /// to the installed apps list. Failures are reported to the error stream
+  /// and clear the transaction state so the UI doesn't get stuck.
   Future<void> updateDeb(String debId) async {
     if (!state.hasValue) return;
     final deb = state.value!.firstWhere((d) => d.id == debId);
@@ -145,6 +146,9 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
         activeTransactionId: null,
       );
       ref.read(installedAppsProvider.notifier).addDebToList(updatedDeb);
+    } on Exception catch (e) {
+      log.warning('Update transaction failed: $transactionId for $debId: $e');
+      ref.read(errorStreamControllerProvider).add(e);
     } finally {
       // Always clear the transaction state, even if cancelled or failed
       _updateTransactionId(debId, null);

--- a/packages/app_center/lib/manage/local_deb_updates_model.dart
+++ b/packages/app_center/lib/manage/local_deb_updates_model.dart
@@ -147,8 +147,11 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
       );
       ref.read(installedAppsProvider.notifier).addDebToList(updatedDeb);
     } on PackageKitTransactionCancelled {
-      // User cancelled (e.g. dismissed the polkit dialog) — not an error.
+      // User cancelled (e.g. dismissed the polkit dialog) — not an error, but
+      // propagate it so callers like [updateAll] can stop the batch instead of
+      // triggering another authentication prompt for the next deb.
       log.info('Update transaction cancelled: $transactionId for $debId');
+      rethrow;
     } on Exception catch (e) {
       log.warning('Update transaction failed: $transactionId for $debId: $e');
       ref.read(errorStreamControllerProvider).add(e);
@@ -169,6 +172,7 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
 
   /// Updates all debs with pending updates sequentially. Collects any errors
   /// per-deb and reports them to the error stream after all updates complete.
+  /// A user-initiated cancellation stops the whole batch.
   Future<void> updateAll() async {
     if (!state.hasValue) return;
     final debIds = state.value!
@@ -183,6 +187,11 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
     for (final debId in debIds) {
       try {
         await updateDeb(debId);
+      } on PackageKitTransactionCancelled {
+        // The user cancelled the batch (Cancel All or a dismissed polkit
+        // dialog) — don't start further transactions, each would prompt for
+        // authentication again.
+        break;
       } on Exception catch (e) {
         errors[debId] = e;
       }

--- a/packages/app_center/lib/manage/local_deb_updates_model.dart
+++ b/packages/app_center/lib/manage/local_deb_updates_model.dart
@@ -147,9 +147,9 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
       );
       ref.read(installedAppsProvider.notifier).addDebToList(updatedDeb);
     } on PackageKitTransactionCancelled {
-      // User cancelled (e.g. dismissed the polkit dialog) — not an error, but
-      // propagate it so callers like [updateAll] can stop the batch instead of
-      // triggering another authentication prompt for the next deb.
+      /* User cancelled (e.g. dismissed the polkit dialog) — not an error,
+         but propagate it so callers like [updateAll] can stop the batch
+         instead of triggering another authentication prompt. */
       log.info('Update transaction cancelled: $transactionId for $debId');
       rethrow;
     } on Exception catch (e) {
@@ -188,9 +188,8 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
       try {
         await updateDeb(debId);
       } on PackageKitTransactionCancelled {
-        // The user cancelled the batch (Cancel All or a dismissed polkit
-        // dialog) — don't start further transactions, each would prompt for
-        // authentication again.
+        /* The user cancelled the batch — starting the next deb's transaction
+           would prompt for authentication again. */
         break;
       } on Exception catch (e) {
         errors[debId] = e;

--- a/packages/app_center/lib/manage/local_deb_updates_model.dart
+++ b/packages/app_center/lib/manage/local_deb_updates_model.dart
@@ -146,6 +146,9 @@ class LocalDebUpdatesModel extends _$LocalDebUpdatesModel {
         activeTransactionId: null,
       );
       ref.read(installedAppsProvider.notifier).addDebToList(updatedDeb);
+    } on PackageKitTransactionCancelled {
+      // User cancelled (e.g. dismissed the polkit dialog) — not an error.
+      log.info('Update transaction cancelled: $transactionId for $debId');
     } on Exception catch (e) {
       log.warning('Update transaction failed: $transactionId for $debId: $e');
       ref.read(errorStreamControllerProvider).add(e);

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -33,6 +33,15 @@ class PackageKitTransactionCancelled extends PackageKitTransactionError {
   PackageKitTransactionCancelled(super.message);
 }
 
+// PackageKit reports a dismissed polkit dialog as ErrorCode(notAuthorized)
+// followed by Finished(exit=failed) — there is no cancelled exit code for it
+// (pk-transaction.c: pk_transaction_authorize_actions_cb). Both
+// user-driven codes must be treated as cancellations everywhere, so callers
+// never surface a dialog for an action the user declined.
+bool _isUserCancellation(PackageKitError code) =>
+    code == PackageKitError.notAuthorized ||
+    code == PackageKitError.transactionCancelled;
+
 class PackageKitService {
   PackageKitService({
     @visibleForTesting PackageKitClient? client,
@@ -134,10 +143,16 @@ class PackageKitService {
           log.warning('onDone callback threw during transaction cleanup: $e');
         }
       } else if (event is PackageKitErrorCodeEvent) {
-        _errorStreamController.add(event);
-        log.error(
-          'Received PackageKitErrorCodeEvent (${event.code}): ${event.details}',
-        );
+        if (_isUserCancellation(event.code)) {
+          log.info(
+            'Transaction cancelled by user (${event.code}): ${event.details}',
+          );
+        } else {
+          _errorStreamController.add(event);
+          log.error(
+            'Received PackageKitErrorCodeEvent (${event.code}): ${event.details}',
+          );
+        }
       }
     });
     try {
@@ -156,20 +171,25 @@ class PackageKitService {
   }
 
   /// Waits until the transaction specified by the internal `id` has finished.
-  /// Throws a [PackageKitTransactionError] if the transaction fails or is
-  /// destroyed before finishing.
+  /// Throws a [PackageKitTransactionCancelled] if the transaction was
+  /// cancelled by the user — explicitly, or by dismissing the polkit dialog,
+  /// which the daemon reports as a failed exit with a `notAuthorized` error
+  /// code. Throws a [PackageKitTransactionError] for any other failure or if
+  /// the transaction is destroyed before finishing.
   Future<void> waitTransaction(int id) async {
     if (!_transactions.keys.contains(id)) {
       throw PackageKitTransactionError('Transaction $id not found');
     }
 
+    var cancelledByUser = false;
     final completer = Completer();
     final subscription = _transactions[id]!.events.listen(
       (event) {
         if (event is PackageKitFinishedEvent) {
           if (event.exit == PackageKitExit.success) {
             completer.complete();
-          } else if (event.exit == PackageKitExit.cancelled) {
+          } else if (event.exit == PackageKitExit.cancelled ||
+              cancelledByUser) {
             completer.completeError(
               PackageKitTransactionCancelled('Transaction $id was cancelled'),
             );
@@ -179,6 +199,10 @@ class PackageKitService {
                 'Transaction $id finished with exit code: ${event.exit}',
               ),
             );
+          }
+        } else if (event is PackageKitErrorCodeEvent) {
+          if (_isUserCancellation(event.code)) {
+            cancelledByUser = true;
           }
         } else if (event is PackageKitDestroyEvent) {
           completer.completeError(

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -27,6 +27,12 @@ class PackageKitTransactionError implements Exception {
   String toString() => 'PackageKitTransactionError: $message';
 }
 
+/// Thrown when a transaction is cancelled by the user (e.g. by dismissing
+/// the polkit dialog). Callers should treat this as a no-op, not an error.
+class PackageKitTransactionCancelled extends PackageKitTransactionError {
+  PackageKitTransactionCancelled(super.message);
+}
+
 class PackageKitService {
   PackageKitService({
     @visibleForTesting PackageKitClient? client,
@@ -163,6 +169,10 @@ class PackageKitService {
         if (event is PackageKitFinishedEvent) {
           if (event.exit == PackageKitExit.success) {
             completer.complete();
+          } else if (event.exit == PackageKitExit.cancelled) {
+            completer.completeError(
+              PackageKitTransactionCancelled('Transaction $id was cancelled'),
+            );
           } else {
             completer.completeError(
               PackageKitTransactionError(

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -399,7 +399,11 @@ class PackageKitService {
     await _createTransaction(
       action: (transaction) => transaction.getUpdates(),
       listener: (event) {
-        if (event is PackageKitPackageEvent) {
+        // Skip blocked (e.g. phased) updates — they are not installable
+        // candidates and attempting to update them fails with
+        // PackageKitError.packageNotFound.
+        if (event is PackageKitPackageEvent &&
+            event.info != PackageKitInfo.blocked) {
           updates.add(event);
         }
       },

--- a/packages/app_center/lib/packagekit/packagekit_service.dart
+++ b/packages/app_center/lib/packagekit/packagekit_service.dart
@@ -33,11 +33,11 @@ class PackageKitTransactionCancelled extends PackageKitTransactionError {
   PackageKitTransactionCancelled(super.message);
 }
 
-// PackageKit reports a dismissed polkit dialog as ErrorCode(notAuthorized)
-// followed by Finished(exit=failed) — there is no cancelled exit code for it
-// (pk-transaction.c: pk_transaction_authorize_actions_cb). Both
-// user-driven codes must be treated as cancellations everywhere, so callers
-// never surface a dialog for an action the user declined.
+/* PackageKit reports a dismissed polkit dialog as ErrorCode(notAuthorized)
+   followed by Finished(exit=failed) — there is no cancelled exit code for it
+   (pk-transaction.c: pk_transaction_authorize_actions_cb). Both user-driven
+   codes must be treated as cancellations everywhere, so callers never
+   surface a dialog for an action the user declined. */
 bool _isUserCancellation(PackageKitError code) =>
     code == PackageKitError.notAuthorized ||
     code == PackageKitError.transactionCancelled;
@@ -433,9 +433,9 @@ class PackageKitService {
     await _createTransaction(
       action: (transaction) => transaction.getUpdates(),
       listener: (event) {
-        // Skip blocked (e.g. phased) updates — they are not installable
-        // candidates and attempting to update them fails with
-        // PackageKitError.packageNotFound.
+        /* Skip blocked (e.g. phased) updates — they are not installable
+           candidates and attempting to update them fails with
+           PackageKitError.packageNotFound. */
         if (event is PackageKitPackageEvent &&
             event.info != PackageKitInfo.blocked) {
           updates.add(event);

--- a/packages/app_center/lib/providers/error_stream_provider.dart
+++ b/packages/app_center/lib/providers/error_stream_provider.dart
@@ -16,4 +16,6 @@ ErrorStreamController errorStreamController(Ref ref) {
   return getService<ErrorStreamController>();
 }
 
+/* Object, not Exception: PackageKitServiceError is a plain event class and
+   must flow through the same stream as exceptions. */
 typedef ErrorStreamController = StreamController<Object>;

--- a/packages/app_center/lib/providers/error_stream_provider.dart
+++ b/packages/app_center/lib/providers/error_stream_provider.dart
@@ -7,7 +7,7 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 part 'error_stream_provider.g.dart';
 
 /// Used to listen to incoming errors to show them to the user.
-final errorStreamProvider = StreamProvider<Exception>(
+final errorStreamProvider = StreamProvider<Object>(
   (ref) => ref.watch(errorStreamControllerProvider).stream,
 );
 
@@ -16,4 +16,4 @@ ErrorStreamController errorStreamController(Ref ref) {
   return getService<ErrorStreamController>();
 }
 
-typedef ErrorStreamController = StreamController<Exception>;
+typedef ErrorStreamController = StreamController<Object>;

--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -7,6 +7,7 @@ import 'package:app_center/gstreamer/gstreamer.dart';
 import 'package:app_center/l10n.dart';
 import 'package:app_center/layout.dart';
 import 'package:app_center/manage/manage_page.dart';
+import 'package:app_center/packagekit/packagekit.dart';
 import 'package:app_center/providers/error_stream_provider.dart';
 import 'package:app_center/search/search.dart';
 import 'package:app_center/snapd/snapd.dart';
@@ -100,7 +101,7 @@ class _StoreAppHome extends ConsumerWidget {
 
   NavigatorState get navigator => navigatorKey.currentState!;
 
-  Future<void> _showError(BuildContext context, SnapdException e) {
+  Future<void> _showError(BuildContext context, Object e) {
     final errorMessage = ErrorMessage.fromObject(e);
     final title = errorMessage.title(AppLocalizations.of(context));
     final body = errorMessage.body(AppLocalizations.of(context));
@@ -121,13 +122,20 @@ class _StoreAppHome extends ConsumerWidget {
     final textScalar = MediaQuery.textScalerOf(context);
 
     ref.listen(errorStreamProvider, (_, error) {
-      if (error.hasValue && error.value is SnapdException) {
-        final snapdError = error.value as SnapdException;
+      if (!error.hasValue) return;
+      final value = error.value!;
+      if (value is SnapdException) {
         // Don't show an error if the user cancelled the auth dialog.
-        if (snapdError.kind == 'auth-cancelled') {
+        if (value.kind == 'auth-cancelled') {
           return;
         }
-        _showError(context, snapdError);
+        _showError(context, value);
+      } else if (value is PackageKitTransactionCancelled) {
+        // User cancelled (e.g. dismissed the polkit dialog) — not an error.
+        return;
+      } else if (value is PackageKitTransactionError ||
+          value is PackageKitServiceError) {
+        _showError(context, value);
       }
     });
 

--- a/packages/app_center/test/deb_model_test.dart
+++ b/packages/app_center/test/deb_model_test.dart
@@ -95,6 +95,73 @@ void main() {
     ).called(1);
   });
 
+  test('hasUpdate when an installable update exists', () async {
+    const updateId = PackageKitPackageId(name: 'testdeb', version: '2.0');
+    createMockPackageKitService(
+      packageInfo: packageInfo,
+      packageUpdates: PackageKitUpdateDetailEvent(
+        packageId: packageInfo.packageId,
+        updates: [updateId],
+      ),
+      availableUpdates: [
+        const PackageKitPackageInfo(
+          info: PackageKitInfo.normal,
+          packageId: updateId,
+          summary: 'update',
+        ),
+      ],
+      resolveMap: {
+        'testdeb-package': packageInfo,
+        'testdeb': const PackageKitPackageInfo(
+          info: PackageKitInfo.installed,
+          packageId: PackageKitPackageId(name: 'testdeb', version: '1.0'),
+          summary: 'summary',
+        ),
+      },
+    );
+    createMockAppstreamService(component: component);
+    final container = ProviderContainer();
+    container.listen(debModelProvider('testdeb'), (_, __) {});
+
+    await expectLater(
+      container.read(debModelProvider('testdeb').future),
+      completes,
+    );
+
+    expect(
+      container.read(debModelProvider('testdeb')).value!.hasUpdate,
+      isTrue,
+    );
+  });
+
+  test('no hasUpdate when the update is blocked (phased)', () async {
+    // Blocked updates are filtered out of PackageKitService.getUpdates, so
+    // an update listed only in getUpdateDetails must not mark the deb as
+    // updatable.
+    const updateId = PackageKitPackageId(name: 'testdeb', version: '2.0');
+    createMockPackageKitService(
+      packageInfo: packageInfo,
+      packageUpdates: PackageKitUpdateDetailEvent(
+        packageId: packageInfo.packageId,
+        updates: [updateId],
+      ),
+      availableUpdates: [],
+    );
+    createMockAppstreamService(component: component);
+    final container = ProviderContainer();
+    container.listen(debModelProvider('testdeb'), (_, __) {});
+
+    await expectLater(
+      container.read(debModelProvider('testdeb').future),
+      completes,
+    );
+
+    expect(
+      container.read(debModelProvider('testdeb')).value!.hasUpdate,
+      isFalse,
+    );
+  });
+
   test('remove', () async {
     final packageKit = createMockPackageKitService(
       packageInfo: packageInfo,

--- a/packages/app_center/test/deb_model_test.dart
+++ b/packages/app_center/test/deb_model_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_center/deb/deb_model.dart';
 import 'package:app_center/packagekit/packagekit_service.dart';
 import 'package:appstream/appstream.dart';
@@ -249,5 +251,115 @@ void main() {
     expect(states.any((s) => s.error != null), isFalse);
   });
 
-  // TODO: test `activeTransactionId` and `cancel()`
+  test(
+    'cancelTransaction during in-flight install clears state without error',
+    () async {
+      final packageKit = createMockPackageKitService(
+        packageInfo: packageInfo,
+        transactionId: 42,
+      );
+      // PackageKit answers Cancel by finishing the transaction with
+      // PackageKitExit.cancelled, which waitTransaction surfaces as
+      // PackageKitTransactionCancelled.
+      final waitCompleter = Completer<void>();
+      when(
+        packageKit.waitTransaction(any),
+      ).thenAnswer((_) => waitCompleter.future);
+      when(packageKit.cancelTransaction(any)).thenAnswer(
+        (_) async => waitCompleter.completeError(
+          PackageKitTransactionCancelled('Transaction 42 was cancelled'),
+        ),
+      );
+      createMockAppstreamService(component: component);
+      final container = ProviderContainer();
+      final states = <DebData>[];
+      container.listen(debModelProvider('testdeb'), (_, next) {
+        if (next.hasValue) states.add(next.value!);
+      });
+
+      await expectLater(
+        container.read(debModelProvider('testdeb').future),
+        completes,
+      );
+
+      final installFuture = container
+          .read(debModelProvider('testdeb').notifier)
+          .installDeb();
+      // Let installDeb() reach the waitTransaction() await.
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        container.read(debModelProvider('testdeb')).value!.activeTransactionId,
+        equals(42),
+      );
+
+      await container
+          .read(debModelProvider('testdeb').notifier)
+          .cancelTransaction();
+      await installFuture;
+
+      verify(packageKit.cancelTransaction(42)).called(1);
+      expect(states.any((s) => s.error != null), isFalse);
+      expect(states.last.activeTransactionId, isNull);
+    },
+  );
+
+  test('failed transaction reports error and clears transaction', () async {
+    final packageKit = createMockPackageKitService(
+      packageInfo: packageInfo,
+      transactionId: 42,
+    );
+    when(packageKit.waitTransaction(any)).thenAnswer(
+      (_) async => throw PackageKitTransactionError(
+        'Transaction 42 exited with exit failed',
+      ),
+    );
+    createMockAppstreamService(component: component);
+    final container = ProviderContainer();
+    final states = <DebData>[];
+    container.listen(debModelProvider('testdeb'), (_, next) {
+      if (next.hasValue) states.add(next.value!);
+    });
+
+    await expectLater(
+      container.read(debModelProvider('testdeb').future),
+      completes,
+    );
+
+    await container.read(debModelProvider('testdeb').notifier).installDeb();
+
+    // The error is reported, and the transaction state is cleared without
+    // wiping the error from the state.
+    expect(
+      states.any(
+        (s) => s.error != null && s.activeTransactionId == null,
+      ),
+      isTrue,
+    );
+    final errorState = states.firstWhere((s) => s.error != null);
+    expect(errorState.error!.code, equals(PackageKitError.internalError));
+  });
+
+  test('successful transaction clears transaction without error', () async {
+    createMockPackageKitService(
+      packageInfo: packageInfo,
+      transactionId: 42,
+    );
+    createMockAppstreamService(component: component);
+    final container = ProviderContainer();
+    final states = <DebData>[];
+    container.listen(debModelProvider('testdeb'), (_, next) {
+      if (next.hasValue) states.add(next.value!);
+    });
+
+    await expectLater(
+      container.read(debModelProvider('testdeb').future),
+      completes,
+    );
+
+    await container.read(debModelProvider('testdeb').notifier).installDeb();
+
+    // The transaction ran and was cleared; no error state was ever emitted.
+    expect(states.any((s) => s.activeTransactionId == 42), isTrue);
+    expect(states.any((s) => s.error != null), isFalse);
+  });
 }

--- a/packages/app_center/test/deb_model_test.dart
+++ b/packages/app_center/test/deb_model_test.dart
@@ -137,9 +137,9 @@ void main() {
   });
 
   test('no hasUpdate when the update is blocked (phased)', () async {
-    // Blocked updates are filtered out of PackageKitService.getUpdates, so
-    // an update listed only in getUpdateDetails must not mark the deb as
-    // updatable.
+    /* Blocked updates are filtered out of PackageKitService.getUpdates, so
+       an update listed only in getUpdateDetails must not mark the deb as
+       updatable. */
     const updateId = PackageKitPackageId(name: 'testdeb', version: '2.0');
     createMockPackageKitService(
       packageInfo: packageInfo,
@@ -243,7 +243,6 @@ void main() {
 
     await container.read(debModelProvider('testdeb').notifier).installDeb();
 
-    // The transaction ran, but no error state was ever emitted.
     expect(
       states.any((s) => s.activeTransactionId == 42),
       isTrue,
@@ -258,9 +257,9 @@ void main() {
         packageInfo: packageInfo,
         transactionId: 42,
       );
-      // PackageKit answers Cancel by finishing the transaction with
-      // PackageKitExit.cancelled, which waitTransaction surfaces as
-      // PackageKitTransactionCancelled.
+      /* PackageKit answers Cancel by finishing the transaction with
+         PackageKitExit.cancelled, which waitTransaction surfaces as
+         PackageKitTransactionCancelled. */
       final waitCompleter = Completer<void>();
       when(
         packageKit.waitTransaction(any),
@@ -327,8 +326,6 @@ void main() {
 
     await container.read(debModelProvider('testdeb').notifier).installDeb();
 
-    // The error is reported, and the transaction state is cleared without
-    // wiping the error from the state.
     expect(
       states.any(
         (s) => s.error != null && s.activeTransactionId == null,
@@ -358,7 +355,6 @@ void main() {
 
     await container.read(debModelProvider('testdeb').notifier).installDeb();
 
-    // The transaction ran and was cleared; no error state was ever emitted.
     expect(states.any((s) => s.activeTransactionId == 42), isTrue);
     expect(states.any((s) => s.error != null), isFalse);
   });

--- a/packages/app_center/test/deb_model_test.dart
+++ b/packages/app_center/test/deb_model_test.dart
@@ -218,5 +218,36 @@ void main() {
     );
   });
 
+  test('cancelled transaction is not reported as an error', () async {
+    final packageKit = createMockPackageKitService(
+      packageInfo: packageInfo,
+      transactionId: 42,
+    );
+    when(packageKit.waitTransaction(any)).thenAnswer(
+      (_) async =>
+          throw PackageKitTransactionCancelled('Transaction 42 was cancelled'),
+    );
+    createMockAppstreamService(component: component);
+    final container = ProviderContainer();
+    final states = <DebData>[];
+    container.listen(debModelProvider('testdeb'), (_, next) {
+      if (next.hasValue) states.add(next.value!);
+    });
+
+    await expectLater(
+      container.read(debModelProvider('testdeb').future),
+      completes,
+    );
+
+    await container.read(debModelProvider('testdeb').notifier).installDeb();
+
+    // The transaction ran, but no error state was ever emitted.
+    expect(
+      states.any((s) => s.activeTransactionId == 42),
+      isTrue,
+    );
+    expect(states.any((s) => s.error != null), isFalse);
+  });
+
   // TODO: test `activeTransactionId` and `cancel()`
 }

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -5,6 +5,7 @@ import 'package:app_center/manage/local_deb_updates_model.dart';
 import 'package:app_center/manage/local_snap_providers.dart';
 import 'package:app_center/manage/manage_app_data.dart';
 import 'package:app_center/manage/snap_updates_model.dart';
+import 'package:app_center/packagekit/packagekit.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:packagekit/packagekit.dart';
@@ -327,6 +328,37 @@ void main() {
 
       // Verify error was reported
       verify(errorStream.add(any)).called(1);
+    });
+
+    test('updateDeb does not report cancellation to error stream', () async {
+      registerMockSnapdService(installedSnaps: []);
+
+      final mockPackageKit = createMockPackageKitService();
+      when(mockPackageKit.waitTransaction(any)).thenAnswer(
+        (_) async => throw PackageKitTransactionCancelled(
+          'Transaction 0 was cancelled',
+        ),
+      );
+
+      // ignore: close_sinks
+      final errorStream = registerMockErrorStreamControllerService();
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith((ref) async => [defaultDebWithUpdate]),
+        ],
+      );
+
+      await container.read(localDebUpdatesModelProvider.future);
+
+      await container
+          .read(localDebUpdatesModelProvider.notifier)
+          .updateDeb(defaultDebWithUpdate.id);
+
+      // Cancellation is not an error, but the transaction state is cleared.
+      verifyNever(errorStream.add(any));
+      final updates = container.read(localDebUpdatesModelProvider).value!;
+      expect(updates.first.activeTransactionId, isNull);
     });
 
     test('silentUpdatesCheck updates state when updates change', () async {

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -402,6 +402,57 @@ void main() {
       },
     );
 
+    test('updateAll continues after a failing deb', () async {
+      registerMockSnapdService(installedSnaps: []);
+
+      final debUpdate2 = createLocalDebInfo(
+        id: 'blender',
+        name: 'Blender',
+        packageName: 'blender',
+        version: '3.0',
+        updatePackageId: const PackageKitPackageId(
+          name: 'blender',
+          version: '3.1',
+        ),
+      );
+
+      final mockPackageKit = createMockPackageKitService();
+      // First deb's transaction fails; the second succeeds.
+      var waitCalls = 0;
+      when(mockPackageKit.waitTransaction(any)).thenAnswer((_) async {
+        if (waitCalls++ == 0) {
+          throw PackageKitTransactionError('Transaction 0 exited with failed');
+        }
+      });
+
+      // ignore: close_sinks
+      final errorStream = registerMockErrorStreamControllerService();
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith(
+            (ref) async => [defaultDebWithUpdate, debUpdate2],
+          ),
+        ],
+      );
+
+      await container.read(installedAppsProvider.future);
+      await container.read(localDebUpdatesModelProvider.future);
+
+      await container.read(localDebUpdatesModelProvider.notifier).updateAll();
+
+      // A genuine failure must not stop the batch: both were attempted.
+      verify(mockPackageKit.update(any)).called(2);
+      verify(errorStream.add(any)).called(1);
+
+      // The failed deb stays in the updates list (retryable), the
+      // successful one is removed.
+      final updates = container.read(localDebUpdatesModelProvider).value!;
+      expect(updates, hasLength(1));
+      expect(updates.single.id, equals(defaultDebWithUpdate.id));
+      expect(updates.single.activeTransactionId, isNull);
+    });
+
     test('updateAll stops the batch after a user cancellation', () async {
       registerMockSnapdService(installedSnaps: []);
 

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -361,6 +361,96 @@ void main() {
       expect(updates.first.activeTransactionId, isNull);
     });
 
+    test(
+      'updateDeb reports failure to error stream and clears transaction',
+      () async {
+        registerMockSnapdService(installedSnaps: []);
+
+        final mockPackageKit = createMockPackageKitService();
+        when(mockPackageKit.waitTransaction(any)).thenAnswer(
+          (_) async => throw PackageKitTransactionError(
+            'Transaction 0 exited with exit failed',
+          ),
+        );
+
+        // ignore: close_sinks
+        final errorStream = registerMockErrorStreamControllerService();
+
+        final container = createContainer(
+          overrides: [
+            localDebsProvider.overrideWith(
+              (ref) async => [defaultDebWithUpdate],
+            ),
+          ],
+        );
+
+        await container.read(localDebUpdatesModelProvider.future);
+
+        await container
+            .read(localDebUpdatesModelProvider.notifier)
+            .updateDeb(defaultDebWithUpdate.id);
+
+        verify(errorStream.add(any)).called(1);
+        final updates = container.read(localDebUpdatesModelProvider).value!;
+        // The deb was not updated, so it stays in the list with its
+        // transaction state cleared.
+        expect(updates.first.activeTransactionId, isNull);
+        expect(updates.first.updatePackageId, isNotNull);
+      },
+    );
+
+    test('updateAll continues after a cancelled transaction', () async {
+      registerMockSnapdService(installedSnaps: []);
+
+      final debUpdate2 = createLocalDebInfo(
+        id: 'blender',
+        name: 'Blender',
+        packageName: 'blender',
+        version: '3.0',
+        updatePackageId: const PackageKitPackageId(
+          name: 'blender',
+          version: '3.1',
+        ),
+      );
+
+      final mockPackageKit = createMockPackageKitService();
+      // First deb's transaction is cancelled (e.g. polkit dialog dismissed);
+      // the second succeeds.
+      var waitCalls = 0;
+      when(mockPackageKit.waitTransaction(any)).thenAnswer((_) async {
+        if (waitCalls++ == 0) {
+          throw PackageKitTransactionCancelled('Transaction 0 was cancelled');
+        }
+      });
+
+      // ignore: close_sinks
+      final errorStream = registerMockErrorStreamControllerService();
+
+      final container = createContainer(
+        overrides: [
+          localDebsProvider.overrideWith(
+            (ref) async => [defaultDebWithUpdate, debUpdate2],
+          ),
+        ],
+      );
+
+      await container.read(installedAppsProvider.future);
+      await container.read(localDebUpdatesModelProvider.future);
+
+      await container.read(localDebUpdatesModelProvider.notifier).updateAll();
+
+      // Both updates were attempted; the cancelled one is not an error.
+      verify(mockPackageKit.update(any)).called(2);
+      verifyNever(errorStream.add(any));
+
+      // Only the cancelled deb remains in the updates list, transaction
+      // state cleared.
+      final updates = container.read(localDebUpdatesModelProvider).value!;
+      expect(updates, hasLength(1));
+      expect(updates.single.id, equals(defaultDebWithUpdate.id));
+      expect(updates.single.activeTransactionId, isNull);
+    });
+
     test('silentUpdatesCheck updates state when updates change', () async {
       registerMockSnapdService(installedSnaps: []);
 

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -358,7 +358,6 @@ void main() {
         throwsA(isA<PackageKitTransactionCancelled>()),
       );
 
-      // Cancellation is not an error, but the transaction state is cleared.
       verifyNever(errorStream.add(any));
       final updates = container.read(localDebUpdatesModelProvider).value!;
       expect(updates.first.activeTransactionId, isNull);
@@ -395,8 +394,6 @@ void main() {
 
         verify(errorStream.add(any)).called(1);
         final updates = container.read(localDebUpdatesModelProvider).value!;
-        // The deb was not updated, so it stays in the list with its
-        // transaction state cleared.
         expect(updates.first.activeTransactionId, isNull);
         expect(updates.first.updatePackageId, isNotNull);
       },
@@ -417,7 +414,6 @@ void main() {
       );
 
       final mockPackageKit = createMockPackageKitService();
-      // First deb's transaction fails; the second succeeds.
       var waitCalls = 0;
       when(mockPackageKit.waitTransaction(any)).thenAnswer((_) async {
         if (waitCalls++ == 0) {
@@ -445,8 +441,6 @@ void main() {
       verify(mockPackageKit.update(any)).called(2);
       verify(errorStream.add(any)).called(1);
 
-      // The failed deb stays in the updates list (retryable), the
-      // successful one is removed.
       final updates = container.read(localDebUpdatesModelProvider).value!;
       expect(updates, hasLength(1));
       expect(updates.single.id, equals(defaultDebWithUpdate.id));
@@ -468,8 +462,6 @@ void main() {
       );
 
       final mockPackageKit = createMockPackageKitService();
-      // The first deb's transaction is cancelled (e.g. the user clicked
-      // Cancel All or dismissed the polkit dialog).
       when(mockPackageKit.waitTransaction(any)).thenAnswer(
         (_) async => throw PackageKitTransactionCancelled(
           'Transaction 0 was cancelled',
@@ -492,13 +484,11 @@ void main() {
 
       await container.read(localDebUpdatesModelProvider.notifier).updateAll();
 
-      // Only the first update was attempted — cancelling must not start the
-      // second transaction (which would prompt for authentication again).
+      /* Only the first update was attempted — cancelling must not start
+         the next transaction, which would prompt for auth again. */
       verify(mockPackageKit.update(any)).called(1);
       verifyNever(errorStream.add(any));
 
-      // The cancelled deb remains in the updates list with its transaction
-      // state cleared; the second deb is untouched.
       final updates = container.read(localDebUpdatesModelProvider).value!;
       expect(updates, hasLength(2));
       expect(

--- a/packages/app_center/test/manage_models_test.dart
+++ b/packages/app_center/test/manage_models_test.dart
@@ -351,9 +351,12 @@ void main() {
 
       await container.read(localDebUpdatesModelProvider.future);
 
-      await container
-          .read(localDebUpdatesModelProvider.notifier)
-          .updateDeb(defaultDebWithUpdate.id);
+      await expectLater(
+        container
+            .read(localDebUpdatesModelProvider.notifier)
+            .updateDeb(defaultDebWithUpdate.id),
+        throwsA(isA<PackageKitTransactionCancelled>()),
+      );
 
       // Cancellation is not an error, but the transaction state is cleared.
       verifyNever(errorStream.add(any));
@@ -399,7 +402,7 @@ void main() {
       },
     );
 
-    test('updateAll continues after a cancelled transaction', () async {
+    test('updateAll stops the batch after a user cancellation', () async {
       registerMockSnapdService(installedSnaps: []);
 
       final debUpdate2 = createLocalDebInfo(
@@ -414,14 +417,13 @@ void main() {
       );
 
       final mockPackageKit = createMockPackageKitService();
-      // First deb's transaction is cancelled (e.g. polkit dialog dismissed);
-      // the second succeeds.
-      var waitCalls = 0;
-      when(mockPackageKit.waitTransaction(any)).thenAnswer((_) async {
-        if (waitCalls++ == 0) {
-          throw PackageKitTransactionCancelled('Transaction 0 was cancelled');
-        }
-      });
+      // The first deb's transaction is cancelled (e.g. the user clicked
+      // Cancel All or dismissed the polkit dialog).
+      when(mockPackageKit.waitTransaction(any)).thenAnswer(
+        (_) async => throw PackageKitTransactionCancelled(
+          'Transaction 0 was cancelled',
+        ),
+      );
 
       // ignore: close_sinks
       final errorStream = registerMockErrorStreamControllerService();
@@ -439,16 +441,25 @@ void main() {
 
       await container.read(localDebUpdatesModelProvider.notifier).updateAll();
 
-      // Both updates were attempted; the cancelled one is not an error.
-      verify(mockPackageKit.update(any)).called(2);
+      // Only the first update was attempted — cancelling must not start the
+      // second transaction (which would prompt for authentication again).
+      verify(mockPackageKit.update(any)).called(1);
       verifyNever(errorStream.add(any));
 
-      // Only the cancelled deb remains in the updates list, transaction
-      // state cleared.
+      // The cancelled deb remains in the updates list with its transaction
+      // state cleared; the second deb is untouched.
       final updates = container.read(localDebUpdatesModelProvider).value!;
-      expect(updates, hasLength(1));
-      expect(updates.single.id, equals(defaultDebWithUpdate.id));
-      expect(updates.single.activeTransactionId, isNull);
+      expect(updates, hasLength(2));
+      expect(
+        updates
+            .firstWhere((d) => d.id == defaultDebWithUpdate.id)
+            .activeTransactionId,
+        isNull,
+      );
+      expect(
+        updates.firstWhere((d) => d.id == 'blender').activeTransactionId,
+        isNull,
+      );
     });
 
     test('silentUpdatesCheck updates state when updates change', () async {

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -702,6 +702,42 @@ void main() {
     expect(updates, contains(barUpdate));
     expect(updates.length, equals(2));
   });
+
+  test('getUpdates excludes blocked updates', () async {
+    const availableUpdate = PackageKitPackageEvent(
+      info: PackageKitInfo.normal,
+      packageId: PackageKitPackageId(
+        name: 'foo',
+        version: '2.0',
+        arch: 'amd64',
+      ),
+      summary: 'foo update',
+    );
+    const blockedUpdate = PackageKitPackageEvent(
+      info: PackageKitInfo.blocked,
+      packageId: PackageKitPackageId(
+        name: 'bar',
+        version: '3.0',
+        arch: 'amd64',
+      ),
+      summary: 'bar blocked (phased) update',
+    );
+    final mockTransaction = createMockPackageKitTransaction(
+      events: [availableUpdate, blockedUpdate],
+    );
+    final mockClient = createMockPackageKitClient(transaction: mockTransaction);
+    final packageKit = PackageKitService(
+      dbus: createMockDbusClient(),
+      client: mockClient,
+      fs: MemoryFileSystem.test(),
+    );
+    await packageKit.activateService();
+
+    final updates = await packageKit.getUpdates();
+    expect(updates, contains(availableUpdate));
+    expect(updates, isNot(contains(blockedUpdate)));
+    expect(updates.length, equals(1));
+  });
 }
 
 @GenerateMocks([DBusClient, XdgDocumentsPortal])

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -433,6 +433,84 @@ void main() {
   );
 
   test(
+    'waitTransaction throws PackageKitTransactionCancelled when polkit dialog is dismissed',
+    () async {
+      // The daemon fails the transaction (exit=failed) after a `notAuthorized`
+      // error code — PackageKit has no cancelled exit code for this case.
+      final startCompleter = Completer();
+      final mockTransaction = createMockPackageKitTransaction(
+        events: [
+          const PackageKitErrorCodeEvent(
+            code: PackageKitError.notAuthorized,
+            details: 'Failed to obtain authentication.',
+          ),
+        ],
+        exit: PackageKitExit.failed,
+        start: startCompleter.future,
+      );
+      final mockClient = createMockPackageKitClient(
+        transaction: mockTransaction,
+      );
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        client: mockClient,
+        fs: MemoryFileSystem.test(),
+      );
+      await packageKit.activateService();
+      final id = await packageKit.install(
+        const PackageKitPackageId(name: 'foo', version: '1.0'),
+      );
+      final future = packageKit.waitTransaction(id);
+      startCompleter.complete();
+      await expectLater(
+        future,
+        throwsA(isA<PackageKitTransactionCancelled>()),
+      );
+    },
+  );
+
+  test('error stream ignores user cancellations', () async {
+    final startCompleter = Completer();
+    final mockTransaction = createMockPackageKitTransaction(
+      events: [
+        const PackageKitErrorCodeEvent(
+          code: PackageKitError.notAuthorized,
+          details: 'Failed to obtain authentication.',
+        ),
+        const PackageKitErrorCodeEvent(
+          code: PackageKitError.noNetwork,
+          details: 'error details',
+        ),
+      ],
+      exit: PackageKitExit.failed,
+      start: startCompleter.future,
+    );
+    final mockClient = createMockPackageKitClient(transaction: mockTransaction);
+    final packageKit = PackageKitService(
+      dbus: createMockDbusClient(),
+      client: mockClient,
+      fs: MemoryFileSystem.test(),
+    );
+    await packageKit.activateService();
+
+    final errors = <PackageKitServiceError>[];
+    packageKit.errorStream.listen(errors.add);
+    final id = await packageKit.install(
+      const PackageKitPackageId(name: 'foo', version: '1.0'),
+    );
+    final future = packageKit.waitTransaction(id);
+    startCompleter.complete();
+    await expectLater(
+      future,
+      throwsA(isA<PackageKitTransactionCancelled>()),
+    );
+    expect(
+      errors.map((e) => e.code),
+      equals([PackageKitError.noNetwork]),
+    );
+  });
+
+  test(
     'waitTransaction throws PackageKitTransactionError on non-cancelled exit',
     () async {
       final mockTransaction = createMockPackageKitTransaction(

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -407,6 +407,31 @@ void main() {
     expect(packageKit.getTransaction(id), isNull);
   });
 
+  test(
+    'waitTransaction throws PackageKitTransactionCancelled when cancelled',
+    () async {
+      final mockTransaction = createMockPackageKitTransaction(
+        exit: PackageKitExit.cancelled,
+      );
+      final mockClient = createMockPackageKitClient(
+        transaction: mockTransaction,
+      );
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        client: mockClient,
+        fs: MemoryFileSystem.test(),
+      );
+      await packageKit.activateService();
+      final id = await packageKit.install(
+        const PackageKitPackageId(name: 'foo', version: '1.0'),
+      );
+      await expectLater(
+        packageKit.waitTransaction(id),
+        throwsA(isA<PackageKitTransactionCancelled>()),
+      );
+    },
+  );
+
   test('error stream', () async {
     const mockError = PackageKitErrorCodeEvent(
       code: PackageKitError.noNetwork,

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -432,6 +432,40 @@ void main() {
     },
   );
 
+  test(
+    'waitTransaction throws PackageKitTransactionError on non-cancelled exit',
+    () async {
+      final mockTransaction = createMockPackageKitTransaction(
+        exit: PackageKitExit.failed,
+      );
+      final mockClient = createMockPackageKitClient(
+        transaction: mockTransaction,
+      );
+      final packageKit = PackageKitService(
+        dbus: createMockDbusClient(),
+        client: mockClient,
+        fs: MemoryFileSystem.test(),
+      );
+      await packageKit.activateService();
+      final id = await packageKit.install(
+        const PackageKitPackageId(name: 'foo', version: '1.0'),
+      );
+      await expectLater(
+        packageKit.waitTransaction(id),
+        throwsA(
+          isA<PackageKitTransactionError>()
+              .having((e) => e.message, 'message', contains('failed'))
+              // A failure must not look like a user cancellation.
+              .having(
+                (e) => e is PackageKitTransactionCancelled,
+                'isCancelled',
+                isFalse,
+              ),
+        ),
+      );
+    },
+  );
+
   test('error stream', () async {
     const mockError = PackageKitErrorCodeEvent(
       code: PackageKitError.noNetwork,

--- a/packages/app_center/test/packagekit_service_test.dart
+++ b/packages/app_center/test/packagekit_service_test.dart
@@ -435,8 +435,8 @@ void main() {
   test(
     'waitTransaction throws PackageKitTransactionCancelled when polkit dialog is dismissed',
     () async {
-      // The daemon fails the transaction (exit=failed) after a `notAuthorized`
-      // error code — PackageKit has no cancelled exit code for this case.
+      /* The daemon fails the transaction (exit=failed) after a notAuthorized
+         error code — PackageKit has no cancelled exit code for this case. */
       final startCompleter = Completer();
       final mockTransaction = createMockPackageKitTransaction(
         events: [

--- a/packages/app_center/test/store_app_test.dart
+++ b/packages/app_center/test/store_app_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_center/error/error_l10n.dart';
+import 'package:app_center/packagekit/packagekit.dart';
 import 'package:app_center/providers/error_stream_provider.dart';
 import 'package:app_center/ratings/ratings.dart';
 import 'package:app_center/snapd/snapd.dart';
@@ -10,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gtk/gtk.dart';
 import 'package:mockito/mockito.dart';
+import 'package:packagekit/packagekit.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
@@ -129,6 +131,24 @@ void main() {
         (
           name: 'auth-cancelled error',
           error: SnapdException(message: 'cancelled', kind: 'auth-cancelled'),
+          expectDialog: false,
+        ),
+        (
+          name: 'PackageKit transaction error',
+          error: PackageKitTransactionError('Transaction 1 was destroyed'),
+          expectDialog: true,
+        ),
+        (
+          name: 'PackageKit service error',
+          error: const PackageKitServiceError(
+            code: PackageKitError.packageNotFound,
+            details: 'not available as an update candidate',
+          ),
+          expectDialog: true,
+        ),
+        (
+          name: 'PackageKit transaction cancelled',
+          error: PackageKitTransactionCancelled('Transaction 1 was cancelled'),
           expectDialog: false,
         ),
       ]) {

--- a/packages/app_center/test/store_app_test.dart
+++ b/packages/app_center/test/store_app_test.dart
@@ -151,6 +151,13 @@ void main() {
           error: PackageKitTransactionCancelled('Transaction 1 was cancelled'),
           expectDialog: false,
         ),
+        (
+          // The stream is typed Object; unknown values must be ignored
+          // rather than crash the listener.
+          name: 'unknown error object',
+          error: 'not an exception',
+          expectDialog: false,
+        ),
       ]) {
         testWidgets(testCase.name, (tester) async {
           registerMockSnapdService();

--- a/packages/app_center/test/store_app_test.dart
+++ b/packages/app_center/test/store_app_test.dart
@@ -152,8 +152,8 @@ void main() {
           expectDialog: false,
         ),
         (
-          // The stream is typed Object; unknown values must be ignored
-          // rather than crash the listener.
+          /* The stream is typed Object; unknown values must be ignored
+             rather than crash the listener. */
           name: 'unknown error object',
           error: 'not an exception',
           expectDialog: false,


### PR DESCRIPTION
## Summary

PackageKit reports phased deb updates with `info=blocked` via `GetUpdates`. These are not installable candidates, so `app-center` listing them in the Manage page leads to update attempts that fail with `PackageKitError.packageNotFound`, repeated polkit auth prompts, and a spinner that never resolves.

```
$ ERROR packagekit: Received PackageKitErrorCodeEvent (PackageKitError.packageNotFound):
  Package id 'nautilus;1:50.2.2-0ubuntu0.1;amd64;ubuntu-resolute-updates-main' is not available as an update candidate

$ apt policy nautilus
  Candidate: 1:50.2.2-0ubuntu0.1
     1:50.2.2-0ubuntu0.1 500 (phased 0%)

$ apt-get -s upgrade
The following upgrades have been deferred due to phasing:
  libnautilus-extension4 nautilus nautilus-data
```

## Changes

**Filter blocked updates at the source** — `PackageKitService.getUpdates()` now skips `PackageKitInfo.blocked` events. Both consumers (`local_deb_providers.dart:88` and `local_deb_updates_model.dart:78`) go through this single call, so filtering once here covers the whole Manage page rather than repeating a guard in each caller.

**Cross-check the deb page against installable updates** — `DebModel._hasUpdate` previously trusted `getUpdateDetails`, whose `UpdateDetail` events carry no blocked flag, so a phased update would still light up the Update button on an individual deb page. It now intersects those package names with the installable set from `getUpdates()`.

This also fixes a pre-existing bug in the same loop: it iterated `updates` but unconditionally `break`-ed after the first entry, so only the first candidate was ever considered and the loop was misleading. The rewrite returns on the first installable match and returns `false` when none is found.

**Handle the update failures that do get through** — a failing `waitTransaction` previously escaped uncaught, leaving `activeTransactionId` set and the UI spinning indefinitely:
- `DebModel._packageKitAction` routes the exception through the existing `_onError` path, which surfaces the error and clears the transaction state.
- `LocalDebUpdatesModel.updateDeb` logs and pushes the exception to `errorStreamControllerProvider`.

Both feed the error plumbing that `deb_page.dart` and the Manage page already consume, so no changes were needed in the widget layer itself.

## Testing

Three new tests:
- `packagekit_service_test.dart` — `getUpdates` excludes blocked updates.
- `deb_model_test.dart` — `hasUpdate` is true when an installable update exists.
- `deb_model_test.dart` — `hasUpdate` is false when the only update is blocked (phased).

`melos test`, `melos analyze --fatal-infos` and `melos format:exclude` all pass.

Related to #2169 and #2142.


---

UDENG-11211
