### PR TITLE
fix: bundle and fallback to Noto Sans CJK for missing Chinese glyphs

### DIFF
--- a/packages/app_center/lib/store/store_app.dart
+++ b/packages/app_center/lib/store/store_app.dart
@@ -93,10 +93,7 @@ class _StoreAppState extends ConsumerState<StoreApp> {
 }
 
 class _StoreAppHome extends ConsumerWidget {
-  const _StoreAppHome({
-    required this.navigatorKey,
-    required this.searchFocus,
-  });
+  const _StoreAppHome({required this.navigatorKey, required this.searchFocus});
 
   final GlobalKey<NavigatorState> navigatorKey;
   final FocusNode searchFocus;
@@ -174,27 +171,21 @@ class _StoreAppHome extends ConsumerWidget {
             settings: settings,
             builder: (_) => YaruDetailPage(
               appBar: searchField,
-              body: DebPage(
-                id: StoreRoutes.debOf(settings)!,
-              ),
+              body: DebPage(id: StoreRoutes.debOf(settings)!),
             ),
           ),
           StoreRoutes.localDeb => MaterialPageRoute(
             settings: settings,
             builder: (_) => YaruDetailPage(
               appBar: searchField,
-              body: LocalDebPage(
-                path: StoreRoutes.localDebOf(settings)!,
-              ),
+              body: LocalDebPage(path: StoreRoutes.localDebOf(settings)!),
             ),
           ),
           StoreRoutes.snap => MaterialPageRoute(
             settings: settings,
             builder: (_) => YaruDetailPage(
               appBar: searchField,
-              body: SnapPage(
-                snapName: StoreRoutes.snapOf(settings)!,
-              ),
+              body: SnapPage(snapName: StoreRoutes.snapOf(settings)!),
             ),
           ),
           StoreRoutes.search => MaterialPageRoute(
@@ -216,10 +207,8 @@ class _StoreAppHome extends ConsumerWidget {
           ),
           StoreRoutes.manage => MaterialPageRoute(
             settings: settings,
-            builder: (_) => YaruDetailPage(
-              appBar: searchField,
-              body: const ManagePage(),
-            ),
+            builder: (_) =>
+                YaruDetailPage(appBar: searchField, body: const ManagePage()),
           ),
           StoreRoutes.gstreamer => MaterialPageRoute(
             settings: settings,
@@ -257,16 +246,44 @@ class _MaybeBackButton extends ConsumerWidget {
 
 extension StoreAppThemeX on ThemeData {
   ThemeData customize({bool highContrast = false}) {
+    const cjkFallback = [
+      'Noto Sans CJK SC',
+      'Noto Sans CJK TC',
+      'Noto Sans CJK HK',
+    ];
+
     final base = copyWith(
+      textTheme: textTheme.apply(fontFamilyFallback: cjkFallback),
+      primaryTextTheme: primaryTextTheme.apply(fontFamilyFallback: cjkFallback),
+
+      appBarTheme: appBarTheme.copyWith(
+        titleTextStyle: appBarTheme.titleTextStyle?.apply(
+          fontFamilyFallback: cjkFallback,
+        ),
+      ),
+
+      navigationRailTheme: navigationRailTheme.copyWith(
+        selectedLabelTextStyle: navigationRailTheme.selectedLabelTextStyle
+            ?.apply(fontFamilyFallback: cjkFallback),
+        unselectedLabelTextStyle: navigationRailTheme.unselectedLabelTextStyle
+            ?.apply(fontFamilyFallback: cjkFallback),
+      ),
+
+      listTileTheme: listTileTheme.copyWith(
+        titleTextStyle: listTileTheme.titleTextStyle?.apply(
+          fontFamilyFallback: cjkFallback,
+        ),
+        subtitleTextStyle: listTileTheme.subtitleTextStyle?.apply(
+          fontFamilyFallback: cjkFallback,
+        ),
+      ),
       inputDecorationTheme: inputDecorationTheme.copyWith(
         fillColor: colorScheme.surface,
         hoverColor: colorScheme.surface,
       ),
     );
 
-    final highContrastTheme = base.copyWith(
-      hintColor: colorScheme.onSurface,
-    );
+    final highContrastTheme = base.copyWith(hintColor: colorScheme.onSurface);
 
     return highContrast ? highContrastTheme : base;
   }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,8 @@ parts:
       fvm flutter build linux --release -v
       mkdir -p $CRAFT_PART_INSTALL/bin/
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
+    stage-packages:
+      - fonts-noto-cjk
 
   packagekit-session-installer:
     source: ./packagekit-session-installer


### PR DESCRIPTION
## Summary

Flutter has a known issue on ARM64 Linux platforms (flutter/flutter#90951) where Chinese glyphs fail to render and display as tofu boxes (`□□□`). Within snap confinement, the application lacks access to necessary CJK glyph tables, causing unrendered characters across the interface.

Ahead of an upstream release for the Lenovo partnership, this provides a workaround in App Center by bundling the fonts and declaring explicit fallbacks.

## Changes

**Add Noto Sans CJK to font fallbacks** — In `packages/app_center/lib/store/store_app.dart` (inside `StoreAppThemeX`), added `Noto Sans CJK (SC, TC, HK)` to `fontFamilyFallback`. 

**Stage CJK fonts in the snap** — Added `fonts-noto-cjk` to `stage-packages` in `snapcraft.yaml` so the required font files are bundled and accessible inside snap confinement at runtime.

## Testing

Manual verification on ARM64 hardware:
1. Build and install the snap on an ARM64 test machine.
2. Launch App Center with a Chinese locale (`LANG=zh_CN.UTF-8`).
3. Verify that Chinese glyphs render properly across all views without tofu boxes (□□□).

---

UDENG-11262