### PR TITLE
fix(ratings): rate the installed revision, not the one in the store

### DIFF
--- a/packages/app_center/lib/ratings/ratings_model.dart
+++ b/packages/app_center/lib/ratings/ratings_model.dart
@@ -16,8 +16,16 @@ class RatingsModel extends _$RatingsModel {
 
   @override
   Future<RatingsData> build(String snapName) async {
-    final snap = (await ref.watch(snapModelProvider(snapName).future)).snap;
-    final snapId = snap.id;
+    final snapData = await ref.watch(snapModelProvider(snapName).future);
+    final snapId = snapData.snap.id;
+
+    // Ratings are recorded per revision, and the rating buttons are only shown
+    // for an installed snap, so the revision being rated is the installed one.
+    // `SnapData.snap` prefers the store snap, which carries the newest revision
+    // in the channel and differs from the installed one whenever an update is
+    // pending, so reading the revision from it attributes the vote to a
+    // revision the user has not run.
+    final snapRevision = snapData.localSnap?.revision ?? snapData.snap.revision;
 
     final cacheFile = _getCacheFile(snapId);
 
@@ -40,9 +48,9 @@ class RatingsModel extends _$RatingsModel {
 
     final ratingsData = RatingsData(
       snapId: snapId,
-      snapRevision: snap.revision,
+      snapRevision: snapRevision,
       rating: rating,
-      voteStatus: _getUserVote(snap.revision, votes),
+      voteStatus: _getUserVote(snapRevision, votes),
       snapName: snapName,
     );
 

--- a/packages/app_center/test/ratings_model_test.dart
+++ b/packages/app_center/test/ratings_model_test.dart
@@ -78,4 +78,68 @@ void main() {
       ),
     ).called(1);
   });
+
+  group('with a pending update', () {
+    final installed = createSnap(name: 'firefox', id: '1234', revision: 42);
+    final inStore = createSnap(name: 'firefox', id: '1234', revision: 99);
+
+    setUp(() async {
+      await resetAllServices();
+      registerMockSnapdService(localSnap: installed, storeSnap: inStore);
+      registerMockRatingsService(
+        rating: const Rating(
+          snapId: '1234',
+          totalVotes: 1337,
+          ratingsBand: RatingsBand.veryGood,
+          snapName: 'firefox',
+        ),
+        snapVotes: [
+          Vote(
+            snapId: '1234',
+            snapRevision: 42,
+            voteUp: true,
+            dateTime: DateTime(1970),
+            snapName: 'firefox',
+          ),
+        ],
+      );
+    });
+
+    test('rates the installed revision, not the one in the store', () async {
+      final container = createContainer();
+      final ratingsData = await container.read(
+        ratingsModelProvider('firefox').future,
+      );
+
+      expect(ratingsData.snapRevision, equals(42));
+      // The earlier vote was cast against the installed revision, so it is
+      // found instead of the buttons coming up unset.
+      expect(ratingsData.voteStatus, equals(VoteStatus.up));
+    });
+
+    test('casts the vote against the installed revision', () async {
+      final container = createContainer();
+      final mockService = getService<RatingsService>();
+      final model = container.read(ratingsModelProvider('firefox').notifier);
+      container.listen(ratingsModelProvider('firefox'), (_, __) {});
+      await container.read(ratingsModelProvider('firefox').future);
+
+      await withClock(
+        Clock.fixed(DateTime(1984)),
+        () => model.castVote(VoteStatus.down),
+      );
+
+      verify(
+        mockService.vote(
+          Vote(
+            dateTime: DateTime(1984),
+            snapId: '1234',
+            snapRevision: 42,
+            voteUp: false,
+            snapName: 'firefox',
+          ),
+        ),
+      ).called(1);
+    });
+  });
 }


### PR DESCRIPTION
Fixes #1717.

Ratings are recorded per revision, but `RatingsModel.build` reads the revision from `SnapData.snap`:

```dart
Snap get snap => storeSnap ?? localSnap!;
```

That prefers the store snap, which carries the newest revision in the channel. Whenever an update is pending the two differ, so the vote is attributed to a revision the user has not run.

It cuts both ways. With firefox installed at 4400 and 4483 available:

- casting a vote records it against 4483
- an existing vote on 4400 is not found by `_getUserVote`, so the buttons come up unset and the same user can vote again

Neither is visible in the UI, and it only happens while an update is pending, which is why it goes unnoticed. The cost is on the backend, where per-revision aggregation is the point of sending `snapRevision` at all.

The rating buttons are only rendered for an installed snap:

```dart
if (snapData.isInstalled)
  ... _RatingsActionButtons(
```

so `localSnap` is always there to read when a vote can be cast, and there is no case where the store revision is the only thing available to a voter.

Both tests fail against the current code with `Expected: <42> Actual: <99>`.

One thing left alone: `RatingsData` is cached for a day, so an entry written before this change still carries the store revision until it expires or a vote deletes it. Self-correcting, and clearing the cache on upgrade seemed like more than this fix warrants, but say the word if you would rather handle it.
